### PR TITLE
Introduce an out-of-line query cache storing matching archetypes

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -107,78 +107,57 @@ fn iterate_mut_100k(b: &mut Bencher) {
     })
 }
 
-fn spawn_100k_by_50(world: &mut World) {
-    for i in 0..2_000 {
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 0]));
-        world.spawn((Position(-(i as f32)), [(); 0]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 1]));
-        world.spawn((Position(-(i as f32)), [(); 1]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 2]));
-        world.spawn((Position(-(i as f32)), [(); 2]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 3]));
-        world.spawn((Position(-(i as f32)), [(); 3]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 4]));
-        world.spawn((Position(-(i as f32)), [(); 4]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 5]));
-        world.spawn((Position(-(i as f32)), [(); 5]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 6]));
-        world.spawn((Position(-(i as f32)), [(); 6]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 7]));
-        world.spawn((Position(-(i as f32)), [(); 7]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 8]));
-        world.spawn((Position(-(i as f32)), [(); 8]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 9]));
-        world.spawn((Position(-(i as f32)), [(); 9]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 10]));
-        world.spawn((Position(-(i as f32)), [(); 10]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 11]));
-        world.spawn((Position(-(i as f32)), [(); 11]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 12]));
-        world.spawn((Position(-(i as f32)), [(); 12]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 13]));
-        world.spawn((Position(-(i as f32)), [(); 13]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 14]));
-        world.spawn((Position(-(i as f32)), [(); 14]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 15]));
-        world.spawn((Position(-(i as f32)), [(); 15]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 16]));
-        world.spawn((Position(-(i as f32)), [(); 16]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 17]));
-        world.spawn((Position(-(i as f32)), [(); 17]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 18]));
-        world.spawn((Position(-(i as f32)), [(); 18]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 19]));
-        world.spawn((Position(-(i as f32)), [(); 19]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 20]));
-        world.spawn((Position(-(i as f32)), [(); 20]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 21]));
-        world.spawn((Position(-(i as f32)), [(); 21]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 22]));
-        world.spawn((Position(-(i as f32)), [(); 22]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 23]));
-        world.spawn((Position(-(i as f32)), [(); 23]));
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 24]));
-        world.spawn((Position(-(i as f32)), [(); 24]));
+fn spawn_100_by_50(world: &mut World) {
+    fn spawn_two<const N: usize>(world: &mut World, i: i32) {
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); N]));
+        world.spawn((Position(-(i as f32)), [(); N]));
+    }
+
+    for i in 0..2 {
+        spawn_two::<0>(world, i);
+        spawn_two::<1>(world, i);
+        spawn_two::<2>(world, i);
+        spawn_two::<3>(world, i);
+        spawn_two::<4>(world, i);
+        spawn_two::<5>(world, i);
+        spawn_two::<6>(world, i);
+        spawn_two::<7>(world, i);
+        spawn_two::<8>(world, i);
+        spawn_two::<9>(world, i);
+        spawn_two::<10>(world, i);
+        spawn_two::<11>(world, i);
+        spawn_two::<12>(world, i);
+        spawn_two::<13>(world, i);
+        spawn_two::<14>(world, i);
+        spawn_two::<15>(world, i);
+        spawn_two::<16>(world, i);
+        spawn_two::<17>(world, i);
+        spawn_two::<18>(world, i);
+        spawn_two::<19>(world, i);
+        spawn_two::<20>(world, i);
+        spawn_two::<21>(world, i);
+        spawn_two::<22>(world, i);
+        spawn_two::<23>(world, i);
+        spawn_two::<24>(world, i);
     }
 }
 
