### PR TITLE
Implements out of band cloning for World

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["std"]
 std = []
+clone = []
 # Enables derive(Bundle)
 macros = ["hecs-macros", "lazy_static"]
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -8,7 +8,9 @@
 use bencher::{benchmark_group, benchmark_main, Bencher};
 use hecs::*;
 
+#[derive(Clone)]
 struct Position(f32);
+#[derive(Clone)]
 struct Velocity(f32);
 
 fn spawn_tuple(b: &mut Bencher) {
@@ -77,6 +79,22 @@ fn iterate_mut_100k(b: &mut Bencher) {
     })
 }
 
+#[cfg(feature = "clone")]
+fn clone_100k(b: &mut Bencher) {
+    let mut world = World::new_with(
+        CloneRegistry::default()
+            .register::<Position>()
+            .register::<Velocity>(),
+    );
+    for i in 0..100_000 {
+        world.spawn((Position(-(i as f32)), Velocity(i as f32)));
+    }
+
+    b.iter(|| {
+        let _ = world.clone();
+    });
+}
+
 fn build(b: &mut Bencher) {
     let mut world = World::new();
     let mut builder = EntityBuilder::new();
@@ -93,6 +111,7 @@ benchmark_group!(
     spawn_batch,
     iterate_100k,
     iterate_mut_100k,
+    clone_100k,
     build
 );
 benchmark_main!(benches);

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -431,6 +431,18 @@ impl Entities {
     }
 }
 
+#[cfg(feature = "clone")]
+impl Clone for Entities {
+    fn clone(&self) -> Self {
+        Self {
+            meta: self.meta.clone(),
+            pending: self.pending.clone(),
+            free_cursor: AtomicI64::new(self.free_cursor.load(Ordering::SeqCst)),
+            len: self.len,
+        }
+    }
+}
+
 #[derive(Copy, Clone)]
 pub(crate) struct EntityMeta {
     pub generation: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,8 @@ pub use lazy_static;
 #[doc(hidden)]
 pub use query::Fetch;
 
+#[cfg(feature = "clone")]
+pub use archetype::clone::CloneRegistry;
 #[cfg(feature = "macros")]
 pub use hecs_macros::{Bundle, Query};
 


### PR DESCRIPTION
User needs to keep a registry of functions to use to clone the world, and the cloning can and will
fail if theres an outstanding unique borrow, or the registry is missing
a component type.

Outstanding questions:

How should I handle the two error cases?  I wanted to return a nice error, but if you turn off debug_asserts, then the current method doesn't work.  I can switch both to panicking, I'm guessing I should print out a more accurate panic when the info is available though. [so this can't be merged as is]

If keeping the Result is intended, is there anything I should do on the borrow/release section?  If clone_with fails to borrow here, it won't release the borrows its acquired so far.

Also, someone needs to take a looksie to make sure I'm not breaking invariants with my unsafe code.