### PR TITLE
Use a much faster hash for TypeId

### DIFF
--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -17,10 +17,11 @@ use crate::alloc::boxed::Box;
 use crate::alloc::{vec, vec::Vec};
 use core::any::{type_name, TypeId};
 use core::cell::UnsafeCell;
+use core::hash::{BuildHasher, BuildHasherDefault, Hasher};
 use core::mem;
 use core::ptr::{self, NonNull};
 
-use hashbrown::HashMap;
+use hashbrown::{hash_map::DefaultHashBuilder, HashMap};
 
 use crate::borrow::AtomicBorrow;
 use crate::query::Fetch;
@@ -32,7 +33,7 @@ use crate::{Access, Component, Query};
 /// go through the `World`.
 pub struct Archetype {
     types: Vec<TypeInfo>,
-    state: HashMap<TypeId, TypeState>,
+    state: TypeIdMap<TypeState>,
     len: u32,
     entities: Box<[u32]>,
     // UnsafeCell allows unique references into `data` to be constructed while shared references
@@ -198,7 +199,7 @@ impl Archetype {
             self.entities = new_entities;
 
             let old_data_size = mem::replace(&mut self.data_size, 0);
-            let mut state = HashMap::with_capacity(self.types.len());
+            let mut state = HashMap::with_capacity_and_hasher(self.types.len(), Default::default());
             for ty in &self.types {
                 self.data_size = align(self.data_size, ty.layout.align());
                 state.insert(ty.id, TypeState::new(self.data_size));
@@ -337,6 +338,50 @@ impl Drop for Archetype {
         }
     }
 }
+
+/// A hasher optimized for hashing a single TypeId.
+///
+/// TypeId is already thoroughly hashed, so there's no reason to hash it again.
+/// Just leave the bits unchanged.
+#[derive(Default)]
+pub(crate) struct TypeIdHasher {
+    hash: u64,
+}
+
+impl Hasher for TypeIdHasher {
+    fn write_u64(&mut self, n: u64) {
+        // Only a single value can be hashed, so the old hash should be zero.
+        debug_assert_eq!(self.hash, 0);
+        self.hash = n;
+    }
+
+    // Tolerate TypeId being either u64 or u128.
+    fn write_u128(&mut self, n: u128) {
+        debug_assert_eq!(self.hash, 0);
+        self.hash = n as u64;
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        debug_assert_eq!(self.hash, 0);
+
+        // This will only be called if TypeId is neither u64 nor u128, which is not anticipated.
+        // In that case we'll just fall back to using a different hash implementation.
+        let mut hasher = DefaultHashBuilder::new().build_hasher();
+        hasher.write(bytes);
+        self.hash = hasher.finish();
+    }
+
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+}
+
+/// A HashMap with TypeId keys
+///
+/// Because TypeId is already a fully-hashed u64 (including data in the high seven bits,
+/// which hashbrown needs), there is no need to hash it again. Instead, this uses the much
+/// faster no-op hash.
+pub(crate) type TypeIdMap<V> = HashMap<TypeId, V, BuildHasherDefault<TypeIdHasher>>;
 
 struct TypeState {
     offset: usize,

--- a/src/entity_builder.rs
+++ b/src/entity_builder.rs
@@ -19,9 +19,9 @@ use core::any::TypeId;
 use core::mem::{self, MaybeUninit};
 use core::ptr;
 
-use hashbrown::hash_map::{Entry, HashMap};
+use hashbrown::hash_map::Entry;
 
-use crate::archetype::TypeInfo;
+use crate::archetype::{TypeIdMap, TypeInfo};
 use crate::{Component, DynamicBundle};
 
 /// Helper for incrementally constructing a bundle of components with dynamic component types
@@ -42,7 +42,7 @@ pub struct EntityBuilder {
     cursor: usize,
     info: Vec<(TypeInfo, usize)>,
     ids: Vec<TypeId>,
-    indices: HashMap<TypeId, usize>,
+    indices: TypeIdMap<usize>,
 }
 
 impl EntityBuilder {
@@ -53,7 +53,7 @@ impl EntityBuilder {
             storage: Box::new([]),
             info: Vec::new(),
             ids: Vec::new(),
-            indices: HashMap::new(),
+            indices: Default::default(),
         }
     }
 


### PR DESCRIPTION
TypeId is already a fully-hashed u64, so there is no need to hash it further.
Instead, just use nohash-hasher to pass it through unchanged.