### PR TITLE
Columnar component access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - The `serde` feature, enabling serialization of `Entity` handles, and a `serialization` module to
   simplify (de)serializing worlds
 - `World::len()` exposing the number of live entities
+- `ColumnBatch` for efficiently spawning collections of entities with the same components when those
+  components' types are not statically known
 
 # 0.3.1 (November 9, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - The `serde` feature, enabling serialization of `Entity` handles, and a `serialization` module to
   simplify (de)serializing worlds
 - `World::len()` exposing the number of live entities
+- Access to component data inside `Archetypes` to allow custom column-major operations
 - `ColumnBatch` for efficiently spawning collections of entities with the same components when those
   components' types are not statically known
 

--- a/macros/src/query.rs
+++ b/macros/src/query.rs
@@ -63,7 +63,7 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
             .unzip(),
         syn::Fields::Unit => (Vec::new(), Vec::new()),
     };
-    let fetches = fetches.into_iter().collect::<Result<Vec<_>>>()?;
+    let fetches = fetches.into_iter().collect::<Vec<_>>();
     let fetch_ident = Ident::new(&format!("__HecsInternal{}Fetch", ident), Span::call_site());
     let fetch = match data.fields {
         syn::Fields::Named(_) => quote! {
@@ -140,7 +140,7 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
     })
 }
 
