### PR TITLE
Adds API surface to EntityBuilder to check and modify the current components of the builder.

### DIFF
--- a/src/entity_builder.rs
+++ b/src/entity_builder.rs
@@ -105,6 +105,36 @@ impl EntityBuilder {
         self
     }
 
+    /// Checks to see if the component of type `T` exists
+    pub fn has<T: Component>(&self) -> bool {
+        self.indices.contains_key(&TypeId::of::<T>())
+    }
+
+    /// Borrow the component of type `T`, if it exists
+    pub fn get<T: Component>(&self) -> Option<&T> {
+        let index = self.indices.get(&TypeId::of::<T>())?;
+        let (_, offset) = self.info[*index];
+        unsafe {
+            let storage = self.storage.as_ptr().add(offset).cast::<T>();
+            Some(&*storage)
+        }
+    }
+
+    /// Uniquely borrow the component of type `T`, if it exists
+    pub fn get_mut<T: Component>(&mut self) -> Option<&mut T> {
+        let index = self.indices.get(&TypeId::of::<T>())?;
+        let (_, offset) = self.info[*index];
+        unsafe {
+            let storage = self.storage.as_ptr().add(offset).cast::<T>();
+            Some(&mut *storage)
+        }
+    }
+
+    /// Enumerate the types of the entity builder's components
+    pub fn component_types(&self) -> impl Iterator<Item = TypeId> + '_ {
+        self.info.iter().map(|(info, _)| info.id())
+    }
+
     unsafe fn grow(
         min_size: usize,
         cursor: usize,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -145,6 +145,31 @@ fn build_entity() {
 }
 
 #[test]
+fn access_builder_components() {
+    let mut world = World::new();
+    let mut entity = EntityBuilder::new();
+
+    entity.add("abc");
+    entity.add(123);
+
+    assert!(entity.has::<&str>());
+    assert!(entity.has::<i32>());
+    assert!(!entity.has::<usize>());
+
+    assert_eq!(*entity.get::<&str>().unwrap(), "abc");
+    assert_eq!(*entity.get::<i32>().unwrap(), 123);
+    assert_eq!(entity.get::<usize>(), None);
+
+    *entity.get_mut::<i32>().unwrap() = 456;
+    assert_eq!(*entity.get::<i32>().unwrap(), 456);
+
+    let g = world.spawn(entity.build());
+
+    assert_eq!(*world.get::<&str>(g).unwrap(), "abc");
+    assert_eq!(*world.get::<i32>(g).unwrap(), 456);
+}
+
+#[test]
 fn build_entity_bundle() {
     let mut world = World::new();
     let mut entity = EntityBuilder::new();


### PR DESCRIPTION
This is a pretty basic PR.  I contemplate adding `remove` functionality, but it was a lot more involved than this, and while I can think of use-cases I didn't find it very pressing to implement.  Let me know if you want me to update the PR with that functionality though.