### PR TITLE
Nitpicking: don't create a new BuildHasher on each hash call

### DIFF
--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -366,7 +366,7 @@ impl Hasher for TypeIdHasher {
 
         // This will only be called if TypeId is neither u64 nor u128, which is not anticipated.
         // In that case we'll just fall back to using a different hash implementation.
-        let mut hasher = DefaultHashBuilder::new().build_hasher();
+        let mut hasher = <DefaultHashBuilder as BuildHasher>::Hasher::default();
         hasher.write(bytes);
         self.hash = hasher.finish();
     }


### PR DESCRIPTION
This is in new paranoia code that won't be run, because TypeId is u64,
but technically if TypeId changed to not be u64 or u128, and hashbrown
changed from ahash to use randomly-seeded hashes, then this would
compute ever-varying hashes for the same value. You can see this
if you replace the DefaultHashBuilder with RandomState.

Instead, construct hashbrown's default Hasher's using default().
This produces repeatable hashes even if using RandomState.