### PR TITLE
Allow clippy::forget_copy in generated code

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -54,6 +54,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
                 Self::static_type_info()
             }
 
+            #[allow(clippy::forget_copy)]
             unsafe fn put(mut self, mut f: impl FnMut(*mut u8, std::any::TypeId, usize) -> bool) {
                 #(
                     if f((&mut self.#fields as *mut #tys).cast::<u8>(), std::any::TypeId::of::<#tys>(), std::mem::size_of::<#tys>()) {


### PR DESCRIPTION
The code generated by `derive(Bundle)` triggers a clippy correctness lint in user crate when one of the components in the bundle is `Copy`. This silences the lint.