### PR TITLE
Mark a couple archetype methods as `inline`

### DIFF
--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -122,10 +122,12 @@ impl Archetype {
         }
     }
 
+    #[inline]
     pub(crate) fn len(&self) -> u32 {
         self.len
     }
 
+    #[inline]
     pub(crate) fn entities(&self) -> NonNull<u32> {
         unsafe { NonNull::new_unchecked(self.entities.as_ptr() as *mut _) }
     }


### PR DESCRIPTION
ChunkIter calls `archetype.entities()` and `archetype.len()`.
By marking them `inline`, the outer loop of query iteration
avoids two function calls to these trivial methods (and the
register spills those cause).

This speeds up the iterate_100k benchmark by 23%. That feels
unreasonably high since it doesn't affect the innermost loop, but
even if this benefit is illusory the machine code is tighter so
this is a win.