### PR TITLE
Store components aligned in EntityBuilder

### DIFF
--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -25,7 +25,7 @@ use hashbrown::{hash_map::DefaultHashBuilder, HashMap};
 
 use crate::borrow::AtomicBorrow;
 use crate::query::Fetch;
-use crate::{Access, Component, Query};
+use crate::{align, Access, Component, Query};
 
 /// A collection of entities having the same component types
 ///
@@ -477,8 +477,3 @@ impl PartialEq for TypeInfo {
 }
 
 impl Eq for TypeInfo {}
-
-fn align(x: usize, alignment: usize) -> usize {
-    debug_assert!(alignment.is_power_of_two());
-    (x + alignment - 1) & (!alignment + 1)
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,3 +93,8 @@ pub use query::Fetch;
 
 #[cfg(feature = "macros")]
 pub use hecs_macros::{Bundle, Query};
+
+fn align(x: usize, alignment: usize) -> usize {
+    debug_assert!(alignment.is_power_of_two());
+    (x + alignment - 1) & (!alignment + 1)
+}


### PR DESCRIPTION
Allows us to drop entities faster when needed and drastically
simplifies the implementation at the cost of occasional small padding
that the caller can avoid if they need to.