### PR TITLE
Methods for querying from a mutable borrow

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -72,6 +72,18 @@ fn iterate_100k(b: &mut Bencher) {
     })
 }
 
+fn iterate_mut_100k(b: &mut Bencher) {
+    let mut world = World::new();
+    for i in 0..100_000 {
+        world.spawn((Position(-(i as f32)), Velocity(i as f32)));
+    }
+    b.iter(|| {
+        for (_, (pos, vel)) in world.query_mut::<(&mut Position, &Velocity)>() {
+            pos.0 += vel.0;
+        }
+    })
+}
+
 fn build(b: &mut Bencher) {
     let mut world = World::new();
     let mut builder = EntityBuilder::new();
@@ -87,6 +99,7 @@ benchmark_group!(
     spawn_static,
     spawn_batch,
     iterate_100k,
+    iterate_mut_100k,
     build
 );
 benchmark_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,9 @@ pub use borrow::{EntityRef, Ref, RefMut};
 pub use bundle::{Bundle, DynamicBundle, MissingComponent};
 pub use entities::{Entity, NoSuchEntity};
 pub use entity_builder::{BuiltEntity, EntityBuilder};
-pub use query::{Access, BatchedIter, Query, QueryBorrow, QueryIter, QueryItem, With, Without};
+pub use query::{
+    Access, BatchedIter, Query, QueryBorrow, QueryItem, QueryIter, QueryMut, With, Without,
+};
 pub use query_one::QueryOne;
 pub use world::{ArchetypesGeneration, Component, ComponentError, Iter, SpawnBatchIter, World};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub use borrow::{EntityRef, Ref, RefMut};
 pub use bundle::{Bundle, DynamicBundle, MissingComponent};
 pub use entities::{Entity, NoSuchEntity};
 pub use entity_builder::{BuiltEntity, EntityBuilder};
-pub use query::{Access, BatchedIter, Query, QueryBorrow, QueryIter, With, Without};
+pub use query::{Access, BatchedIter, Query, QueryBorrow, QueryIter, QueryItem, With, Without};
 pub use query_one::QueryOne;
 pub use world::{ArchetypesGeneration, Component, ComponentError, Iter, SpawnBatchIter, World};
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -464,7 +464,7 @@ unsafe impl<'q, Q: Query> Sync for QueryIter<'q, Q> {}
 impl<'q, Q: Query> Iterator for QueryIter<'q, Q> {
     type Item = (Entity, QueryItem<'q, Q>);
 
-    #[inline]
+    #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             match unsafe { self.iter.next() } {

--- a/src/query_one.rs
+++ b/src/query_one.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 use crate::query::{Fetch, With, Without};
-use crate::{Archetype, Component, Query};
+use crate::{Archetype, Component, Query, QueryItem};
 
 /// A borrow of a `World` sufficient to execute the query `Q` on a single entity
 pub struct QueryOne<'a, Q: Query> {
@@ -32,7 +32,8 @@ impl<'a, Q: Query> QueryOne<'a, Q> {
     ///
     /// Panics if called more than once or if it would construct a borrow that clashes with another
     /// pre-existing borrow.
-    pub fn get(&mut self) -> Option<<Q::Fetch as Fetch<'_>>::Item> {
+    // Note that this uses self's lifetime, not 'a, for soundness.
+    pub fn get(&mut self) -> Option<QueryItem<'_, Q>> {
         if self.borrowed {
             panic!("called QueryOnce::get twice; construct a new query instead");
         }


### PR DESCRIPTION
These allow dynamic borrow checks to be bypassed when there's no concurrency needed. Confusingly, despite being literally the same iterator minus some setup work, the benchmark is ~50% slower. @mjhostet, am I doing something stupid here?