### PR TITLE
Fix disjoint queries, strip out useless scope accessors

### DIFF
--- a/src/world.rs
+++ b/src/world.rs
@@ -353,24 +353,6 @@ impl World {
     pub fn remove_one<T: Component>(&mut self, entity: Entity) -> Result<T, ComponentError> {
         self.remove::<(T,)>(entity).map(|(x,)| x)
     }
-
-    // /// Determine which collections of entities will be borrowed by `Q`
-    // ///
-    // /// The identifiers returned by this are invalidated when any entity or component is added or
-    // /// removed.
-    // pub fn query_scope<'a, Q: Query<'a>>(&self) -> impl Iterator<Item = u32> + '_ {
-    //     (0..self.archetypes.len() as u32)
-    //         .filter(move |&i| Q::Fetch::wants(&self.archetypes[i as usize]))
-    // }
-
-    // /// Determine which collections of entities will be uniquely borrowed by `Q`
-    // ///
-    // /// The identifiers returned by this are invalidated when any entity or component is added or
-    // /// removed.
-    // pub fn query_scope_mut<'a, Q: Query<'a>>(&self) -> impl Iterator<Item = u32> + '_ {
-    //     (0..self.archetypes.len() as u32)
-    //         .filter(move |&i| Q::Fetch::wants_mut(&self.archetypes[i as usize]))
-    // }
 }
 
 unsafe impl Sync for World {}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -181,6 +181,16 @@ fn illegal_borrow_2() {
 }
 
 #[test]
+fn disjoint_queries() {
+    let mut world = World::new();
+    world.spawn(("abc", true));
+    world.spawn(("def", 456));
+
+    let _a = world.query::<(&mut &str, &bool)>();
+    let _b = world.query::<(&mut &str, &i32)>();
+}
+
+#[test]
 fn shared_borrow() {
     let mut world = World::new();
     world.spawn(("abc", 123));


### PR DESCRIPTION
These didn't account for queries that were safe on the same archetype.