### PR TITLE
Serialization convenience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.2 (Unreleased)
+
+### Added
+- The `serde` feature, enabling serialization of `Entity` handles, and a `serialization` module to
+  simplify (de)serializing worlds
+
 # 0.3.1 (November 9, 2020)
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ macros = ["hecs-macros", "lazy_static"]
 hecs-macros = { path = "macros", version = "0.4.0", optional = true }
 hashbrown = { version = "0.9.0", default-features = false, features = ["ahash", "inline-more"] }
 lazy_static = { version = "1.4.0", optional = true, features = ["spin_no_std"] }
+serde = { version = "1.0.117", default-features = false, optional = true }
 
 [dev-dependencies]
 bencher = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ serde = { version = "1.0.117", default-features = false, optional = true }
 bencher = "0.1.5"
 rand = "0.7.3"
 trybuild = "1.0.23"
+serde = { version = "1.0.117", features = ["derive"] }
+serde_test = "1.0.117"
 
 [[bench]]
 name = "bench"

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -9,6 +9,9 @@ use std::error::Error;
 /// Lightweight unique ID, or handle, of an entity
 ///
 /// Obtained from `World::spawn`. Can be stored to refer to an entity in the future.
+///
+/// Enable the `serde` feature on the crate to make this `Serialize`able. Some applications may be
+/// able to save space by only serializing the output of `Entity::id`.
 #[derive(Clone, Copy, Hash, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Entity {
     pub(crate) generation: u32,
@@ -53,6 +56,27 @@ impl Entity {
 impl fmt::Debug for Entity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}v{}", self.id, self.generation)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Entity {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.to_bits().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Entity {
+    fn deserialize<D>(deserializer: D) -> Result<Entity, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let bits = u64::deserialize(deserializer)?;
+        Ok(Entity::from_bits(bits))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,8 @@ mod entities;
 mod entity_builder;
 mod query;
 mod query_one;
