### PR TITLE
`SmartComponent` interface for change-tracking functionality

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -66,7 +66,7 @@ fn iterate_100k(b: &mut Bencher) {
         world.spawn((Position(-(i as f32)), Velocity(i as f32)));
     }
     b.iter(|| {
-        for (_, (pos, vel)) in &mut world.query::<(&mut Position, &Velocity)>() {
+        for (_, (mut pos, vel)) in &mut world.query::<(&mut Position, &Velocity)>() {
             pos.0 += vel.0;
         }
     })

--- a/examples/ffa_simulation.rs
+++ b/examples/ffa_simulation.rs
@@ -62,7 +62,7 @@ fn batch_spawn_entities(world: &mut World, n: usize) {
 fn system_integrate_motion(world: &mut World) {
     let mut rng = thread_rng();
 
-    for (id, (pos, s)) in &mut world.query::<(&mut Position, &Speed)>() {
+    for (id, (mut pos, s)) in &mut world.query::<(&mut Position, &Speed)>() {
         let change = (rng.gen_range(-s.0, s.0), rng.gen_range(-s.0, s.0));
         pos.x += change.0;
         pos.y += change.1;
@@ -72,7 +72,7 @@ fn system_integrate_motion(world: &mut World) {
 
 // In this system entities find the closest entity and fire at them
 fn system_fire_at_closest(world: &mut World) {
-    for (id0, (pos0, dmg0, kc0)) in
+    for (id0, (pos0, dmg0, mut kc0)) in
         &mut world.query::<With<Health, (&Position, &Damage, &mut KillCount)>>()
     {
         // Find closest:

--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -301,7 +301,7 @@ impl Archetype {
     }
 
     /// How, if at all, `Q` will access entities in this archetype
-    pub fn access<Q: Query>(&self) -> Option<Access> {
+    pub fn access<'w, Q: Query<'w, C>, C: Copy + 'w>(&self) -> Option<Access> {
         Q::Fetch::access(self)
     }
 }

--- a/src/borrow.rs
+++ b/src/borrow.rs
@@ -107,7 +107,7 @@ impl<'a, T: SmartComponent<C>, C: Clone> Deref for Ref<'a, T, C> {
     type Target = T;
     fn deref(&self) -> &T {
         let value = unsafe { self.target.as_ref() };
-        value.on_borrow(self.entity, &self.context);
+        value.on_borrow(self.entity, self.context.clone());
         value
     }
 }
@@ -157,7 +157,7 @@ impl<'a, T: Component> Deref for RefMut<'a, T> {
     type Target = T;
     fn deref(&self) -> &T {
         let value = unsafe { self.target.as_ref() };
-        value.on_borrow(self.entity, &self.context);
+        value.on_borrow(self.entity, self.context.clone());
         value
     }
 }
@@ -165,7 +165,7 @@ impl<'a, T: Component> Deref for RefMut<'a, T> {
 impl<'a, T: Component> DerefMut for RefMut<'a, T> {
     fn deref_mut(&mut self) -> &mut T {
         let value = unsafe { self.target.as_mut() };
-        value.on_borrow_mut(self.entity, &self.context);
+        value.on_borrow_mut(self.entity, self.context.clone());
         value
     }
 }

--- a/src/borrow.rs
+++ b/src/borrow.rs
@@ -18,7 +18,7 @@ use core::ptr::NonNull;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::archetype::Archetype;
-use crate::{Component, Entity, MissingComponent, SmartComponent};
+use crate::{Entity, MissingComponent, SmartComponent};
 
 pub struct AtomicBorrow(AtomicUsize);
 
@@ -153,7 +153,7 @@ impl<'a, T: SmartComponent<C>, C: Clone> Drop for RefMut<'a, T, C> {
     }
 }
 
-impl<'a, T: Component> Deref for RefMut<'a, T> {
+impl<'a, T: SmartComponent<C>, C: Clone> Deref for RefMut<'a, T, C> {
     type Target = T;
     fn deref(&self) -> &T {
         let value = unsafe { self.target.as_ref() };
@@ -162,7 +162,7 @@ impl<'a, T: Component> Deref for RefMut<'a, T> {
     }
 }
 
-impl<'a, T: Component> DerefMut for RefMut<'a, T> {
+impl<'a, T: SmartComponent<C>, C: Clone> DerefMut for RefMut<'a, T, C> {
     fn deref_mut(&mut self) -> &mut T {
         let value = unsafe { self.target.as_mut() };
         value.on_borrow_mut(self.entity, self.context.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,8 @@
 //! let a = world.spawn((123, true, "abc"));
 //! let b = world.spawn((42, false));
 //! // Systems can be simple for loops
-//! for (id, (number, &flag)) in world.query::<(&mut i32, &bool)>().iter() {
-//!   if flag { *number *= 2; }
+//! for (id, (mut number, flag)) in world.query::<(&mut i32, &bool)>().iter() {
+//!   if *flag { *number *= 2; }
 //! }
 //! // Random access is simple and safe
 //! assert_eq!(*world.get::<i32>(a).unwrap(), 246);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,9 @@ pub use entities::{Entity, NoSuchEntity};
 pub use entity_builder::{BuiltEntity, EntityBuilder};
 pub use query::{Access, BatchedIter, Query, QueryBorrow, QueryIter, With, Without};
 pub use query_one::QueryOne;
-pub use world::{ArchetypesGeneration, Component, ComponentError, Iter, SpawnBatchIter, World};
+pub use world::{
+    ArchetypesGeneration, Component, ComponentError, Iter, SmartComponent, SpawnBatchIter, World,
+};
 
 // Unstable implementation details needed by the macros
 #[doc(hidden)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -101,7 +101,7 @@ impl<'a, T: SmartComponent<C>, C: Clone> Deref for Ref<'a, T, C> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        self.value.on_borrow(self.id, &self.context);
+        self.value.on_borrow(self.id, self.context.clone());
         self.value
     }
 }
@@ -165,14 +165,14 @@ impl<'a, T: SmartComponent<C>, C: Clone> Deref for RefMut<'a, T, C> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        (&*self.value).on_borrow(self.id, &self.context);
+        (&*self.value).on_borrow(self.id, self.context.clone());
         self.value
     }
 }
 
 impl<'a, T: SmartComponent<C>, C: Clone> DerefMut for RefMut<'a, T, C> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.value.on_borrow_mut(self.id, &self.context);
+        self.value.on_borrow_mut(self.id, self.context.clone());
         self.value
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -257,7 +257,7 @@ impl<'q, 'c, T: Fetch<'q, 'c, C>, C: Clone + 'c> Fetch<'q, 'c, C> for TryFetch<T
 /// let c = world.spawn((42, "def"));
 /// let entities = world.query::<Without<bool, &i32>>()
 ///     .iter()
-///     .map(|(e, &i)| (e, i))
+///     .map(|(e, i)| (e, *i))
 ///     .collect::<Vec<_>>();
 /// assert_eq!(entities, &[(c, 42)]);
 /// ```
@@ -314,7 +314,7 @@ impl<'q, 'c, T: Component, F: Fetch<'q, 'c, C>, C: Clone + 'c> Fetch<'q, 'c, C>
 /// let c = world.spawn((42, "def"));
 /// let entities = world.query::<With<bool, &i32>>()
 ///     .iter()
-///     .map(|(e, &i)| (e, i))
+///     .map(|(e, i)| (e, *i))
 ///     .collect::<Vec<_>>();
 /// assert_eq!(entities.len(), 2);
 /// assert!(entities.contains(&(a, 123)));
@@ -441,7 +441,7 @@ impl<'w, Q: Query<'w, C>, C: Clone + 'w> QueryBorrow<'w, Q, C> {
     /// let entities = world.query::<&i32>()
     ///     .with::<bool>()
     ///     .iter()
-    ///     .map(|(e, &i)| (e, i)) // Clone out of the world
+    ///     .map(|(e, i)| (e, *i)) // Clone out of the world
     ///     .collect::<Vec<_>>();
     /// assert!(entities.contains(&(a, 123)));
     /// assert!(entities.contains(&(b, 456)));
@@ -464,7 +464,7 @@ impl<'w, Q: Query<'w, C>, C: Clone + 'w> QueryBorrow<'w, Q, C> {
     /// let entities = world.query::<&i32>()
     ///     .without::<bool>()
     ///     .iter()
-    ///     .map(|(e, &i)| (e, i)) // Clone out of the world
+    ///     .map(|(e, i)| (e, *i)) // Clone out of the world
     ///     .collect::<Vec<_>>();
     /// assert_eq!(entities, &[(c, 42)]);
     /// ```

--- a/src/query_one.rs
+++ b/src/query_one.rs
@@ -4,24 +4,26 @@ use crate::query::{Fetch, With, Without};
 use crate::{Archetype, Component, Query};
 
 /// A borrow of a `World` sufficient to execute the query `Q` on a single entity
-pub struct QueryOne<'a, Q: Query> {
+pub struct QueryOne<'a, Q: Query<C>, C> {
     archetype: &'a Archetype,
     index: u32,
     borrowed: bool,
+    context: &'a C,
     _marker: PhantomData<Q>,
 }
 
-impl<'a, Q: Query> QueryOne<'a, Q> {
+impl<'a, Q: Query<C>, C> QueryOne<'a, Q, C> {
     /// Construct a query accessing the entity in `archetype` at `index`
     ///
     /// # Safety
     ///
     /// `index` must be in-bounds for `archetype`
-    pub(crate) unsafe fn new(archetype: &'a Archetype, index: u32) -> Self {
+    pub(crate) unsafe fn new(archetype: &'a Archetype, index: u32, context: &'a C) -> Self {
         Self {
             archetype,
             index,
             borrowed: false,
+            context,
             _marker: PhantomData,
         }
     }
@@ -32,7 +34,7 @@ impl<'a, Q: Query> QueryOne<'a, Q> {
     ///
     /// Panics if called more than once or if it would construct a borrow that clashes with another
     /// pre-existing borrow.
-    pub fn get(&mut self) -> Option<<Q::Fetch as Fetch<'_>>::Item> {
+    pub fn get(&mut self) -> Option<<Q::Fetch as Fetch<'_, C>>::Item> {
         if self.borrowed {
             panic!("called QueryOnce::get twice; construct a new query instead");
         }
@@ -40,30 +42,31 @@ impl<'a, Q: Query> QueryOne<'a, Q> {
             let mut fetch = Q::Fetch::get(self.archetype, self.index as usize)?;
             self.borrowed = true;
             Q::Fetch::borrow(self.archetype);
-            Some(fetch.next())
+            Some(fetch.next(self.index, self.context))
         }
     }
 
     /// Transform the query into one that requires a certain component without borrowing it
     ///
     /// See `QueryBorrow::with` for details.
-    pub fn with<T: Component>(self) -> QueryOne<'a, With<T, Q>> {
+    pub fn with<T: Component>(self) -> QueryOne<'a, With<T, Q>, C> {
         self.transform()
     }
 
     /// Transform the query into one that skips entities having a certain component
     ///
     /// See `QueryBorrow::without` for details.
-    pub fn without<T: Component>(self) -> QueryOne<'a, Without<T, Q>> {
+    pub fn without<T: Component>(self) -> QueryOne<'a, Without<T, Q>, C> {
         self.transform()
     }
 
     /// Helper to change the type of the query
-    fn transform<R: Query>(mut self) -> QueryOne<'a, R> {
+    fn transform<R: Query<C>>(mut self) -> QueryOne<'a, R, C> {
         let x = QueryOne {
             archetype: self.archetype,
             index: self.index,
             borrowed: self.borrowed,
+            context: self.context,
             _marker: PhantomData,
         };
         // Ensure `Drop` won't fire redundantly
@@ -72,7 +75,7 @@ impl<'a, Q: Query> QueryOne<'a, Q> {
     }
 }
 
-impl<Q: Query> Drop for QueryOne<'_, Q> {
+impl<Q: Query<C>, C> Drop for QueryOne<'_, Q, C> {
     fn drop(&mut self) {
         if self.borrowed {
             Q::Fetch::release(self.archetype);
@@ -80,5 +83,5 @@ impl<Q: Query> Drop for QueryOne<'_, Q> {
     }
 }
 
-unsafe impl<Q: Query> Send for QueryOne<'_, Q> {}
-unsafe impl<Q: Query> Sync for QueryOne<'_, Q> {}
+unsafe impl<Q: Query<C>, C: Sync> Send for QueryOne<'_, Q, C> {}
+unsafe impl<Q: Query<C>, C: Sync> Sync for QueryOne<'_, Q, C> {}

--- a/src/query_one.rs
+++ b/src/query_one.rs
@@ -4,15 +4,15 @@ use crate::query::{Fetch, With, Without};
 use crate::{Archetype, Component, Query};
 
 /// A borrow of a `World` sufficient to execute the query `Q` on a single entity
-pub struct QueryOne<'w, 'c, Q: Query<'c, C>, C: Copy + 'c> {
+pub struct QueryOne<'w, Q: Query<'w, C>, C: Copy + 'w> {
     archetype: &'w Archetype,
     index: u32,
     borrowed: bool,
     context: C,
-    _marker: PhantomData<(Q, &'c ())>,
+    _marker: PhantomData<Q>,
 }
 
-impl<'w, 'c, Q: Query<'c, C>, C: Copy + 'c> QueryOne<'w, 'c, Q, C> {
+impl<'w, Q: Query<'w, C>, C: Copy + 'w> QueryOne<'w, Q, C> {
     /// Construct a query accessing the entity in `archetype` at `index`
     ///
     /// # Safety
@@ -34,7 +34,7 @@ impl<'w, 'c, Q: Query<'c, C>, C: Copy + 'c> QueryOne<'w, 'c, Q, C> {
     ///
     /// Panics if called more than once or if it would construct a borrow that clashes with another
     /// pre-existing borrow.
-    pub fn get(&mut self) -> Option<<Q::Fetch as Fetch<'_, 'c, C>>::Item> {
+    pub fn get(&mut self) -> Option<<Q::Fetch as Fetch<'_, 'w, C>>::Item> {
         if self.borrowed {
             panic!("called QueryOnce::get twice; construct a new query instead");
         }
@@ -49,19 +49,19 @@ impl<'w, 'c, Q: Query<'c, C>, C: Copy + 'c> QueryOne<'w, 'c, Q, C> {
     /// Transform the query into one that requires a certain component without borrowing it
     ///
     /// See `QueryBorrow::with` for details.
-    pub fn with<T: Component>(self) -> QueryOne<'w, 'c, With<T, Q>, C> {
+    pub fn with<T: Component>(self) -> QueryOne<'w, With<T, Q>, C> {
         self.transform()
     }
 
     /// Transform the query into one that skips entities having a certain component
     ///
     /// See `QueryBorrow::without` for details.
-    pub fn without<T: Component>(self) -> QueryOne<'w, 'c, Without<T, Q>, C> {
+    pub fn without<T: Component>(self) -> QueryOne<'w, Without<T, Q>, C> {
         self.transform()
     }
 
     /// Helper to change the type of the query
-    fn transform<R: Query<'c, C>>(mut self) -> QueryOne<'w, 'c, R, C> {
+    fn transform<R: Query<'w, C>>(mut self) -> QueryOne<'w, R, C> {
         let x = QueryOne {
             archetype: self.archetype,
             index: self.index,
@@ -75,7 +75,7 @@ impl<'w, 'c, Q: Query<'c, C>, C: Copy + 'c> QueryOne<'w, 'c, Q, C> {
     }
 }
 
-impl<'w, 'c, Q: Query<'c, C>, C: Copy + 'c> Drop for QueryOne<'w, 'c, Q, C> {
+impl<'w, Q: Query<'w, C>, C: Copy + 'w> Drop for QueryOne<'w, Q, C> {
     fn drop(&mut self) {
         if self.borrowed {
             Q::Fetch::release(self.archetype);
@@ -83,5 +83,5 @@ impl<'w, 'c, Q: Query<'c, C>, C: Copy + 'c> Drop for QueryOne<'w, 'c, Q, C> {
     }
 }
 
-unsafe impl<'w, 'c, Q: Query<'c, C>, C: Copy + Sync + 'c> Send for QueryOne<'w, 'c, Q, C> {}
-unsafe impl<'w, 'c, Q: Query<'c, C>, C: Copy + Sync + 'c> Sync for QueryOne<'w, 'c, Q, C> {}
+unsafe impl<'w, Q: Query<'w, C>, C: Copy + Sync + 'w> Send for QueryOne<'w, Q, C> {}
+unsafe impl<'w, Q: Query<'w, C>, C: Copy + Sync + 'w> Sync for QueryOne<'w, Q, C> {}

--- a/src/world.rs
+++ b/src/world.rs
@@ -244,14 +244,15 @@ impl World {
     /// assert!(entities.contains(&(a, 123, true)));
     /// assert!(entities.contains(&(b, 456, false)));
     /// ```
-    pub fn query<'q, Q: Query<'static>>(&'q self) -> QueryBorrow<'q, 'static, Q, ()> {
+    pub fn query<'q, Q: Query<'q>>(&'q self) -> QueryBorrow<'q, Q, ()> {
         QueryBorrow::new(&self.entities.meta, &self.archetypes, ())
     }
 
-    pub fn smart_query<'q, 'c, Q: Query<'c, C>, C: Copy + 'c>(
-        &'q self,
-        context: C,
-    ) -> QueryBorrow<'q, 'c, Q, C> {
+    pub fn smart_query<'q, Q, C>(&'q self, context: C) -> QueryBorrow<'q, Q, C>
+    where
+        Q: Query<'q, C>,
+        C: Copy + 'q,
+    {
         QueryBorrow::new(&self.entities.meta, &self.archetypes, context)
     }
 
@@ -274,19 +275,23 @@ impl World {
     /// if *flag { *number *= 2; }
     /// assert_eq!(*number, 246);
     /// ```
-    pub fn query_one<Q: Query<'static>>(
-        &self,
-        entity: Entity,
-    ) -> Result<QueryOne<'_, 'static, Q, ()>, NoSuchEntity> {
+    pub fn query_one<'q, Q>(&'q self, entity: Entity) -> Result<QueryOne<'_, Q, ()>, NoSuchEntity>
+    where
+        Q: Query<'q>,
+    {
         let loc = self.entities.get(entity)?;
         Ok(unsafe { QueryOne::new(&self.archetypes[loc.archetype as usize], loc.index, ()) })
     }
 
-    pub fn smart_query_one<'q, 'c, Q: Query<'c, C>, C: Copy + 'c>(
+    pub fn smart_query_one<'q, Q, C>(
         &'q self,
         entity: Entity,
         context: C,
-    ) -> Result<QueryOne<'q, 'c, Q, C>, NoSuchEntity> {
+    ) -> Result<QueryOne<'q, Q, C>, NoSuchEntity>
+    where
+        Q: Query<'q, C>,
+        C: Copy + 'q,
+    {
         let loc = self.entities.get(entity)?;
         Ok(unsafe { QueryOne::new(&self.archetypes[loc.archetype as usize], loc.index, context) })
     }

--- a/src/world.rs
+++ b/src/world.rs
@@ -753,8 +753,8 @@ pub trait Component: Send + Sync + 'static {}
 impl<T: Send + Sync + 'static> Component for T {}
 
 pub trait SmartComponent<T: Clone>: Component {
-    fn on_borrow(&self, _id: Entity, _x: &T) {}
-    fn on_borrow_mut(&mut self, _id: Entity, _x: &T) {}
+    fn on_borrow(&self, _id: Entity, _x: T) {}
+    fn on_borrow_mut(&mut self, _id: Entity, _x: T) {}
 }
 
 impl<T: Component> SmartComponent<()> for T {}

--- a/src/world.rs
+++ b/src/world.rs
@@ -306,54 +306,22 @@ impl World {
     ///
     /// Panics if the component is already uniquely borrowed from another entity with the same
     /// components.
-    pub fn get<T: Component>(&self, entity: Entity) -> Result<Ref<'_, T, ()>, ComponentError> {
-        let loc = self.entities.get(entity)?;
-        if loc.archetype == 0 {
-            return Err(MissingComponent::new::<T>().into());
-        }
-        Ok(unsafe {
-            Ref::new(
-                &self.archetypes[loc.archetype as usize],
-                loc.index,
-                entity,
-                (),
-            )?
-        })
+    pub fn get<T: Component>(&self, entity: Entity) -> Result<Ref<'_, T>, ComponentError> {
+        self.get_with_context(entity, ())
     }
 
     /// Uniquely borrow the `T` component of `entity`
     ///
     /// Panics if the component is already borrowed from another entity with the same components.
     pub fn get_mut<T: Component>(&self, entity: Entity) -> Result<RefMut<'_, T>, ComponentError> {
-        let loc = self.entities.get(entity)?;
-        if loc.archetype == 0 {
-            return Err(MissingComponent::new::<T>().into());
-        }
-        Ok(unsafe {
-            RefMut::new(
-                &self.archetypes[loc.archetype as usize],
-                loc.index,
-                entity,
-                (),
-            )?
-        })
+        self.get_mut_with_context(entity, ())
     }
 
     /// Access an entity regardless of its component types
     ///
     /// Does not immediately borrow any component.
     pub fn entity(&self, entity: Entity) -> Result<EntityRef<'_>, NoSuchEntity> {
-        Ok(match self.entities.get(entity)? {
-            Location { archetype: 0, .. } => EntityRef::empty(entity, ()),
-            loc => unsafe {
-                EntityRef::new(
-                    &self.archetypes[loc.archetype as usize],
-                    loc.index,
-                    entity,
-                    (),
-                )
-            },
-        })
+        self.entity_with_context(entity, ())
     }
 
     pub fn get_with_context<T: SmartComponent<C>, C: Clone>(

--- a/src/world.rs
+++ b/src/world.rs
@@ -238,7 +238,7 @@ impl World {
     /// let c = world.spawn((42, "def"));
     /// let entities = world.query::<(&i32, &bool)>()
     ///     .iter()
-    ///     .map(|(e, (&i, &b))| (e, i, b)) // Copy out of the world
+    ///     .map(|(e, (i, b))| (e, *i, *b)) // Copy out of the world
     ///     .collect::<Vec<_>>();
     /// assert_eq!(entities.len(), 2);
     /// assert!(entities.contains(&(a, 123, true)));
@@ -271,7 +271,7 @@ impl World {
     /// let a = world.spawn((123, true, "abc"));
     /// // The returned query must outlive the borrow made by `get`
     /// let mut query = world.query_one::<(&mut i32, &bool)>(a).unwrap();
-    /// let (number, flag) = query.get().unwrap();
+    /// let (mut number, flag) = query.get().unwrap();
     /// if *flag { *number *= 2; }
     /// assert_eq!(*number, 246);
     /// ```

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -342,12 +342,22 @@ fn query_one() {
     let a = world.spawn(("abc", 123));
     let b = world.spawn(("def", 456));
     let c = world.spawn(("ghi", 789, true));
-    assert_eq!(world.query_one::<&i32>(a).unwrap().get(), Some(&123));
-    assert_eq!(world.query_one::<&i32>(b).unwrap().get(), Some(&456));
+    assert_eq!(
+        world.query_one::<&i32>(a).unwrap().get().as_deref(),
+        Some(&123)
+    );
+    assert_eq!(
+        world.query_one::<&i32>(b).unwrap().get().as_deref(),
+        Some(&456)
+    );
     assert!(world.query_one::<(&i32, &bool)>(a).unwrap().get().is_none());
     assert_eq!(
-        world.query_one::<(&i32, &bool)>(c).unwrap().get(),
-        Some((&789, &true))
+        world
+            .query_one::<(&i32, &bool)>(c)
+            .unwrap()
+            .get()
+            .map(|(x, y)| (*x, *y)),
+        Some((789, true))
     );
     world.despawn(a).unwrap();
     assert!(world.query_one::<&i32>(a).is_err());

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -50,7 +50,7 @@ fn query_all() {
     let ents = world
         .query::<(&i32, &&str)>()
         .iter()
-        .map(|(e, (&i, &s))| (e, i, s))
+        .map(|(e, (i, s))| (e, *i, *s))
         .collect::<Vec<_>>();
     assert_eq!(ents.len(), 2);
     assert!(ents.contains(&(e, 123, "abc")));
@@ -70,7 +70,7 @@ fn query_single_component() {
     let ents = world
         .query::<&i32>()
         .iter()
-        .map(|(e, &i)| (e, i))
+        .map(|(e, i)| (e, *i))
         .collect::<Vec<_>>();
     assert_eq!(ents.len(), 2);
     assert!(ents.contains(&(e, 123)));
@@ -93,7 +93,7 @@ fn query_sparse_component() {
     let ents = world
         .query::<&bool>()
         .iter()
-        .map(|(e, &b)| (e, b))
+        .map(|(e, b)| (e, *b))
         .collect::<Vec<_>>();
     assert_eq!(ents, &[(f, true)]);
 }
@@ -106,7 +106,7 @@ fn query_optional_component() {
     let ents = world
         .query::<(Option<&bool>, &i32)>()
         .iter()
-        .map(|(e, (b, &i))| (e, b.copied(), i))
+        .map(|(e, (b, i))| (e, b.as_deref().copied(), *i))
         .collect::<Vec<_>>();
     assert_eq!(ents.len(), 2);
     assert!(ents.contains(&(e, None, 123)));
@@ -139,7 +139,7 @@ fn dynamic_components() {
         world
             .query::<(&i32, &bool)>()
             .iter()
-            .map(|(e, (&i, &b))| (e, i, b))
+            .map(|(e, (i, b))| (e, *i, *b))
             .collect::<Vec<_>>(),
         &[(e, 42, true)]
     );
@@ -148,7 +148,7 @@ fn dynamic_components() {
         world
             .query::<(&i32, &bool)>()
             .iter()
-            .map(|(e, (&i, &b))| (e, i, b))
+            .map(|(e, (i, b))| (e, *i, *b))
             .collect::<Vec<_>>(),
         &[]
     );
@@ -156,7 +156,7 @@ fn dynamic_components() {
         world
             .query::<(&bool, &&str)>()
             .iter()
-            .map(|(e, (&b, &s))| (e, b, s))
+            .map(|(e, (b, s))| (e, *b, *s))
             .collect::<Vec<_>>(),
         &[(e, true, "abc")]
     );
@@ -331,7 +331,7 @@ fn spawn_batch() {
     let entities = world
         .query::<&i32>()
         .iter()
-        .map(|(_, &x)| x)
+        .map(|(_, x)| *x)
         .collect::<Vec<_>>();
     assert_eq!(entities.len(), 100);
 }


### PR DESCRIPTION
This PR adds a `SmartComponent` trait which allows a user to implement their own callbacks for mutable/immutable component access. See https://github.com/sdleffler/sludge/blob/master/src/ecs.rs for a WIP example of its usage.