### PR TITLE
Downgrade hashbrown to 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ macros = ["hecs-macros", "lazy_static"]
 
 [dependencies]
 hecs-macros = { path = "macros", version = "0.4.0", optional = true }
-hashbrown = { version = "0.10.0", default-features = false, features = ["ahash", "inline-more"] }
+hashbrown = { version = "0.9.1", default-features = false, features = ["ahash", "inline-more"] }
 lazy_static = { version = "1.4.0", optional = true, features = ["spin_no_std"] }
 serde = { version = "1.0.117", default-features = false, optional = true }
 


### PR DESCRIPTION
`hashbrown` 0.10.0 has been yanked.