### PR TITLE
Cloneable component specialization of EntityBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - `Or` query combinator, allowing a single query to select entities that satisfy at least one of two
   sub-queries.
 - `EntityRef::has` to efficiently check for the presence of a component without borrowing it
+- `EntityBulider::new_cloneable` constructs an `EntityBuilder` that builds a `ReusableBuiltEntity`,
+  which can be spawned repeatedly by reference.
 
 ### Changed
 - Added a niche to `Entity`, making `Option<Entity>` the same size as a bare `Entity`. As a

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -8,7 +8,9 @@
 use bencher::{benchmark_group, benchmark_main, Bencher};
 use hecs::*;
 
+#[derive(Clone)]
 struct Position(f32);
+#[derive(Clone)]
 struct Velocity(f32);
 
 fn spawn_tuple(b: &mut Bencher) {
@@ -195,6 +197,16 @@ fn build(b: &mut Bencher) {
     });
 }
 
+fn build_cloneable(b: &mut Bencher) {
+    let mut world = World::new();
+    let mut builder = EntityBuilder::new_cloneable();
+    builder.add(Position(0.0)).add(Velocity(0.0));
+    let bundle = builder.build();
+    b.iter(|| {
+        world.spawn(&bundle);
+    });
+}
+
 benchmark_group!(
     benches,
     spawn_tuple,
@@ -208,6 +220,7 @@ benchmark_group!(
     iterate_cached_100_by_50,
     iterate_mut_uncached_100_by_50,
     iterate_mut_cached_100_by_50,
-    build
+    build,
+    build_cloneable,
 );
 benchmark_main!(benches);

--- a/src/entity_builder.rs
+++ b/src/entity_builder.rs
@@ -28,26 +28,133 @@ use crate::{align, Component, DynamicBundle};
 /// assert_eq!(*world.get::<i32>(e).unwrap(), 123);
 /// assert_eq!(*world.get::<&str>(e).unwrap(), "abc");
 /// ```
-pub struct EntityBuilder {
+///
+/// `EntityBuilder<()>`s make no assumptions about components types. `EntityBuilder<Cloneable>` can
+/// be used instead to manage groups of components that all implement [`Clone`], allowing the built
+/// entity to be spawned repeatedly by reference.
+///
+/// ```
+/// # use hecs::*;
+/// let mut world = World::new();
+/// let mut builder = EntityBuilder::new_cloneable();
+/// builder.add(123).add("abc");
+/// let bundle = builder.build();
+/// let e = world.spawn(&bundle);
+/// let f = world.spawn(&bundle);
+/// assert_eq!(*world.get::<i32>(e).unwrap(), 123);
+/// assert_eq!(*world.get::<&str>(e).unwrap(), "abc");
+/// assert_eq!(*world.get::<i32>(f).unwrap(), 123);
+/// assert_eq!(*world.get::<&str>(f).unwrap(), "abc");
+/// ```
+pub struct EntityBuilder<M = ()> {
     storage: NonNull<u8>,
     layout: Layout,
     cursor: usize,
-    info: Vec<(TypeInfo, usize)>,
+    info: Vec<(TypeInfo, usize, M)>,
     ids: Vec<TypeId>,
     indices: TypeIdMap<usize>,
 }
 
-impl EntityBuilder {
+impl<M> EntityBuilder<M> {
+    /// Checks to see if the component of type `T` exists
+    pub fn has<T: Component>(&self) -> bool {
+        self.indices.contains_key(&TypeId::of::<T>())
+    }
+
+    /// Borrow the component of type `T`, if it exists
+    pub fn get<T: Component>(&self) -> Option<&T> {
+        let index = self.indices.get(&TypeId::of::<T>())?;
+        let (_, offset, _) = self.info[*index];
+        unsafe {
+            let storage = self.storage.as_ptr().add(offset).cast::<T>();
+            Some(&*storage)
+        }
+    }
+
+    /// Uniquely borrow the component of type `T`, if it exists
+    pub fn get_mut<T: Component>(&mut self) -> Option<&mut T> {
+        let index = self.indices.get(&TypeId::of::<T>())?;
+        let (_, offset, _) = self.info[*index];
+        unsafe {
+            let storage = self.storage.as_ptr().add(offset).cast::<T>();
+            Some(&mut *storage)
+        }
+    }
+
+    /// Enumerate the types of the entity builder's components
+    pub fn component_types(&self) -> impl Iterator<Item = TypeId> + '_ {
+        self.info.iter().map(|(info, _, _)| info.id())
+    }
+
+    unsafe fn grow(
+        min_size: usize,
+        cursor: usize,
+        align: usize,
+        storage: NonNull<u8>,
+    ) -> (NonNull<u8>, Layout) {
+        let layout = Layout::from_size_align(min_size.next_power_of_two().max(64), align).unwrap();
+        let new_storage = NonNull::new_unchecked(alloc(layout));
+        ptr::copy_nonoverlapping(storage.as_ptr(), new_storage.as_ptr(), cursor);
+        (new_storage, layout)
+    }
+
+    /// Drop previously `add`ed components
+    ///
+    /// The builder is cleared implicitly when an entity is built, so this doesn't usually need to
+    /// be called.
+    pub fn clear(&mut self) {
+        self.ids.clear();
+        self.indices.clear();
+        self.cursor = 0;
+        unsafe {
+            for (ty, offset, _) in self.info.drain(..) {
+                ty.drop(self.storage.as_ptr().add(offset));
+            }
+        }
+    }
+
+    unsafe fn add_inner(&mut self, ptr: *mut u8, ty: TypeInfo, meta: M) {
+        match self.indices.entry(ty.id()) {
+            Entry::Occupied(occupied) => {
+                let index = *occupied.get();
+                let (ty, offset, _) = self.info[index];
+                let storage = self.storage.as_ptr().add(offset);
+
+                // Drop the existing value
+                ty.drop(storage);
+
+                // Overwrite the old value with our new one.
+                ptr::copy_nonoverlapping(ptr, storage, ty.layout().size());
+            }
+            Entry::Vacant(vacant) => {
+                let offset = align(self.cursor, ty.layout().align());
+                let end = offset + ty.layout().size();
+                if end > self.layout.size() || ty.layout().align() > self.layout.align() {
+                    let new_align = self.layout.align().max(ty.layout().align());
+                    let (new_storage, new_layout) =
+                        Self::grow(end, self.cursor, new_align, self.storage);
+                    if self.layout.size() != 0 {
+                        dealloc(self.storage.as_ptr(), self.layout);
+                    }
+                    self.storage = new_storage;
+                    self.layout = new_layout;
+                }
+
+                let addr = self.storage.as_ptr().add(offset);
+                ptr::copy_nonoverlapping(ptr, addr, ty.layout().size());
+
+                vacant.insert(self.info.len());
+                self.info.push((ty, offset, meta));
+                self.cursor = end;
+            }
+        }
+    }
+}
+
+impl EntityBuilder<()> {
     /// Create a builder representing an entity with no components
     pub fn new() -> Self {
-        Self {
-            storage: NonNull::dangling(),
-            layout: Layout::from_size_align(0, 8).unwrap(),
-            cursor: 0,
-            info: Vec::new(),
-            ids: Vec::new(),
-            indices: Default::default(),
-        }
+        Self::default()
     }
 
     /// Add `component` to the entity.
@@ -65,86 +172,9 @@ impl EntityBuilder {
     /// will replace the old component and the old component will be dropped.
     pub fn add_bundle(&mut self, bundle: impl DynamicBundle) -> &mut Self {
         unsafe {
-            bundle.put(|ptr, ty| {
-                match self.indices.entry(ty.id()) {
-                    Entry::Occupied(occupied) => {
-                        let index = *occupied.get();
-                        let (ty, offset) = self.info[index];
-                        let storage = self.storage.as_ptr().add(offset);
-
-                        // Drop the existing value
-                        ty.drop(storage);
-
-                        // Overwrite the old value with our new one.
-                        ptr::copy_nonoverlapping(ptr, storage, ty.layout().size());
-                    }
-                    Entry::Vacant(vacant) => {
-                        let offset = align(self.cursor, ty.layout().align());
-                        let end = offset + ty.layout().size();
-                        if end > self.layout.size() || ty.layout().align() > self.layout.align() {
-                            let new_align = self.layout.align().max(ty.layout().align());
-                            let (new_storage, new_layout) =
-                                Self::grow(end, self.cursor, new_align, self.storage);
-                            if self.layout.size() != 0 {
-                                dealloc(self.storage.as_ptr(), self.layout);
-                            }
-                            self.storage = new_storage;
-                            self.layout = new_layout;
-                        }
-
-                        let addr = self.storage.as_ptr().add(offset);
-                        ptr::copy_nonoverlapping(ptr, addr, ty.layout().size());
-
-                        vacant.insert(self.info.len());
-                        self.info.push((ty, offset));
-                        self.cursor = end;
-                    }
-                }
-            });
+            bundle.put(|ptr, ty| self.add_inner(ptr, ty, ()));
         }
         self
-    }
-
-    /// Checks to see if the component of type `T` exists
-    pub fn has<T: Component>(&self) -> bool {
-        self.indices.contains_key(&TypeId::of::<T>())
-    }
-
-    /// Borrow the component of type `T`, if it exists
-    pub fn get<T: Component>(&self) -> Option<&T> {
-        let index = self.indices.get(&TypeId::of::<T>())?;
-        let (_, offset) = self.info[*index];
-        unsafe {
-            let storage = self.storage.as_ptr().add(offset).cast::<T>();
-            Some(&*storage)
-        }
-    }
-
-    /// Uniquely borrow the component of type `T`, if it exists
-    pub fn get_mut<T: Component>(&mut self) -> Option<&mut T> {
-        let index = self.indices.get(&TypeId::of::<T>())?;
-        let (_, offset) = self.info[*index];
-        unsafe {
-            let storage = self.storage.as_ptr().add(offset).cast::<T>();
-            Some(&mut *storage)
-        }
-    }
-
-    /// Enumerate the types of the entity builder's components
-    pub fn component_types(&self) -> impl Iterator<Item = TypeId> + '_ {
-        self.info.iter().map(|(info, _)| info.id())
-    }
-
-    unsafe fn grow(
-        min_size: usize,
-        cursor: usize,
-        align: usize,
-        storage: NonNull<u8>,
-    ) -> (NonNull<u8>, Layout) {
-        let layout = Layout::from_size_align(min_size.next_power_of_two().max(64), align).unwrap();
-        let new_storage = NonNull::new_unchecked(alloc(layout));
-        ptr::copy_nonoverlapping(storage.as_ptr(), new_storage.as_ptr(), cursor);
-        (new_storage, layout)
     }
 
     /// Construct a `Bundle` suitable for spawning
@@ -153,27 +183,67 @@ impl EntityBuilder {
         self.ids.extend(self.info.iter().map(|x| x.0.id()));
         BuiltEntity { builder: self }
     }
+}
 
-    /// Drop previously `add`ed components
+impl EntityBuilder<Cloneable> {
+    /// Create a builder representing an entity with no components, and which can only accept
+    /// components that implement `Clone`
+    pub fn new_cloneable() -> Self {
+        Self::default()
+    }
+
+    /// Add `component` to the entity.
     ///
-    /// The builder is cleared implicitly when an entity is built, so this doesn't usually need to
-    /// be called.
-    pub fn clear(&mut self) {
-        self.ids.clear();
-        self.indices.clear();
-        self.cursor = 0;
+    /// If the bundle already contains a component of type `T`, it will be dropped and replaced with
+    /// the most recently added one.
+    pub fn add<T: Component + Clone>(&mut self, mut component: T) -> &mut Self {
         unsafe {
-            for (ty, offset) in self.info.drain(..) {
-                ty.drop(self.storage.as_ptr().add(offset));
+            self.add_inner(
+                (&mut component as *mut T).cast(),
+                TypeInfo::of::<T>(),
+                Cloneable::new::<T>(),
+            );
+            core::mem::forget(component);
+        }
+        self
+    }
+
+    /// Convert into a value whose shared references are [`DynamicBundle`]s suitable for repeated
+    /// spawning
+    pub fn build(self) -> ReusableBuiltEntity {
+        self.into()
+    }
+}
+
+impl Clone for EntityBuilder<Cloneable> {
+    fn clone(&self) -> Self {
+        unsafe {
+            let result = Self {
+                storage: NonNull::new_unchecked(alloc(self.layout)),
+                layout: self.layout,
+                cursor: self.cursor,
+                info: self.info.clone(),
+                ids: Vec::new(),
+                indices: self.indices.clone(),
+            };
+            for &(_, offset, ref clone) in &self.info {
+                (clone.0)(self.storage.as_ptr().add(offset), &mut |src, ty| {
+                    result
+                        .storage
+                        .as_ptr()
+                        .add(offset)
+                        .copy_from_nonoverlapping(src, ty.layout().size())
+                });
             }
+            result
         }
     }
 }
 
-unsafe impl Send for EntityBuilder {}
-unsafe impl Sync for EntityBuilder {}
+unsafe impl<M> Send for EntityBuilder<M> {}
+unsafe impl<M> Sync for EntityBuilder<M> {}
 
-impl Drop for EntityBuilder {
+impl<M> Drop for EntityBuilder<M> {
     fn drop(&mut self) {
         // Ensure buffered components aren't leaked
         self.clear();
@@ -185,16 +255,38 @@ impl Drop for EntityBuilder {
     }
 }
 
-impl Default for EntityBuilder {
+impl<M> Default for EntityBuilder<M> {
+    /// Create a builder representing an entity with no components
     fn default() -> Self {
-        Self::new()
+        Self {
+            storage: NonNull::dangling(),
+            layout: Layout::from_size_align(0, 8).unwrap(),
+            cursor: 0,
+            info: Vec::new(),
+            ids: Vec::new(),
+            indices: Default::default(),
+        }
+    }
+}
+
+/// Type parameter for [`EntityBuilder`]s with cloneable components
+#[derive(Clone)]
+pub struct Cloneable(unsafe fn(*const u8, &mut dyn FnMut(*mut u8, TypeInfo)));
+
+impl Cloneable {
+    fn new<T: Component + Clone>() -> Self {
+        Self(|src, f| unsafe {
+            let mut tmp = (*src.cast::<T>()).clone();
+            f((&mut tmp as *mut T).cast(), TypeInfo::of::<T>());
+            core::mem::forget(tmp);
+        })
     }
 }
 
 /// The output of an [`EntityBuilder`], suitable for passing to
 /// [`World::spawn`](crate::World::spawn) or [`World::insert`](crate::World::insert)
 pub struct BuiltEntity<'a> {
-    builder: &'a mut EntityBuilder,
+    builder: &'a mut EntityBuilder<()>,
 }
 
 unsafe impl DynamicBundle for BuiltEntity<'_> {
@@ -208,7 +300,7 @@ unsafe impl DynamicBundle for BuiltEntity<'_> {
     }
 
     unsafe fn put(self, mut f: impl FnMut(*mut u8, TypeInfo)) {
-        for (ty, offset) in self.builder.info.drain(..) {
+        for (ty, offset, ()) in self.builder.info.drain(..) {
             let ptr = self.builder.storage.as_ptr().add(offset);
             f(ptr, ty);
         }
@@ -220,5 +312,43 @@ impl Drop for BuiltEntity<'_> {
         // Ensures components aren't leaked if `store` was never called, and prepares the builder
         // for reuse.
         self.builder.clear();
+    }
+}
+
+/// A collection of components that implement `Clone`
+///
+/// Built from, and convertible back into, [`EntityBuilder<Cloneable>`]
+#[derive(Clone)]
+pub struct ReusableBuiltEntity(EntityBuilder<Cloneable>);
+
+unsafe impl DynamicBundle for &'_ ReusableBuiltEntity {
+    fn with_ids<T>(&self, f: impl FnOnce(&[TypeId]) -> T) -> T {
+        f(&self.0.ids)
+    }
+
+    fn type_info(&self) -> Vec<TypeInfo> {
+        self.0.info.iter().map(|x| x.0).collect()
+    }
+
+    unsafe fn put(self, mut f: impl FnMut(*mut u8, TypeInfo)) {
+        for &(_, offset, ref clone) in &self.0.info {
+            let ptr = self.0.storage.as_ptr().add(offset);
+            (clone.0)(ptr, &mut f);
+        }
+    }
+}
+
+impl From<EntityBuilder<Cloneable>> for ReusableBuiltEntity {
+    fn from(mut x: EntityBuilder<Cloneable>) -> Self {
+        x.info.sort_unstable_by_key(|y| y.0);
+        x.ids.extend(x.info.iter().map(|y| y.0.id()));
+        Self(x)
+    }
+}
+
+impl From<ReusableBuiltEntity> for EntityBuilder<Cloneable> {
+    fn from(mut x: ReusableBuiltEntity) -> Self {
+        x.0.ids.clear();
+        x.0
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub use archetype::Archetype;
 pub use batch::{BatchIncomplete, BatchWriter, ColumnBatch, ColumnBatchBuilder, ColumnBatchType};
 pub use bundle::{Bundle, DynamicBundle, MissingComponent};
 pub use entities::{Entity, NoSuchEntity};
-pub use entity_builder::{BuiltEntity, EntityBuilder};
+pub use entity_builder::{BuiltEntity, Cloneable, EntityBuilder};
 pub use entity_ref::{EntityRef, Ref, RefMut};
 pub use query::{
     Access, BatchedIter, Or, PreparedQuery, PreparedQueryBorrow, PreparedQueryIter, Query,


### PR DESCRIPTION
This is convenient for storing dynamic entity prototypes, which may be used to efficiently spawn individual identical entities on a recurring basis.

Fixes #193.

There's one aspect of the current draft I'm not happy with: a double indirect function call per component when building an entity from a cloneable builder. There's no escaping at least one indirect call per component, but it'd be nice not to have two. This is difficult because we need temporary storage for the cloned component value so that we can construct a pointer to it in `DynamicBundle::put` which the caller can move out of. If we refactored `DynamicBundle::put` to take pointers to write into instead, bundles would have to handle random access by `TypeId`, which is awkward and might compromise performance. Maybe we should allocate reusable scratch space on the heap? Probably better benchmark to be sure...