### PR TITLE
Revert "Use a much faster hash for TypeId"

### DIFF
--- a/src/entity_builder.rs
+++ b/src/entity_builder.rs
@@ -19,9 +19,9 @@ use core::any::TypeId;
 use core::mem::{self, MaybeUninit};
 use core::ptr;
 
-use hashbrown::hash_map::Entry;
+use hashbrown::hash_map::{Entry, HashMap};
 
-use crate::archetype::{TypeIdMap, TypeInfo};
+use crate::archetype::TypeInfo;
 use crate::{Component, DynamicBundle};
 
 /// Helper for incrementally constructing a bundle of components with dynamic component types
@@ -42,7 +42,7 @@ pub struct EntityBuilder {
     cursor: usize,
     info: Vec<(TypeInfo, usize)>,
     ids: Vec<TypeId>,
-    indices: TypeIdMap<usize>,
+    indices: HashMap<TypeId, usize>,
 }
 
 impl EntityBuilder {
@@ -53,7 +53,7 @@ impl EntityBuilder {
             storage: Box::new([]),
             info: Vec::new(),
             ids: Vec::new(),
-            indices: Default::default(),
+            indices: HashMap::new(),
         }
     }
 


### PR DESCRIPTION
This reverts commits 5ffba7fc3a63e988e5966481b5842055c44f6801 and 0b78f1453d4a51fbc1ce96f256403bca9242f0a6.

These still, somehow, seem to slow down iteration significantly (~36%).

cc @mjhostet

On reexamination it looks like I was a bit hasty in declaring the strange behavior solved; this revert reduces spawn_batch perf by 25% but improves iterate_100k perf more. I'm still mystified by what's going on here. Some inlining heuristic screwup?