### PR TITLE
Fix query_mut permitting unsound double-borrows

### DIFF
--- a/macros/src/query.rs
+++ b/macros/src/query.rs
@@ -128,6 +128,13 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
                 #(#fetches::release(archetype);)*
             }
 
+            #[allow(unused_variables, unused_mut)]
+            fn for_each_borrow(mut f: impl ::core::ops::FnMut(::core::any::TypeId, bool)) {
+                #(
+                    <#fetches as ::hecs::Fetch<'static>>::for_each_borrow(&mut f);
+                )*
+            }
+
             #[allow(unused_variables)]
             unsafe fn get(&self, n: usize) -> Self::Item {
                 #ident {

--- a/tests/derive/enum.rs
+++ b/tests/derive/enum.rs
@@ -1,6 +1,9 @@
 use hecs::{Bundle, Query};
 
-#[derive(Bundle, Query)]
+#[derive(Query)]
 enum Foo {}
+
+#[derive(Bundle)]
+enum Bar {}
 
 fn main() {}

--- a/tests/derive/enum.stderr
+++ b/tests/derive/enum.stderr
@@ -5,7 +5,7 @@ error: derive(Query) may only be applied to structs
   |      ^^^
 
 error: derive(Bundle) does not support enums or unions
- --> $DIR/enum.rs:4:6
+ --> $DIR/enum.rs:7:6
   |
-4 | enum Foo {}
+7 | enum Bar {}
   |      ^^^

--- a/tests/derive/union.rs
+++ b/tests/derive/union.rs
@@ -1,7 +1,12 @@
 use hecs::{Bundle, Query};
 
-#[derive(Bundle, Query)]
+#[derive(Query)]
 union Foo {
+    u8: u8,
+}
+
+#[derive(Bundle)]
+union Bar {
     u8: u8,
 }
 

--- a/tests/derive/union.stderr
+++ b/tests/derive/union.stderr
@@ -5,7 +5,7 @@ error: derive(Query) may only be applied to structs
   |       ^^^
 
 error: derive(Bundle) does not support enums or unions
- --> $DIR/union.rs:4:7
+ --> $DIR/union.rs:9:7
   |
-4 | union Foo {
+9 | union Bar {
   |       ^^^

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -237,6 +237,16 @@ fn illegal_borrow_2() {
 }
 
 #[test]
+#[should_panic(expected = "query violates a unique borrow")]
+fn illegal_query_mut_borrow() {
+    let mut world = World::new();
+    world.spawn(("abc", 123));
+    world.spawn(("def", 456));
+
+    world.query_mut::<(&i32, &mut i32)>();
+}
+
+#[test]
 fn disjoint_queries() {
     let mut world = World::new();
     world.spawn(("abc", true));


### PR DESCRIPTION
Fixes #161.

Not a huge fan of how this complicates `Fetch`, but it fixes the unsoundness and has no overhead in practice.