### PR TITLE
Add `World::resolve_unknown_gen`

### DIFF
--- a/src/entities.rs
+++ b/src/entities.rs
@@ -236,6 +236,22 @@ impl Entities {
         Ok(meta.location)
     }
 
+    /// Returns `None` if the given id would represent an index outside of `meta`.
+    pub unsafe fn resolve_unknown_gen(&self, id: u32) -> Option<Entity> {
+        let meta_len = self.meta.len();
+        if meta_len + self.pending.load(Ordering::Relaxed) as usize <= id as usize {
+            None
+        } else if meta_len <= id as usize {
+            Some(Entity { generation: 0, id })
+        } else {
+            let meta = &self.meta[id as usize];
+            Some(Entity {
+                generation: meta.generation,
+                id,
+            })
+        }
+    }
+
     /// Allocate space for and enumerate pending entities
     #[allow(clippy::reversed_empty_ranges)]
     pub fn flush(&mut self) -> impl Iterator<Item = u32> {

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -237,6 +237,9 @@ impl Entities {
     }
 
     /// Returns `None` if the given id would represent an index outside of `meta`.
+    ///
+    /// # Safety
+    /// Must only be called for currently allocated `id`s.
     pub unsafe fn resolve_unknown_gen(&self, id: u32) -> Option<Entity> {
         let meta_len = self.meta.len();
         if meta_len + self.pending.load(Ordering::Relaxed) as usize <= id as usize {

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -240,18 +240,18 @@ impl Entities {
     ///
     /// # Safety
     /// Must only be called for currently allocated `id`s.
-    pub unsafe fn resolve_unknown_gen(&self, id: u32) -> Option<Entity> {
+    pub unsafe fn resolve_unknown_gen(&self, id: u32) -> Entity {
         let meta_len = self.meta.len();
         if meta_len + self.pending.load(Ordering::Relaxed) as usize <= id as usize {
-            None
+            panic!("entity id is out of range");
         } else if meta_len <= id as usize {
-            Some(Entity { generation: 0, id })
+            Entity { generation: 0, id }
         } else {
             let meta = &self.meta[id as usize];
-            Some(Entity {
+            Entity {
                 generation: meta.generation,
                 id,
-            })
+            }
         }
     }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -312,7 +312,7 @@ impl World {
     ///
     /// # Safety
     /// `id` must correspond to a currently live `Entity`. A despawned or never-allocated `id` will produce undefined behavior.
-    pub unsafe fn resolve_unknown_gen(&self, id: u32) -> Option<Entity> {
+    pub unsafe fn resolve_unknown_gen(&self, id: u32) -> Entity {
         self.entities.resolve_unknown_gen(id)
     }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -305,6 +305,14 @@ impl World {
         })
     }
 
+    /// Given the ID of an entity without a generation, try to find the matching generation.
+    ///
+    /// This function is useful if you know there's an element with a given index, but you
+    /// don't know its generation.
+    pub unsafe fn resolve_unknown_gen(&self, id: u32) -> Option<Entity> {
+        self.entities.resolve_unknown_gen(id)
+    }
+
     /// Iterate over all entities in the world
     ///
     /// Entities are yielded in arbitrary order. Prefer `World::query` for better performance when

--- a/src/world.rs
+++ b/src/world.rs
@@ -309,6 +309,13 @@ impl World {
     ///
     /// This function is useful if you know there's an element with a given index, but you
     /// don't know its generation.
+    ///
+    /// # Safety
+    /// This function can still return `Some` if passed the ID of a dead entity. In this case,
+    /// it will return an entity which will, if looked up, have no components, but which may
+    /// later become allocated with some other set of components. Only use this if you're
+    /// absolutely certain that the entity is live, or if you have some other way to ensure
+    /// you have acquired a live entity!
     pub unsafe fn resolve_unknown_gen(&self, id: u32) -> Option<Entity> {
         self.entities.resolve_unknown_gen(id)
     }

--- a/src/world.rs
+++ b/src/world.rs
@@ -311,11 +311,7 @@ impl World {
     /// don't know its generation.
     ///
     /// # Safety
-    /// This function can still return `Some` if passed the ID of a dead entity. In this case,
-    /// it will return an entity which will, if looked up, have no components, but which may
-    /// later become allocated with some other set of components. Only use this if you're
-    /// absolutely certain that the entity is live, or if you have some other way to ensure
-    /// you have acquired a live entity!
+    /// `id` must correspond to a currently live `Entity`. A despawned or never-allocated `id` will produce undefined behavior.
     pub unsafe fn resolve_unknown_gen(&self, id: u32) -> Option<Entity> {
         self.entities.resolve_unknown_gen(id)
     }

--- a/src/world.rs
+++ b/src/world.rs
@@ -305,14 +305,11 @@ impl World {
         })
     }
 
-    /// Given the ID of an entity without a generation, try to find the matching generation.
-    ///
-    /// This function is useful if you know there's an element with a given index, but you
-    /// don't know its generation.
+    /// Given an id obtained from `Entity::id`, reconstruct the still-live `Entity`.
     ///
     /// # Safety
     /// `id` must correspond to a currently live `Entity`. A despawned or never-allocated `id` will produce undefined behavior.
-    pub unsafe fn entity_from_id(&self, id: u32) -> Entity {
+    pub unsafe fn find_entity_from_id(&self, id: u32) -> Entity {
         self.entities.resolve_unknown_gen(id)
     }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -312,7 +312,7 @@ impl World {
     ///
     /// # Safety
     /// `id` must correspond to a currently live `Entity`. A despawned or never-allocated `id` will produce undefined behavior.
-    pub unsafe fn resolve_unknown_gen(&self, id: u32) -> Entity {
+    pub unsafe fn entity_from_id(&self, id: u32) -> Entity {
         self.entities.resolve_unknown_gen(id)
     }
 


### PR DESCRIPTION
This adds an unsafe method `World::resolve_unknown_gen` which allows the user to map a `u32` identifier extracted via `Entity::id` back to a potentially live `Entity`. As discussed previously it's unsafe because it may return a reference to a dead `Entity`, which will appear as though it has no components and may later spontaneously acquire components by becoming a live `Entity`.