+#[cfg(feature = "serde")]
+pub mod serialize;
 mod world;
 
 pub use archetype::Archetype;

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,0 +1,399 @@
+//! Convenience tools for serializing [`World`]s; requires the `serde` feature
+//!
+//! [`Component`]s are not necessarily serializable, so we cannot directly implement [`Serialize`]
+//! for [`World`]. The helper functions defined in this module allow serialization and
+//! deserialization to rely on purpose-defined traits to control the procedures explicitly.
+//!
+//! This module builds on the public [`World::iter()`] and [`World::spawn_at()`] APIs, and are
+//! somewhat opinionated. For some applications, a more custom approach may be preferable.
+//!
+//! In terms of the serde data model, we treat a [`World`] as a map of entity IDs to user-controlled
+//! maps of component IDs to data. Backwards-incompatible changes to this model are subject to the
+//! same semantic versioning stability guarantees as the hecs API.
+
+use core::{cell::RefCell, fmt};
+
+use serde::{
+    de::{DeserializeSeed, MapAccess, Visitor},
+    ser::SerializeMap,
+    Deserializer, Serialize, Serializer,
+};
+
+use crate::{Component, EntityBuilder, EntityRef, World};
+
+/// Implements serialization of individual entities
+///
+/// Data external to the [`World`] can be exposed during serialization by storing references inside
+/// the struct implementing this trait.
+///
+/// # Example
+///
+/// ```
+/// # use serde::{Serialize, Deserialize};
+/// # #[derive(Serialize)]
+/// # struct Position([f32; 3]);
+/// # #[derive(Serialize)]
+/// # struct Velocity([f32; 3]);
+/// use hecs::{*, serialize::*};
+///
+/// // Could include references to external state for use by `serialize_entity`
+/// struct Context;
+/// #[derive(Serialize, Deserialize)]
+/// enum ComponentId { Position, Velocity }
+///
+/// impl SerializeContext for Context {
+///     fn serialize_entity<S>(
+///         &mut self,
+///         entity: EntityRef<'_>,
+///         map: &mut S,
+///     ) -> Result<(), S::Error>
+///     where
+///         S: serde::ser::SerializeMap,
+///     {
+///         // Call `try_serialize` for every serializable component we want to save
+///         try_serialize::<Position, _, _>(&entity, &ComponentId::Position, map)?;
+///         try_serialize::<Velocity, _, _>(&entity, &ComponentId::Velocity, map)?;
+///         // Or do something custom for more complex cases.
+///         Ok(())
+///     }
+/// }
+/// ```
+pub trait SerializeContext {
+    /// Serialize a single entity into a map
+    fn serialize_entity<S>(&mut self, entity: EntityRef<'_>, map: &mut S) -> Result<(), S::Error>
+    where
+        S: SerializeMap;
+}
+
+/// If `entity` has component `T`, serialize it under `key` in `map`
+///
+/// Convenience method for [`SerializeContext`] implementations.
+pub fn try_serialize<T: Component + Serialize, K: Serialize + ?Sized, S: SerializeMap>(
+    entity: &EntityRef<'_>,
+    key: &K,
+    map: &mut S,
+) -> Result<(), S::Error> {
+    if let Some(x) = entity.get::<T>() {
+        map.serialize_key(key)?;
+        map.serialize_value(&*x)?;
+    }
+    Ok(())
+}
+
+/// Serialize a [`World`] through a [`SerializeContext`] to a [`Serializer`]
+pub fn serialize<C, S>(world: &World, context: &mut C, serializer: S) -> Result<S::Ok, S::Error>
+where
+    C: SerializeContext,
+    S: Serializer,
+{
+    let mut seq = serializer.serialize_map(None)?;
+    for (id, components) in world {
+        seq.serialize_key(&id)?;
+        seq.serialize_value(&SerializeComponents(RefCell::new((
+            context,
+            Some(components),
+        ))))?;
+    }
+    seq.end()
+}
+
+struct SerializeComponents<'a, C>(RefCell<(&'a mut C, Option<EntityRef<'a>>)>);
+
+impl<'a, C: SerializeContext> Serialize for SerializeComponents<'a, C> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut this = self.0.borrow_mut();
+        let entity = this.1.take().unwrap();
+        let mut map = serializer.serialize_map(None)?;
+        this.0.serialize_entity(entity, &mut map)?;
+        map.end()
+    }
+}
+
+/// Deserialize a [`World`] with a [`DeserializeContext`] and a [`Deserializer`]
+pub fn deserialize<'de, C, D>(context: &mut C, deserializer: D) -> Result<World, D::Error>
+where
+    C: DeserializeContext,
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_map(WorldVisitor(context))
+}
+
+/// Implements deserialization of entities from a serde [`MapAccess`] into an [`EntityBuilder`]
+///
+/// Data external to the [`World`] can be populated during deserialization by storing mutable
+/// references inside the struct implementing this trait.
+///
+/// # Example
+/// ```
+/// # use serde::{Serialize, Deserialize};
+/// # #[derive(Deserialize)]
+/// # struct Position([f32; 3]);
+/// # #[derive(Deserialize)]
+/// # struct Velocity([f32; 3]);
+/// use hecs::{*, serialize::*};
+///
+/// // Could include references to external state for use by `deserialize_entity`
+/// struct Context;
+/// #[derive(Serialize, Deserialize)]
+/// enum ComponentId { Position, Velocity }
+///
+/// impl DeserializeContext for Context {
+///     fn deserialize_entity<'de, M>(
+///         &mut self,
+///         mut map: M,
+///         entity: &mut EntityBuilder,
+///     ) -> Result<(), M::Error>
+///     where
+///         M: serde::de::MapAccess<'de>,
+///     {
+///         while let Some(key) = map.next_key()? {
+///             match key {
+///                 ComponentId::Position => {
+///                     entity.add::<Position>(map.next_value()?);
+///                 }
+///                 ComponentId::Velocity => {
+///                     entity.add::<Velocity>(map.next_value()?);
+///                 }
+///             }
+///         }
+///         Ok(())
+///     }
+/// }
+/// ```
+pub trait DeserializeContext {
+    /// Deserialize a single entity
+    fn deserialize_entity<'de, M>(
+        &mut self,
+        map: M,
+        entity: &mut EntityBuilder,
+    ) -> Result<(), M::Error>
+    where
+        M: MapAccess<'de>;
+}
+
+struct WorldVisitor<'a, C>(&'a mut C);
+
+impl<'de, 'a, C> Visitor<'de> for WorldVisitor<'a, C>
+where
+    C: DeserializeContext,
+{
+    type Value = World;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a world")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<World, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut world = World::new();
+        let mut builder = EntityBuilder::new();
+        while let Some(id) = map.next_key()? {
+            map.next_value_seed(DeserializeComponents(self.0, &mut builder))?;
+            world.spawn_at(id, builder.build());
+        }
+        Ok(world)
+    }
+}
+
+struct DeserializeComponents<'a, C>(&'a mut C, &'a mut EntityBuilder);
+
+impl<'de, 'a, C> DeserializeSeed<'de> for DeserializeComponents<'a, C>
+where
+    C: DeserializeContext,
+{
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(ComponentsVisitor(self.0, self.1))
+    }
+}
+
+struct ComponentsVisitor<'a, C>(&'a mut C, &'a mut EntityBuilder);
+
+impl<'de, 'a, C> Visitor<'de> for ComponentsVisitor<'a, C>
+where
+    C: DeserializeContext,
+{
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("an entity's components")
+    }
+
+    fn visit_map<A>(self, map: A) -> Result<(), A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        self.0.deserialize_entity(map, self.1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt;
+
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+    use crate::*;
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Copy, Clone)]
+    struct Position([f32; 3]);
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Copy, Clone)]
+    struct Velocity([f32; 3]);
+
+    struct Context;
+    #[derive(Serialize, Deserialize)]
+    enum ComponentId {
+        Position,
+        Velocity,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    /// Bodge into serde_test's very strict interface
+    struct SerWorld(#[serde(with = "helpers")] World);
+
+    impl PartialEq for SerWorld {
+        fn eq(&self, other: &Self) -> bool {
+            fn same_components<T: Component + PartialEq>(x: &EntityRef, y: &EntityRef) -> bool {
+                x.get::<T>().as_ref().map(|x| &**x) == y.get::<T>().as_ref().map(|x| &**x)
+            }
+
+            for ((x_id, x), (y_id, y)) in self.0.iter().zip(other.0.iter()) {
+                if x_id != y_id
+                    || !same_components::<Position>(&x, &y)
+                    || !same_components::<Velocity>(&x, &y)
+                {
+                    return false;
+                }
+            }
+            true
+        }
+    }
+
+    impl fmt::Debug for SerWorld {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_map()
+                .entries(self.0.iter().map(|(id, ref e)| {
+                    (
+                        id,
+                        (
+                            e.get::<Position>().map(|x| *x),
+                            e.get::<Velocity>().map(|x| *x),
+                        ),
+                    )
+                }))
+                .finish()
+        }
+    }
+
+    mod helpers {
+        use super::*;
+        pub fn serialize<S: Serializer>(x: &World, s: S) -> Result<S::Ok, S::Error> {
+            crate::serialize::serialize(x, &mut Context, s)
+        }
+        pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<World, D::Error> {
+            crate::serialize::deserialize(&mut Context, d)
+        }
+    }
+
+    impl DeserializeContext for Context {
+        fn deserialize_entity<'de, M>(
+            &mut self,
+            mut map: M,
+            entity: &mut EntityBuilder,
+        ) -> Result<(), M::Error>
+        where
+            M: serde::de::MapAccess<'de>,
+        {
+            while let Some(key) = map.next_key()? {
+                match key {
+                    ComponentId::Position => {
+                        entity.add::<Position>(map.next_value()?);
+                    }
+                    ComponentId::Velocity => {
+                        entity.add::<Velocity>(map.next_value()?);
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+
+    impl SerializeContext for Context {
+        fn serialize_entity<S>(
+            &mut self,
+            entity: EntityRef<'_>,
+            map: &mut S,
+        ) -> Result<(), S::Error>
+        where
+            S: serde::ser::SerializeMap,
+        {
+            try_serialize::<Position, _, _>(&entity, &ComponentId::Position, map)?;
+            try_serialize::<Velocity, _, _>(&entity, &ComponentId::Velocity, map)?;
+            Ok(())
+        }
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn roundtrip() {
+        use serde_test::{Token, assert_tokens};
+
+        let mut world = World::new();
+        let p0 = Position([0.0, 0.0, 0.0]);
+        let v0 = Velocity([1.0, 1.0, 1.0]);
+        let p1 = Position([2.0, 2.0, 2.0]);
+        let e0 = world.spawn((p0, v0));
+        let e1 = world.spawn((p1,));
+
+        assert_tokens(&SerWorld(world), &[
+            Token::NewtypeStruct { name: "SerWorld" },
+            Token::Map { len: None },
+
+            Token::U64(e0.to_bits()),
+            Token::Map { len: None },
+
+            Token::UnitVariant { name: "ComponentId", variant: "Position" },
+            Token::NewtypeStruct { name: "Position" },
+            Token::Tuple { len: 3 },
+            Token::F32(0.0),
+            Token::F32(0.0),
+            Token::F32(0.0),
+            Token::TupleEnd,
+
+            Token::UnitVariant { name: "ComponentId", variant: "Velocity" },
+            Token::NewtypeStruct { name: "Velocity" },
+            Token::Tuple { len: 3 },
+            Token::F32(1.0),
+            Token::F32(1.0),
+            Token::F32(1.0),
+            Token::TupleEnd,
+
+            Token::MapEnd,
+
+            Token::U64(e1.to_bits()),
+            Token::Map { len: None },
+
+            Token::UnitVariant { name: "ComponentId", variant: "Position" },
+            Token::NewtypeStruct { name: "Position" },
+            Token::Tuple { len: 3 },
+            Token::F32(2.0),
+            Token::F32(2.0),
+            Token::F32(2.0),
+            Token::TupleEnd,
+
+            Token::MapEnd,
+
+            Token::MapEnd,
+        ])
+    }
+}

--- a/src/world.rs
+++ b/src/world.rs
@@ -107,9 +107,8 @@ impl World {
     ///
     /// Despawns any existing entity with the same `Entity::id`.
     ///
-    /// Can be used for easy handle-preserving deserialization in conjunction with
-    /// `Entity::from_bits`. Be cautious resurrecting old `Entity` handles in populated worlds as it
-    /// vastly increases the likelihood of collisions.
+    /// Useful for easy handle-preserving deserialization. Be cautious resurrecting old `Entity`
+    /// handles in already-populated worlds as it vastly increases the likelihood of collisions.
     ///
     /// # Example
     /// ```


### PR DESCRIPTION
hecs does not currently provide any tools to simplify serialization. I have personally argued that serialization done right tends to be highly application-specific, as users should take care to exclude runtime-only information like GPU resource handles, incorporate non-ECS data gracefully, and elide generation information from serialized entity IDs. In my own projects, I often convert entities or even entire worlds into a more serde-friendly format and serialize that, though this is suboptimal.

Users have frequently asked what the best approach for serialization with hecs is, and I set out to address that with an example. It became clear that any easily-implemented serialization scheme would be inefficient despite significant boilerplate, and an efficient scheme, avoiding redundant copies, was complex. This convinced me that providing support to bypass the bulk of this complexity for most users is justified. While advanced users may still want to consider a custom pipeline, we should be able to dramatically lower the barrier to entry.

I originally targeted a minimal, opinionated, stateful interface along the lines of:
```rust
impl WorldSerializer {
    fn register<T: Component + Serialize, K: Serialize + 'static>(&mut self, key: K);
    fn serialize<S: serde::Seriralizer>(&self, world: &World, serializer: S);
}
```
Supporting any static `Serializer` with this pattern proved difficult, so a lower-level, more verbose approach requiring the application to implement traits was taken (see rustdocs in the diff for examples). The result is still much easier than implementing an equivalently efficient serialization pipeline from scratch, and provides better support for custom logic, particularly involving external state.

This could be expanded in the future with additional traits to allow customizing the process more deeply (e.g. to avoid baking in `Entity` serialization), though we must take care not to complicate simple applications.

As always, feedback very welcome!