### PR TITLE
Consistently apply TypeIdMap optimization where possible

### DIFF
--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -36,7 +36,7 @@ pub struct Archetype {
     data_size: usize,
     /// Maps static bundle types to the archetype that an entity from this archetype is moved to
     /// after removing the components from that bundle.
-    pub(crate) remove_edges: HashMap<TypeId, u32>,
+    pub(crate) remove_edges: TypeIdMap<u32>,
 }
 
 impl Archetype {
@@ -68,7 +68,7 @@ impl Archetype {
             len: 0,
             data: UnsafeCell::new(NonNull::new(max_align as *mut u8).unwrap()),
             data_size: 0,
-            remove_edges: HashMap::new(),
+            remove_edges: HashMap::default(),
         }
     }
 
@@ -250,7 +250,8 @@ impl Archetype {
             self.entities = new_entities;
 
             let old_data_size = mem::replace(&mut self.data_size, 0);
-            let mut state = HashMap::with_capacity_and_hasher(self.types.len(), Default::default());
+            let mut state =
+                TypeIdMap::with_capacity_and_hasher(self.types.len(), Default::default());
             for ty in &self.types {
                 self.data_size = align(self.data_size, ty.layout.align());
                 state.insert(ty.id, TypeState::new(self.data_size));

--- a/src/world.rs
+++ b/src/world.rs
@@ -17,7 +17,7 @@ use std::error::Error;
 use hashbrown::{HashMap, HashSet};
 
 use crate::alloc::boxed::Box;
-use crate::archetype::{Archetype, TypeInfo};
+use crate::archetype::{Archetype, TypeIdMap, TypeInfo};
 use crate::entities::{Entities, Location, ReserveEntitiesIterator};
 use crate::{
     Bundle, ColumnBatch, DynamicBundle, Entity, EntityRef, Fetch, MissingComponent, NoSuchEntity,
@@ -46,7 +46,7 @@ pub struct World {
     entities: Entities,
     archetypes: ArchetypeSet,
     /// Maps statically-typed bundle types to archetypes
-    bundle_to_archetype: HashMap<TypeId, u32>,
+    bundle_to_archetype: TypeIdMap<u32>,
 }
 
 impl World {
@@ -55,7 +55,7 @@ impl World {
         Self {
             entities: Entities::default(),
             archetypes: ArchetypeSet::new(),
-            bundle_to_archetype: HashMap::new(),
+            bundle_to_archetype: HashMap::default(),
         }
     }
 
@@ -1058,7 +1058,7 @@ struct ArchetypeSet {
     /// Maps static bundle types to the archetype that an entity from this archetype is moved to
     /// after inserting the components from that bundle. Stored separately from archetypes to avoid
     /// borrowck difficulties in `World::insert`.
-    insert_edges: Vec<HashMap<TypeId, InsertTarget>>,
+    insert_edges: Vec<TypeIdMap<InsertTarget>>,
 }
 
 impl ArchetypeSet {
@@ -1068,7 +1068,7 @@ impl ArchetypeSet {
             index: Some((Box::default(), 0)).into_iter().collect(),
             archetypes: vec![Archetype::new(Vec::new())],
             generation: 0,
-            insert_edges: vec![HashMap::new()],
+            insert_edges: vec![HashMap::default()],
         }
     }
 
@@ -1125,7 +1125,7 @@ impl ArchetypeSet {
     }
 
     fn post_insert(&mut self) {
-        self.insert_edges.push(HashMap::new());
+        self.insert_edges.push(HashMap::default());
         self.generation += 1;
     }
 


### PR DESCRIPTION
While looking into #154, I noticed that `TypeIdMap` was used in some but not all possible places where hash tables keyed by type ID were used.