### PR TITLE
Support generics in bundle derive macro

### DIFF
--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -12,6 +12,7 @@ fn derive() {
         "tuple_structs.rs",
         "named_structs.rs",
         "no_prelude.rs",
+        "generics.rs",
     ];
     for &passing_test in successes {
         t.pass(&format!("{}/{}", TEST_DIR, passing_test));

--- a/tests/derive/generics.rs
+++ b/tests/derive/generics.rs
@@ -1,0 +1,21 @@
+use hecs::Bundle;
+
+#[derive(Bundle)]
+struct Foo<T> {
+    foo: T,
+}
+
+#[derive(Bundle)]
+struct Bar<T> {
+    foo: i32,
+    bar: T,
+}
+
+#[derive(Bundle)]
+struct Baz<T, U, V> {
+    foo: T,
+    bar: U,
+    baz: V,
+}
+
+fn main() {}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -243,7 +243,18 @@ fn derived_bundle() {
 
 #[test]
 #[cfg(feature = "macros")]
-#[should_panic(expected = "each type must occur at most once")]
+#[cfg_attr(
+    debug_assertions,
+    should_panic(
+        expected = "attempted to create archetype with duplicate components; each type must occur at most once! duplicate component type: i32"
+    )
+)]
+#[cfg_attr(
+    not(debug_assertions),
+    should_panic(
+        expected = r#"attempted to create archetype with duplicate components; each type must occur at most once!"#
+    )
+)]
 fn bad_bundle_derive() {
     #[derive(Bundle)]
     struct Foo {
@@ -367,4 +378,22 @@ fn query_one() {
     );
     world.despawn(a).unwrap();
     assert!(world.query_one::<&i32>(a).is_err());
+}
+
+#[test]
+#[cfg_attr(
+    debug_assertions,
+    should_panic(
+        expected = r#"attempted to create archetype with duplicate components; each type must occur at most once! duplicate component type: f32"#
+    )
+)]
+#[cfg_attr(
+    not(debug_assertions),
+    should_panic(
+        expected = r#"attempted to create archetype with duplicate components; each type must occur at most once!"#
+    )
+)]
+fn duplicate_components_panic() {
+    let mut world = World::new();
+    world.reserve::<(f32, i64, f32)>(1);
 }


### PR DESCRIPTION
Fixes #87

This still does the duplication check, unlike tuples which don't do that. Should that stay or not?

Edit: Maybe the dupe check can be made cheaper by making it lazy and only execute once via AtomicBool and closures?