-fn iterate_uncached_100k_by_50(b: &mut Bencher) {
+fn iterate_uncached_100_by_50(b: &mut Bencher) {
     let mut world = World::new();
-    spawn_100k_by_50(&mut world);
+    spawn_100_by_50(&mut world);
     b.iter(|| {
-        for (_, (pos, vel)) in &mut world.query::<(&mut Position, &Velocity)>() {
+        for (_, (pos, vel)) in world.query_mut::<(&mut Position, &Velocity)>() {
             pos.0 += vel.0;
         }
     })
 }
 
-fn iterate_cached_100k_by_50(b: &mut Bencher) {
+fn iterate_cached_100_by_50(b: &mut Bencher) {
     let mut world = World::new();
-    let mut cache = world.query_cache();
-    spawn_100k_by_50(&mut world);
+    spawn_100_by_50(&mut world);
+    let mut query = world.query::<(&mut Position, &Velocity)>().prepare(&world);
     b.iter(|| {
-        let mut query = world.query::<(&mut Position, &Velocity)>();
-        for (_, (pos, vel)) in query.iter_cached(&mut cache) {
+        for (_, (pos, vel)) in query.iter(&mut world) {
             pos.0 += vel.0;
         }
     })
@@ -202,8 +181,8 @@ benchmark_group!(
     insert,
     iterate_100k,
     iterate_mut_100k,
-    iterate_uncached_100k_by_50,
-    iterate_cached_100k_by_50,
+    iterate_uncached_100_by_50,
+    iterate_cached_100_by_50,
     build
 );
 benchmark_main!(benches);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -156,8 +156,31 @@ fn iterate_cached_100_by_50(b: &mut Bencher) {
     let mut world = World::new();
     spawn_100_by_50(&mut world);
     let mut query = world.query::<(&mut Position, &Velocity)>().prepare(&world);
+    let _ = query.borrow(&world).iter();
     b.iter(|| {
-        for (_, (pos, vel)) in query.borrow(&mut world).iter() {
+        for (_, (pos, vel)) in query.borrow(&world).iter() {
+            pos.0 += vel.0;
+        }
+    })
+}
+
+fn iterate_mut_uncached_100_by_50(b: &mut Bencher) {
+    let mut world = World::new();
+    spawn_100_by_50(&mut world);
+    b.iter(|| {
+        for (_, (pos, vel)) in world.query_mut::<(&mut Position, &Velocity)>() {
+            pos.0 += vel.0;
+        }
+    })
+}
+
+fn iterate_mut_cached_100_by_50(b: &mut Bencher) {
+    let mut world = World::new();
+    spawn_100_by_50(&mut world);
+    let mut query = world.query::<(&mut Position, &Velocity)>().prepare(&world);
+    let _ = query.iter_mut(&mut world);
+    b.iter(|| {
+        for (_, (pos, vel)) in query.iter_mut(&mut world) {
             pos.0 += vel.0;
         }
     })
@@ -183,6 +206,8 @@ benchmark_group!(
     iterate_mut_100k,
     iterate_uncached_100_by_50,
     iterate_cached_100_by_50,
+    iterate_mut_uncached_100_by_50,
+    iterate_mut_cached_100_by_50,
     build
 );
 benchmark_main!(benches);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -156,9 +156,9 @@ fn iterate_cached_100_by_50(b: &mut Bencher) {
     let mut world = World::new();
     spawn_100_by_50(&mut world);
     let mut query = world.query::<(&mut Position, &Velocity)>().prepare(&world);
-    let _ = query.borrow(&world).iter();
+    let _ = query.query(&world).iter();
     b.iter(|| {
-        for (_, (pos, vel)) in query.borrow(&world).iter() {
+        for (_, (pos, vel)) in query.query(&world).iter() {
             pos.0 += vel.0;
         }
     })
@@ -178,9 +178,9 @@ fn iterate_mut_cached_100_by_50(b: &mut Bencher) {
     let mut world = World::new();
     spawn_100_by_50(&mut world);
     let mut query = world.query::<(&mut Position, &Velocity)>().prepare(&world);
-    let _ = query.iter_mut(&mut world);
+    let _ = query.query_mut(&mut world);
     b.iter(|| {
-        for (_, (pos, vel)) in query.iter_mut(&mut world) {
+        for (_, (pos, vel)) in query.query_mut(&mut world) {
             pos.0 += vel.0;
         }
     })

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -155,7 +155,7 @@ fn iterate_uncached_100_by_50(b: &mut Bencher) {
 fn iterate_cached_100_by_50(b: &mut Bencher) {
     let mut world = World::new();
     spawn_100_by_50(&mut world);
-    let mut query = world.query::<(&mut Position, &Velocity)>().prepare(&world);
+    let mut query = PreparedQuery::<(&mut Position, &Velocity)>::default();
     let _ = query.query(&world).iter();
     b.iter(|| {
         for (_, (pos, vel)) in query.query(&world).iter() {
@@ -177,7 +177,7 @@ fn iterate_mut_uncached_100_by_50(b: &mut Bencher) {
 fn iterate_mut_cached_100_by_50(b: &mut Bencher) {
     let mut world = World::new();
     spawn_100_by_50(&mut world);
-    let mut query = world.query::<(&mut Position, &Velocity)>().prepare(&world);
+    let mut query = PreparedQuery::<(&mut Position, &Velocity)>::default();
     let _ = query.query_mut(&mut world);
     b.iter(|| {
         for (_, (pos, vel)) in query.query_mut(&mut world) {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -146,7 +146,7 @@ fn iterate_uncached_100_by_50(b: &mut Bencher) {
     let mut world = World::new();
     spawn_100_by_50(&mut world);
     b.iter(|| {
-        for (_, (pos, vel)) in world.query_mut::<(&mut Position, &Velocity)>() {
+        for (_, (pos, vel)) in world.query::<(&mut Position, &Velocity)>().iter() {
             pos.0 += vel.0;
         }
     })
@@ -157,7 +157,7 @@ fn iterate_cached_100_by_50(b: &mut Bencher) {
     spawn_100_by_50(&mut world);
     let mut query = world.query::<(&mut Position, &Velocity)>().prepare(&world);
     b.iter(|| {
-        for (_, (pos, vel)) in query.iter(&mut world) {
+        for (_, (pos, vel)) in query.borrow(&mut world).iter() {
             pos.0 += vel.0;
         }
     })

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -107,6 +107,83 @@ fn iterate_mut_100k(b: &mut Bencher) {
     })
 }
 
+fn spawn_100k_by_50(world: &mut World) {
+    for i in 0..2_000 {
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 0]));
+        world.spawn((Position(-(i as f32)), [(); 0]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 1]));
+        world.spawn((Position(-(i as f32)), [(); 1]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 2]));
+        world.spawn((Position(-(i as f32)), [(); 2]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 3]));
+        world.spawn((Position(-(i as f32)), [(); 3]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 4]));
+        world.spawn((Position(-(i as f32)), [(); 4]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 5]));
+        world.spawn((Position(-(i as f32)), [(); 5]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 6]));
+        world.spawn((Position(-(i as f32)), [(); 6]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 7]));
+        world.spawn((Position(-(i as f32)), [(); 7]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 8]));
+        world.spawn((Position(-(i as f32)), [(); 8]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 9]));
+        world.spawn((Position(-(i as f32)), [(); 9]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 10]));
+        world.spawn((Position(-(i as f32)), [(); 10]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 11]));
+        world.spawn((Position(-(i as f32)), [(); 11]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 12]));
+        world.spawn((Position(-(i as f32)), [(); 12]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 13]));
+        world.spawn((Position(-(i as f32)), [(); 13]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 14]));
+        world.spawn((Position(-(i as f32)), [(); 14]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 15]));
+        world.spawn((Position(-(i as f32)), [(); 15]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 16]));
+        world.spawn((Position(-(i as f32)), [(); 16]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 17]));
+        world.spawn((Position(-(i as f32)), [(); 17]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 18]));
+        world.spawn((Position(-(i as f32)), [(); 18]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 19]));
+        world.spawn((Position(-(i as f32)), [(); 19]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 20]));
+        world.spawn((Position(-(i as f32)), [(); 20]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 21]));
+        world.spawn((Position(-(i as f32)), [(); 21]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 22]));
+        world.spawn((Position(-(i as f32)), [(); 22]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 23]));
+        world.spawn((Position(-(i as f32)), [(); 23]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); 24]));
+        world.spawn((Position(-(i as f32)), [(); 24]));
+    }
+}
+
+fn iterate_uncached_100k_by_50(b: &mut Bencher) {
+    let mut world = World::new();
+    spawn_100k_by_50(&mut world);
+    b.iter(|| {
+        for (_, (pos, vel)) in &mut world.query::<(&mut Position, &Velocity)>() {
+            pos.0 += vel.0;
+        }
+    })
+}
+
+fn iterate_cached_100k_by_50(b: &mut Bencher) {
+    let mut world = World::new();
+    let mut cache = world.query_cache();
+    spawn_100k_by_50(&mut world);
+    b.iter(|| {
+        let mut query = world.query::<(&mut Position, &Velocity)>();
+        for (_, (pos, vel)) in query.iter_cached(&mut cache) {
+            pos.0 += vel.0;
+        }
+    })
+}
+
 fn build(b: &mut Bencher) {
     let mut world = World::new();
     let mut builder = EntityBuilder::new();
@@ -125,6 +202,8 @@ benchmark_group!(
     insert,
     iterate_100k,
     iterate_mut_100k,
+    iterate_uncached_100k_by_50,
+    iterate_cached_100k_by_50,
     build
 );
 benchmark_main!(benches);

--- a/examples/ffa_simulation.rs
+++ b/examples/ffa_simulation.rs
@@ -62,7 +62,7 @@ fn batch_spawn_entities(world: &mut World, n: usize) {
 fn system_integrate_motion(world: &mut World, query: &mut PreparedQuery<(&mut Position, &Speed)>) {
     let mut rng = thread_rng();
 
-    for (id, (pos, s)) in query.iter_mut(world) {
+    for (id, (pos, s)) in query.query_mut(world) {
         let change = (rng.gen_range(-s.0..s.0), rng.gen_range(-s.0..s.0));
         pos.x += change.0;
         pos.y += change.1;
@@ -148,7 +148,7 @@ fn main() {
 
     batch_spawn_entities(&mut world, 5);
 
-    let mut motion_query = world.query::<(&mut Position, &Speed)>().prepare(&world);
+    let mut motion_query = PreparedQuery::<(&mut Position, &Speed)>::default();
 
     loop {
         println!("\n'Enter' to continue simulation, '?' for enity list, 'q' to quit");

--- a/examples/ffa_simulation.rs
+++ b/examples/ffa_simulation.rs
@@ -59,10 +59,11 @@ fn batch_spawn_entities(world: &mut World, n: usize) {
     // is faster.
 }
 
-fn system_integrate_motion(world: &mut World) {
+fn system_integrate_motion(world: &mut World, cache: &mut QueryCache) {
     let mut rng = thread_rng();
 
-    for (id, (pos, s)) in &mut world.query::<(&mut Position, &Speed)>() {
+    let mut query = world.query::<(&mut Position, &Speed)>();
+    for (id, (pos, s)) in query.iter_cached(cache) {
         let change = (rng.gen_range(-s.0..s.0), rng.gen_range(-s.0..s.0));
         pos.x += change.0;
         pos.y += change.1;
@@ -145,6 +146,7 @@ fn print_world_state(world: &mut World) {
 
 fn main() {
     let mut world = World::new();
+    let mut cache = world.query_cache();
 
     batch_spawn_entities(&mut world, 5);
 
@@ -158,7 +160,7 @@ fn main() {
         match input.trim() {
             "" => {
                 // Run all simulation systems:
-                system_integrate_motion(&mut world);
+                system_integrate_motion(&mut world, &mut cache);
                 system_fire_at_closest(&mut world);
                 system_remove_dead(&mut world);
             }

--- a/examples/ffa_simulation.rs
+++ b/examples/ffa_simulation.rs
@@ -62,7 +62,7 @@ fn batch_spawn_entities(world: &mut World, n: usize) {
 fn system_integrate_motion(world: &mut World, query: &mut PreparedQuery<(&mut Position, &Speed)>) {
     let mut rng = thread_rng();
 
-    for (id, (pos, s)) in query.iter(world) {
+    for (id, (pos, s)) in query.iter_mut(world) {
         let change = (rng.gen_range(-s.0..s.0), rng.gen_range(-s.0..s.0));
         pos.x += change.0;
         pos.y += change.1;

--- a/macros/src/query.rs
+++ b/macros/src/query.rs
@@ -134,8 +134,8 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
             }
 
             #[allow(unused_variables)]
-            fn borrow(archetype: &::hecs::Archetype) {
-                #(#fetches::borrow(archetype);)*
+            fn borrow(archetype: &::hecs::Archetype, state: Self::State) {
+                #(#fetches::borrow(archetype, state.#fields);)*
             }
 
             #[allow(unused_variables)]
@@ -147,7 +147,8 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
                 })
             }
 
-            unsafe fn execute(archetype: &'a ::hecs::Archetype, state: Self::State) -> Self {
+            #[allow(unused_variables)]
+            fn execute(archetype: &'a ::hecs::Archetype, state: Self::State) -> Self {
                 Self {
                     #(
                         #fields: #fetches::execute(archetype, state.#fields),
@@ -156,8 +157,8 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
             }
 
             #[allow(unused_variables)]
-            fn release(archetype: &::hecs::Archetype) {
-                #(#fetches::release(archetype);)*
+            fn release(archetype: &::hecs::Archetype, state: Self::State) {
+                #(#fetches::release(archetype, state.#fields);)*
             }
 
             #[allow(unused_variables, unused_mut)]

--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -97,10 +97,12 @@ impl Archetype {
         self.state.contains_key(&id)
     }
 
+    /// Find the state index associated with `T`, if present
     pub(crate) fn get_state<T: Component>(&self) -> Option<usize> {
         self.state.search(&TypeId::of::<T>())
     }
 
+    /// Get the address of the first `T` component using an index from `get_state::<T>`
     pub(crate) fn get_base<T: Component>(&self, state: usize) -> NonNull<T> {
         let (id, state) = self.state.get_from_index(state);
         assert_eq!(id, &TypeId::of::<T>());

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -57,7 +57,8 @@ impl ColumnBatchBuilder {
     /// Get a handle for inserting `T` components if `T` was in the [`ColumnBatchType`]
     pub fn writer<T: Component>(&mut self) -> Option<BatchWriter<'_, T>> {
         let archetype = self.archetype.as_mut().unwrap();
-        let base = archetype.get_base::<T>()?;
+        let state = archetype.get_state::<T>()?;
+        let base = archetype.get_base::<T>(state);
         Some(BatchWriter {
             fill: self.fill.entry(TypeId::of::<T>()).or_insert(0),
             storage: unsafe {

--- a/src/entity_ref.rs
+++ b/src/entity_ref.rs
@@ -94,6 +94,7 @@ unsafe impl<'a> Sync for EntityRef<'a> {}
 #[derive(Clone)]
 pub struct Ref<'a, T: Component> {
     archetype: &'a Archetype,
+    /// State index for `T` in `archetype`
     state: usize,
     target: NonNull<T>,
 }
@@ -136,6 +137,7 @@ impl<'a, T: Component> Deref for Ref<'a, T> {
 /// Unique borrow of an entity's component
 pub struct RefMut<'a, T: Component> {
     archetype: &'a Archetype,
+    /// State index for `T` in `archetype`
     state: usize,
     target: NonNull<T>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,8 @@ pub use entities::{Entity, NoSuchEntity};
 pub use entity_builder::{BuiltEntity, EntityBuilder};
 pub use entity_ref::{EntityRef, Ref, RefMut};
 pub use query::{
-    Access, BatchedIter, PreparedQuery, PreparedQueryIter, Query, QueryBorrow, QueryItem,
-    QueryIter, QueryMut, With, Without,
+    Access, BatchedIter, PreparedQuery, PreparedQueryBorrow, PreparedQueryIter, Query, QueryBorrow,
+    QueryItem, QueryIter, QueryMut, With, Without,
 };
 pub use query_one::QueryOne;
 pub use world::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,8 @@ pub use entities::{Entity, NoSuchEntity};
 pub use entity_builder::{BuiltEntity, EntityBuilder};
 pub use entity_ref::{EntityRef, Ref, RefMut};
 pub use query::{
-    Access, BatchedIter, CachedIter, Query, QueryBorrow, QueryCache, QueryItem, QueryIter,
-    QueryMut, With, Without,
+    Access, BatchedIter, PreparedQuery, PreparedQueryIter, Query, QueryBorrow, QueryItem,
+    QueryIter, QueryMut, With, Without,
 };
 pub use query_one::QueryOne;
 pub use world::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,8 @@ pub use entities::{Entity, NoSuchEntity};
 pub use entity_builder::{BuiltEntity, EntityBuilder};
 pub use entity_ref::{EntityRef, Ref, RefMut};
 pub use query::{
-    Access, BatchedIter, Query, QueryBorrow, QueryItem, QueryIter, QueryMut, With, Without,
+    Access, BatchedIter, CachedIter, Query, QueryBorrow, QueryCache, QueryItem, QueryIter,
+    QueryMut, With, Without,
 };
 pub use query_one::QueryOne;
 pub use world::{

--- a/src/world.rs
+++ b/src/world.rs
@@ -54,7 +54,7 @@ pub struct World {
 impl World {
     /// Create an empty world
     pub fn new() -> Self {
-        static ID: AtomicU64 = AtomicU64::new(0);
+        static ID: AtomicU64 = AtomicU64::new(1);
 
         Self {
             entities: Entities::default(),

--- a/src/world.rs
+++ b/src/world.rs
@@ -391,6 +391,10 @@ impl World {
         &self.entities.meta
     }
 
+    pub(crate) fn archetypes_inner(&self) -> &[Archetype] {
+        &self.archetypes.archetypes
+    }
+
     /// Prepare a query against a single entity, using dynamic borrow checking
     ///
     /// Prefer [`query_one_mut`](Self::query_one_mut) when concurrent access to the [`World`] is not
@@ -754,7 +758,7 @@ impl World {
     /// Useful for dynamically scheduling concurrent queries by checking borrows in advance, and for
     /// efficient serialization.
     pub fn archetypes(&self) -> impl ExactSizeIterator<Item = &'_ Archetype> + '_ {
-        self.archetypes.archetypes.iter()
+        self.archetypes_inner().iter()
     }
 
     /// Returns a distinct value after `archetypes` is changed

--- a/src/world.rs
+++ b/src/world.rs
@@ -21,7 +21,7 @@ use crate::archetype::{Archetype, TypeIdMap, TypeInfo};
 use crate::entities::{Entities, Location, ReserveEntitiesIterator};
 use crate::{
     Bundle, ColumnBatch, DynamicBundle, Entity, EntityRef, Fetch, MissingComponent, NoSuchEntity,
-    Query, QueryBorrow, QueryItem, QueryMut, QueryOne, Ref, RefMut,
+    Query, QueryBorrow, QueryCache, QueryItem, QueryMut, QueryOne, Ref, RefMut,
 };
 
 /// An unordered collection of entities, each having any number of distinctly typed components
@@ -364,7 +364,11 @@ impl World {
     /// assert!(entities.contains(&(b, 456, false)));
     /// ```
     pub fn query<Q: Query>(&self) -> QueryBorrow<'_, Q> {
-        QueryBorrow::new(&self.entities.meta, &self.archetypes.archetypes)
+        QueryBorrow::new(
+            &self.entities.meta,
+            &self.archetypes.archetypes,
+            self.archetypes.generation,
+        )
     }
 
     /// Query a uniquely borrowed world
@@ -374,6 +378,11 @@ impl World {
     /// directly to a `for` loop.
     pub fn query_mut<Q: Query>(&mut self) -> QueryMut<'_, Q> {
         QueryMut::new(&self.entities.meta, &mut self.archetypes.archetypes)
+    }
+
+    /// TODO
+    pub fn query_cache(&self) -> QueryCache {
+        QueryCache::new(&self.archetypes.archetypes, self.archetypes.generation)
     }
 
     /// Prepare a query against a single entity, using dynamic borrow checking

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -132,7 +132,7 @@ fn prepare_query() {
     let e = world.spawn(("abc", 123));
     let f = world.spawn(("def", 456));
 
-    let mut query = world.query::<(&i32, &&str)>().prepare(&world);
+    let mut query = PreparedQuery::<(&i32, &&str)>::default();
 
     let ents = query
         .query(&world)
@@ -158,7 +158,7 @@ fn invalidate_prepared_query() {
     let e = world.spawn(("abc", 123));
     let f = world.spawn(("def", 456));
 
-    let mut query = world.query::<(&i32, &&str)>().prepare(&world);
+    let mut query = PreparedQuery::<(&i32, &&str)>::default();
 
     let ents = query
         .query(&world)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -127,6 +127,62 @@ fn query_optional_component() {
 }
 
 #[test]
+fn prepare_query() {
+    let mut world = World::new();
+    let e = world.spawn(("abc", 123));
+    let f = world.spawn(("def", 456));
+
+    let mut query = world.query::<(&i32, &&str)>().prepare(&world);
+
+    let ents = query
+        .borrow(&world)
+        .iter()
+        .map(|(e, (&i, &s))| (e, i, s))
+        .collect::<Vec<_>>();
+    assert_eq!(ents.len(), 2);
+    assert!(ents.contains(&(e, 123, "abc")));
+    assert!(ents.contains(&(f, 456, "def")));
+
+    let ents = query
+        .iter_mut(&mut world)
+        .map(|(e, (&i, &s))| (e, i, s))
+        .collect::<Vec<_>>();
+    assert_eq!(ents.len(), 2);
+    assert!(ents.contains(&(e, 123, "abc")));
+    assert!(ents.contains(&(f, 456, "def")));
+}
+
+#[test]
+fn invalidate_prepared_query() {
+    let mut world = World::new();
+    let e = world.spawn(("abc", 123));
+    let f = world.spawn(("def", 456));
+
+    let mut query = world.query::<(&i32, &&str)>().prepare(&world);
+
+    let ents = query
+        .borrow(&world)
+        .iter()
+        .map(|(e, (&i, &s))| (e, i, s))
+        .collect::<Vec<_>>();
+    assert_eq!(ents.len(), 2);
+    assert!(ents.contains(&(e, 123, "abc")));
+    assert!(ents.contains(&(f, 456, "def")));
+
+    world.spawn((true,));
+    let g = world.spawn(("ghi", 789));
+
+    let ents = query
+        .iter_mut(&mut world)
+        .map(|(e, (&i, &s))| (e, i, s))
+        .collect::<Vec<_>>();
+    assert_eq!(ents.len(), 3);
+    assert!(ents.contains(&(e, 123, "abc")));
+    assert!(ents.contains(&(f, 456, "def")));
+    assert!(ents.contains(&(g, 789, "ghi")));
+}
+
+#[test]
 fn build_entity() {
     let mut world = World::new();
     let mut entity = EntityBuilder::new();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -135,7 +135,7 @@ fn prepare_query() {
     let mut query = world.query::<(&i32, &&str)>().prepare(&world);
 
     let ents = query
-        .borrow(&world)
+        .query(&world)
         .iter()
         .map(|(e, (&i, &s))| (e, i, s))
         .collect::<Vec<_>>();
@@ -144,7 +144,7 @@ fn prepare_query() {
     assert!(ents.contains(&(f, 456, "def")));
 
     let ents = query
-        .iter_mut(&mut world)
+        .query_mut(&mut world)
         .map(|(e, (&i, &s))| (e, i, s))
         .collect::<Vec<_>>();
     assert_eq!(ents.len(), 2);
@@ -161,7 +161,7 @@ fn invalidate_prepared_query() {
     let mut query = world.query::<(&i32, &&str)>().prepare(&world);
 
     let ents = query
-        .borrow(&world)
+        .query(&world)
         .iter()
         .map(|(e, (&i, &s))| (e, i, s))
         .collect::<Vec<_>>();
@@ -173,7 +173,7 @@ fn invalidate_prepared_query() {
     let g = world.spawn(("ghi", 789));
 
     let ents = query
-        .iter_mut(&mut world)
+        .query_mut(&mut world)
         .map(|(e, (&i, &s))| (e, i, s))
         .collect::<Vec<_>>();
     assert_eq!(ents.len(), 3);


### PR DESCRIPTION
This uses a separately managed query cache that checks both the memory address of the archetypes as well as the generation number to ensure that the cache its keeping belongs to the same world and in the same state as the query it is backing. (There might be an ABA problem here, e.g. world A adds archetypes until generation N, caches are query, adds more archetypes and reallocates that `Vec`, then world B adds archetypes until generation N which are backed by the same allocation that was dropped by world A after caching a query. Uniquely tagging worlds using an `AtomicUsize` instead might resolve this.)

The main issue I currently see is that the performance does not seem to improve measurably, e.g.
```
test iterate_cached_100k_by_50   ... bench:      22,605 ns/iter (+/- 556)
test iterate_uncached_100k_by_50 ... bench:      23,051 ns/iter (+/- 490)
```
so either I am doing something wrong in the implementation or the complexity implied by the caching is not worth the gain.

Fixes #154 