-fn query_fetch_ty(lifetime: &Lifetime, ty: &Type) -> Result<TokenStream2> {
+fn query_fetch_ty(lifetime: &Lifetime, ty: &Type) -> TokenStream2 {
     struct Visitor<'a> {
         replace: &'a Lifetime,
     };
@@ -154,7 +154,7 @@ fn query_fetch_ty(lifetime: &Lifetime, ty: &Type) -> Result<TokenStream2> {
 
     let mut ty = ty.clone();
     syn::visit_mut::visit_type_mut(&mut Visitor { replace: lifetime }, &mut ty);
-    Ok(quote! {
+    quote! {
         <#ty as ::hecs::Query>::Fetch
-    })
+    }
 }

--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -203,8 +203,8 @@ impl Archetype {
     fn grow(&mut self, increment: u32) {
         unsafe {
             let old_count = self.len as usize;
-            let count = old_count + increment as usize;
-            let mut new_entities = vec![!0; count].into_boxed_slice();
+            let new_cap = self.entities.len() + increment as usize;
+            let mut new_entities = vec![!0; new_cap].into_boxed_slice();
             new_entities[0..old_count].copy_from_slice(&self.entities[0..old_count]);
             self.entities = new_entities;
 
@@ -213,7 +213,7 @@ impl Archetype {
             for ty in &self.types {
                 self.data_size = align(self.data_size, ty.layout.align());
                 state.insert(ty.id, TypeState::new(self.data_size));
-                self.data_size += ty.layout.size() * count;
+                self.data_size += ty.layout.size() * new_cap;
             }
             let new_data = if self.data_size == 0 {
                 NonNull::dangling()

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,0 +1,144 @@
+use crate::alloc::collections::BinaryHeap;
+use core::{any::TypeId, fmt, mem::MaybeUninit, slice};
+
+use crate::{
+    archetype::{TypeIdMap, TypeInfo},
+    Archetype, Component,
+};
+
+/// A collection of component types
+#[derive(Debug, Clone, Default)]
+pub struct ColumnBatchType {
+    types: BinaryHeap<TypeInfo>,
+}
+
+impl ColumnBatchType {
+    /// Create an empty type
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Update to include `T` components
+    pub fn add<T: Component>(&mut self) -> &mut Self {
+        self.types.push(TypeInfo::of::<T>());
+        self
+    }
+
+    /// Construct a [`ColumnBatchBuilder`] for *exactly* `size` entities with these components
+    pub fn into_batch(self, size: u32) -> ColumnBatchBuilder {
+        let mut types = self.types.into_sorted_vec();
+        types.dedup();
+        let fill = TypeIdMap::with_capacity_and_hasher(types.len(), Default::default());
+        let mut arch = Archetype::new(types);
+        arch.reserve(size);
+        ColumnBatchBuilder {
+            fill,
+            archetype: Some(arch),
+        }
+    }
+}
+
+/// An incomplete collection of component data for entities with the same component types
+pub struct ColumnBatchBuilder {
+    /// Number of components written so far for each component type
+    fill: TypeIdMap<u32>,
+    pub(crate) archetype: Option<Archetype>,
+}
+
+unsafe impl Send for ColumnBatchBuilder {}
+unsafe impl Sync for ColumnBatchBuilder {}
+
+impl ColumnBatchBuilder {
+    /// Create a batch for *exactly* `size` entities with certain component types
+    pub fn new(ty: ColumnBatchType, size: u32) -> Self {
+        ty.into_batch(size)
+    }
+
+    /// Get a handle for inserting `T` components if `T` was in the [`ColumnBatchType`]
+    pub fn writer<T: Component>(&mut self) -> Option<BatchWriter<'_, T>> {
+        let archetype = self.archetype.as_mut().unwrap();
+        let base = archetype.get_base::<T>()?;
+        Some(BatchWriter {
+            fill: self.fill.entry(TypeId::of::<T>()).or_insert(0),
+            storage: unsafe {
+                slice::from_raw_parts_mut(base.as_ptr().cast(), archetype.capacity() as usize)
+                    .iter_mut()
+            },
+        })
+    }
+
+    /// Finish the batch, failing if any components are missing
+    pub fn build(mut self) -> Result<ColumnBatch, BatchIncomplete> {
+        let mut archetype = self.archetype.take().unwrap();
+        if archetype
+            .types()
+            .iter()
+            .any(|ty| self.fill.get(&ty.id()).copied().unwrap_or(0) != archetype.capacity())
+        {
+            return Err(BatchIncomplete { _opaque: () });
+        }
+        unsafe {
+            archetype.set_len(archetype.capacity());
+        }
+        Ok(ColumnBatch(archetype))
+    }
+}
+
+impl Drop for ColumnBatchBuilder {
+    fn drop(&mut self) {
+        if let Some(archetype) = self.archetype.take() {
+            for ty in archetype.types() {
+                let fill = self.fill.get(&ty.id()).copied().unwrap_or(0);
+                unsafe {
+                    let base = archetype.get_dynamic(ty.id(), 0, 0).unwrap();
+                    for i in 0..fill {
+                        base.as_ptr().add(i as usize).drop_in_place()
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// A collection of component data for entities with the same component types
+pub struct ColumnBatch(pub(crate) Archetype);
+
+/// Handle for appending components
+pub struct BatchWriter<'a, T> {
+    fill: &'a mut u32,
+    storage: core::slice::IterMut<'a, MaybeUninit<T>>,
+}
+
+impl<T> BatchWriter<'_, T> {
+    /// Add a component if there's space remaining
+    pub fn push(&mut self, x: T) -> Result<(), T> {
+        match self.storage.next() {
+            None => Err(x),
+            Some(slot) => {
+                *slot = MaybeUninit::new(x);
+                *self.fill += 1;
+                Ok(())
+            }
+        }
+    }
+
+    /// How many components have been added so far
+    pub fn fill(&self) -> u32 {
+        *self.fill
+    }
+}
+
+/// Error indicating that a `ColumnBatchBuilder` was missing components
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct BatchIncomplete {
+    _opaque: (),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for BatchIncomplete {}
+
+impl fmt::Display for BatchIncomplete {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("batch incomplete")
+    }
+}

--- a/src/borrow.rs
+++ b/src/borrow.rs
@@ -68,7 +68,7 @@ impl<'a, T: Component> Ref<'a, T> {
     ) -> Result<Self, MissingComponent> {
         let target = NonNull::new_unchecked(
             archetype
-                .get::<T>()
+                .get_base::<T>()
                 .ok_or_else(MissingComponent::new::<T>)?
                 .as_ptr()
                 .add(index as usize),
@@ -107,7 +107,7 @@ impl<'a, T: Component> RefMut<'a, T> {
     ) -> Result<Self, MissingComponent> {
         let target = NonNull::new_unchecked(
             archetype
-                .get::<T>()
+                .get_base::<T>()
                 .ok_or_else(MissingComponent::new::<T>)?
                 .as_ptr()
                 .add(index as usize),

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -1,6 +1,8 @@
 use alloc::vec::Vec;
 use core::cmp;
 use core::convert::TryFrom;
+use core::iter::ExactSizeIterator;
+use core::ops::Range;
 use core::sync::atomic::{AtomicI64, Ordering};
 use core::{fmt, mem};
 #[cfg(feature = "std")]
@@ -111,7 +113,7 @@ impl<'a> Iterator for ReserveEntitiesIterator<'a> {
     }
 }
 
-impl<'a> core::iter::ExactSizeIterator for ReserveEntitiesIterator<'a> {}
+impl<'a> ExactSizeIterator for ReserveEntitiesIterator<'a> {}
 
 #[derive(Default)]
 pub(crate) struct Entities {
@@ -252,6 +254,49 @@ impl Entities {
             self.meta.push(EntityMeta::EMPTY);
             Entity { generation: 0, id }
         }
+    }
+
+    /// Allocate and set locations for many entity IDs laid out contiguously in an archetype
+    ///
+    /// `self.finish_alloc_many()` must be called after!
+    pub fn alloc_many(&mut self, n: u32, archetype: u32, mut first_index: u32) -> AllocManyState {
+        self.verify_flushed();
+
+        let fresh = (n as usize).saturating_sub(self.pending.len()) as u32;
+        assert!(
+            (self.meta.len() + fresh as usize) < u32::MAX as usize,
+            "too many entities"
+        );
+        let pending_end = self.pending.len().saturating_sub(n as usize);
+        for &id in &self.pending[pending_end..] {
+            self.meta[id as usize].location = Location {
+                archetype,
+                index: first_index,
+            };
+            first_index += 1;
+        }
+
+        let fresh_start = self.meta.len() as u32;
+        self.meta.extend(
+            (first_index..(first_index + fresh)).map(|index| EntityMeta {
+                generation: 0,
+                location: Location { archetype, index },
+            }),
+        );
+
+        self.len += n;
+
+        AllocManyState {
+            fresh: fresh_start..(fresh_start + fresh),
+            pending_end,
+        }
+    }
+
+    /// Remove entities used by `alloc_many` from the freelist
+    ///
+    /// This is an awkward separate function to avoid borrowck issues in `SpawnColumnBatchIter`.
+    pub fn finish_alloc_many(&mut self, pending_end: usize) {
+        self.pending.truncate(pending_end);
     }
 
     /// Allocate a specific entity ID, overwriting its generation
@@ -465,6 +510,28 @@ impl fmt::Display for NoSuchEntity {
 
 #[cfg(feature = "std")]
 impl Error for NoSuchEntity {}
+
+#[derive(Clone)]
+pub(crate) struct AllocManyState {
+    pub pending_end: usize,
+    fresh: Range<u32>,
+}
+
+impl AllocManyState {
+    pub fn next(&mut self, entities: &Entities) -> Option<u32> {
+        if self.pending_end < entities.pending.len() {
+            let id = entities.pending[self.pending_end];
+            self.pending_end += 1;
+            Some(id)
+        } else {
+            self.fresh.next()
+        }
+    }
+
+    pub fn len(&self, entities: &Entities) -> usize {
+        self.fresh.len() + (entities.pending.len() - self.pending_end)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ macro_rules! smaller_tuples_too {
 }
 
 mod archetype;
+mod batch;
 mod borrow;
 mod bundle;
 mod entities;
@@ -67,6 +68,7 @@ pub mod serialize;
 mod world;
 
 pub use archetype::Archetype;
+pub use batch::{ColumnBatch, ColumnBatchBuilder, ColumnBatchType};
 pub use borrow::{EntityRef, Ref, RefMut};
 pub use bundle::{Bundle, DynamicBundle, MissingComponent};
 pub use entities::{Entity, NoSuchEntity};
@@ -75,7 +77,10 @@ pub use query::{
     Access, BatchedIter, Query, QueryBorrow, QueryItem, QueryIter, QueryMut, With, Without,
 };
 pub use query_one::QueryOne;
-pub use world::{ArchetypesGeneration, Component, ComponentError, Iter, SpawnBatchIter, World};
+pub use world::{
+    ArchetypesGeneration, Component, ComponentError, Iter, SpawnBatchIter, SpawnColumnBatchIter,
+    World,
+};
 
 // Unstable implementation details needed by the macros
 #[doc(hidden)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -88,7 +88,7 @@ unsafe impl<'a, T: Component> Fetch<'a> for FetchRead<T> {
         archetype.borrow::<T>();
     }
     fn new(archetype: &'a Archetype) -> Option<Self> {
-        archetype.get::<T>().map(Self)
+        archetype.get_base::<T>().map(Self)
     }
     fn release(archetype: &Archetype) {
         archetype.release::<T>();
@@ -125,7 +125,7 @@ unsafe impl<'a, T: Component> Fetch<'a> for FetchWrite<T> {
         archetype.borrow_mut::<T>();
     }
     fn new(archetype: &'a Archetype) -> Option<Self> {
-        archetype.get::<T>().map(Self)
+        archetype.get_base::<T>().map(Self)
     }
     fn release(archetype: &Archetype) {
         archetype.release_mut::<T>();

--- a/src/world.rs
+++ b/src/world.rs
@@ -695,7 +695,7 @@ impl World {
             return Err(MissingComponent::new::<T>().into());
         }
         Ok(&*self.archetypes[loc.archetype as usize]
-            .get::<T>()
+            .get_base::<T>()
             .ok_or_else(MissingComponent::new::<T>)?
             .as_ptr()
             .add(loc.index as usize))
@@ -718,7 +718,7 @@ impl World {
             return Err(MissingComponent::new::<T>().into());
         }
         Ok(&mut *self.archetypes[loc.archetype as usize]
-            .get::<T>()
+            .get_base::<T>()
             .ok_or_else(MissingComponent::new::<T>)?
             .as_ptr()
             .add(loc.index as usize))
@@ -735,8 +735,8 @@ impl World {
 
     /// Inspect the archetypes that entities are organized into
     ///
-    /// Useful for dynamically scheduling concurrent queries by checking borrows in advance. Does
-    /// not provide access to entities.
+    /// Useful for dynamically scheduling concurrent queries by checking borrows in advance, and for
+    /// efficient serialization.
     pub fn archetypes(&self) -> impl ExactSizeIterator<Item = &'_ Archetype> + '_ {
         self.archetypes.iter()
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -461,3 +461,20 @@ fn spawn_column_batch() {
         assert_eq!(*world.get::<i32>(entities[1]).unwrap(), 45);
     }
 }
+
+#[test]
+fn columnar_access() {
+    let mut world = World::new();
+    let e = world.spawn(("abc", 123));
+    let f = world.spawn(("def", 456, true));
+    let g = world.spawn(("ghi", 789, false));
+    let mut archetypes = world.archetypes();
+    let _empty = archetypes.next().unwrap();
+    let a = archetypes.next().unwrap();
+    assert_eq!(a.ids(), &[e.id()]);
+    assert_eq!(*a.get::<i32>().unwrap(), [123]);
+    assert!(a.get::<bool>().is_none());
+    let b = archetypes.next().unwrap();
+    assert_eq!(b.ids(), &[f.id(), g.id()]);
+    assert_eq!(*b.get::<i32>().unwrap(), [456, 789]);
+}


### PR DESCRIPTION
Fixes #60. Allows for cache-efficient column-oriented custom operations such as (de)serialization.