### PR TITLE
Allow deriving more than one iterator from a query borrow

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -354,9 +354,7 @@ impl<'w, Q: Query> QueryBorrow<'w, Q> {
 
     fn borrow(&mut self) {
         if self.borrowed {
-            panic!(
-                "called QueryBorrow::iter twice on the same borrow; construct a new query instead"
-            );
+            return;
         }
         for x in self.archetypes {
             // TODO: Release prior borrows on failure?

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -335,17 +335,6 @@ fn clear() {
 }
 
 #[test]
-#[should_panic(expected = "twice on the same borrow")]
-fn alias() {
-    let mut world = World::new();
-    world.spawn(("abc", 123));
-    world.spawn(("def", 456, true));
-    let mut q = world.query::<&mut i32>();
-    let _a = q.iter().collect::<Vec<_>>();
-    let _b = q.iter().collect::<Vec<_>>();
-}
-
-#[test]
 fn remove_missing() {
     let mut world = World::new();
     let e = world.spawn(("abc", 123));


### PR DESCRIPTION
There should be no soundness issue here as the borrows can only be narrowed by transforming a query after having iterated it and the lifetime narrowing on the iterator itself will prevent keeping the references it yields around until a second iterator can be derived.

The test case `alias` was indeed not really testing aliasing as it never used the references stored in `_a` and `_b` with overlapping lifetimes.