### PR TITLE
Fix memory leak in archetype resizing

### DIFF
--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -211,6 +211,13 @@ impl Archetype {
                         ty.layout.size() * old_count,
                     );
                 }
+                dealloc(
+                    (*self.data.get()).as_ptr().cast(),
+                    Layout::from_size_align_unchecked(
+                        old_data_size,
+                        self.types.first().map_or(1, |x| x.layout.align()),
+                    ),
+                );
             }
 
             self.data = UnsafeCell::new(new_data);


### PR DESCRIPTION
Fixes #79. Though we properly drop the components themselves, the underlying memory was not recovered.