### PR TITLE
Fix random access in column-deserialized worlds

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -760,6 +760,7 @@ macro_rules! tuple_impl {
 
             type State = ($($name::State,)*);
 
+            #[allow(clippy::unused_unit)]
             fn dangling() -> Self {
                 ($($name::dangling(),)*)
             }
@@ -773,7 +774,7 @@ macro_rules! tuple_impl {
                 Some(access)
             }
 
-            #[allow(unused_variables, non_snake_case)]
+            #[allow(unused_variables, non_snake_case, clippy::unused_unit)]
             fn borrow(archetype: &Archetype, state: Self::State) {
                 let ($($name,)*) = state;
                 $($name::borrow(archetype, $name);)*
@@ -782,23 +783,23 @@ macro_rules! tuple_impl {
             fn prepare(archetype: &Archetype) -> Option<Self::State> {
                 Some(($($name::prepare(archetype)?,)*))
             }
-            #[allow(unused_variables, non_snake_case)]
+            #[allow(unused_variables, non_snake_case, clippy::unused_unit)]
             fn execute(archetype: &'a Archetype, state: Self::State) -> Self {
                 let ($($name,)*) = state;
                 ($($name::execute(archetype, $name),)*)
             }
-            #[allow(unused_variables, non_snake_case)]
+            #[allow(unused_variables, non_snake_case, clippy::unused_unit)]
             fn release(archetype: &Archetype, state: Self::State) {
                 let ($($name,)*) = state;
                 $($name::release(archetype, $name);)*
             }
 
-            #[allow(unused_variables, unused_mut)]
+            #[allow(unused_variables, unused_mut, clippy::unused_unit)]
             fn for_each_borrow(mut f: impl FnMut(TypeId, bool)) {
                 $($name::for_each_borrow(&mut f);)*
             }
 
-            #[allow(unused_variables)]
+            #[allow(unused_variables, clippy::unused_unit)]
             unsafe fn get(&self, n: usize) -> Self::Item {
                 #[allow(non_snake_case)]
                 let ($($name,)*) = self;

--- a/src/world.rs
+++ b/src/world.rs
@@ -257,6 +257,10 @@ impl World {
         let archetype = &mut self.archetypes.archetypes[archetype_id as usize];
         for (&handle, index) in handles.iter().zip(base as usize..) {
             archetype.set_entity_id(index, handle.id());
+            self.entities.meta[handle.id() as usize].location = Location {
+                archetype: archetype_id,
+                index: index as u32,
+            };
         }
     }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -1052,7 +1052,7 @@ impl Iterator for SpawnColumnBatchIter<'_> {
     type Item = Entity;
 
     fn next(&mut self) -> Option<Entity> {
-        let id = self.id_alloc.next(&self.entities)?;
+        let id = self.id_alloc.next(self.entities)?;
         Some(unsafe { self.entities.resolve_unknown_gen(id) })
     }
 
@@ -1063,7 +1063,7 @@ impl Iterator for SpawnColumnBatchIter<'_> {
 
 impl ExactSizeIterator for SpawnColumnBatchIter<'_> {
     fn len(&self) -> usize {
-        self.id_alloc.len(&self.entities)
+        self.id_alloc.len(self.entities)
     }
 }
 

--- a/tests/derive/wrong_lifetime.stderr
+++ b/tests/derive/wrong_lifetime.stderr
@@ -22,4 +22,4 @@ note: ...so that reference does not outlive borrowed content
   |
 3 | #[derive(Query)]
   |          ^^^^^
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the derive macro `Query` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
We neglected to populate the entity's location metadata properly. The test passed because archetype-driven iteration still worked fine.