### PR TITLE
Archetype::component_types

### DIFF
--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -137,9 +137,17 @@ impl Archetype {
         &self.types
     }
 
-    /// Enumerate the types of the components of entities stored in this archetype
+    /// Enumerate the types of the components of entities stored in this archetype.
     ///
     /// Convenient for dispatching logic which needs to be performed on sets of type ids.
+    /// For example, suppose you're building a scripting system, and you want to integrate
+    /// the scripting language with your ECS. This functionality allows you to iterate
+    /// through all of the archetypes of the world with [`World::archetypes`] and extract
+    /// all possible combinations of component types which are currently stored in the `World`.
+    /// From there, you can then create a mapping of archetypes to wrapper objects for your
+    /// scripting language that provide functionality based off of the components of any
+    /// given `Entity`, and bind them onto an `Entity` when passed into your scripting
+    /// language by looking up the `Entity`'s archetype using `EntityRef::component_types`.
     pub fn component_types(&self) -> impl Iterator<Item = TypeId> + '_ {
         self.types.iter().map(|typeinfo| typeinfo.id)
     }

--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -137,6 +137,13 @@ impl Archetype {
         &self.types
     }
 
+    /// Enumerate the types of the components of entities stored in this archetype
+    ///
+    /// Convenient for dispatching logic which needs to be performed on sets of type ids.
+    pub fn component_types(&self) -> impl Iterator<Item = TypeId> + '_ {
+        self.types.iter().map(|typeinfo| typeinfo.id)
+    }
+
     /// `index` must be in-bounds
     pub(crate) unsafe fn get_dynamic(
         &self,


### PR DESCRIPTION
This PR adds a method with similar functionality to `Entity::component_types`, but on `Archetype`. This is useful for automating generation of scripting interfaces and schedules from archetypes.