### PR TITLE
Add EntityBuilderClone::add_bundle and tests

### DIFF
--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::alloc::{vec, vec::Vec};
+use crate::entity_builder::Cloneable;
 use core::any::{type_name, TypeId};
 use core::ptr::NonNull;
 use core::{fmt, mem};
@@ -57,6 +58,17 @@ pub unsafe trait Bundle: DynamicBundle {
         Self: Sized;
 }
 
+/// A dynamically typed collection of components that is also cloneable
+pub unsafe trait DynamicBundleClone: DynamicBundle + Clone {
+    /// Allow a callback to move all components out of the bundle
+    ///
+    /// Must invoke `f` only with a valid pointer and the pointee's type and size. `put` may only be
+    /// called at most once on any given value. Provides helper type for cloning
+    /// each type.
+    #[doc(hidden)]
+    unsafe fn put_with_clone(self, f: impl FnMut(*mut u8, TypeInfo, Cloneable));
+}
+
 /// Error indicating that an entity did not have a required component
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct MissingComponent(&'static str);
@@ -100,6 +112,23 @@ macro_rules! tuple_impl {
                     f(
                         (&mut $name as *mut $name).cast::<u8>(),
                         TypeInfo::of::<$name>()
+                    );
+                    mem::forget($name);
+                )*
+            }
+        }
+
+        unsafe impl<$($name: Component + Clone),*> DynamicBundleClone for ($($name,)*) {
+            // Compiler false positive warnings
+            #[allow(unused_variables, unused_mut)]
+            unsafe fn put_with_clone(self, mut f: impl FnMut(*mut u8, TypeInfo, Cloneable)) {
+                #[allow(non_snake_case)]
+                let ($(mut $name,)*) = self;
+                $(
+                    f(
+                        (&mut $name as *mut $name).cast::<u8>(),
+                        TypeInfo::of::<$name>(),
+                        Cloneable::new::<$name>(TypeInfo::of::<$name>())
                     );
                     mem::forget($name);
                 )*

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -128,7 +128,7 @@ macro_rules! tuple_impl {
                     f(
                         (&mut $name as *mut $name).cast::<u8>(),
                         TypeInfo::of::<$name>(),
-                        Cloneable::new::<$name>(TypeInfo::of::<$name>())
+                        Cloneable::new::<$name>()
                     );
                     mem::forget($name);
                 )*

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -58,8 +58,8 @@ pub unsafe trait Bundle: DynamicBundle {
         Self: Sized;
 }
 
-/// A dynamically typed collection of components that is also cloneable
-pub unsafe trait DynamicBundleClone: DynamicBundle + Clone {
+/// A dynamically typed collection of cloneable components
+pub unsafe trait DynamicBundleClone: DynamicBundle {
     /// Allow a callback to move all components out of the bundle
     ///
     /// Must invoke `f` only with a valid pointer and the pointee's type and size. `put` may only be

--- a/src/entity_builder.rs
+++ b/src/entity_builder.rs
@@ -179,7 +179,7 @@ impl EntityBuilderClone {
     /// If the bundle contains any component which matches the type of a component
     /// already in the `EntityBuilder`, the newly added component from the bundle
     /// will replace the old component and the old component will be dropped.
-    pub fn add_bundle<T: Component + DynamicBundleClone>(&mut self, bundle: T) -> &mut Self {
+    pub fn add_bundle(&mut self, bundle: impl DynamicBundleClone) -> &mut Self {
         unsafe {
             bundle.put_with_clone(|ptr, ty, cloneable| self.inner.add(ptr, ty, cloneable));
         }

--- a/src/entity_builder.rs
+++ b/src/entity_builder.rs
@@ -399,7 +399,6 @@ impl Cloneable {
         Self {
             type_info,
             func: |src, ty, f| unsafe {
-                std::dbg!(ty);
                 let mut tmp = (*src.cast::<T>()).clone();
                 f((&mut tmp as *mut T).cast(), ty);
                 core::mem::forget(tmp);

--- a/src/world.rs
+++ b/src/world.rs
@@ -159,7 +159,6 @@ impl World {
             components.put(|ptr, ty| {
                 archetype.put_dynamic(ptr, ty.id(), ty.layout().size(), index);
             });
-
             self.entities.meta[entity.id as usize].location = Location {
                 archetype: archetype_id,
                 index,

--- a/src/world.rs
+++ b/src/world.rs
@@ -159,6 +159,7 @@ impl World {
             components.put(|ptr, ty| {
                 archetype.put_dynamic(ptr, ty.id(), ty.layout().size(), index);
             });
+
             self.entities.meta[entity.id as usize].location = Location {
                 archetype: archetype_id,
                 index,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -201,6 +201,31 @@ fn build_entity() {
 }
 
 #[test]
+fn build_entity_clone() {
+    let mut world = World::new();
+    let mut entity = EntityBuilderClone::new();
+    entity.add("abc");
+    entity.add(123);
+    let e = world.spawn(&entity.build());
+    let mut entity = EntityBuilderClone::new();
+    entity.add("def");
+    entity.add([0u8; 1024]);
+    entity.add(456);
+    entity.add(789);
+    entity.add_bundle(("yup", 67_usize));
+    entity.add_bundle((5.0_f32, String::from("Foo")));
+    entity.add_bundle((7.0_f32, String::from("Bar"), 42_usize));
+    let f = world.spawn(&entity.build());
+    assert_eq!(*world.get::<&str>(e).unwrap(), "abc");
+    assert_eq!(*world.get::<i32>(e).unwrap(), 123);
+    assert_eq!(*world.get::<&str>(f).unwrap(), "yup");
+    assert_eq!(*world.get::<i32>(f).unwrap(), 789);
+    assert_eq!(*world.get::<usize>(f).unwrap(), 42);
+    assert_eq!(*world.get::<f32>(f).unwrap(), 7.0);
+    assert_eq!(*world.get::<String>(f).unwrap(), "Bar");
+}
+
+#[test]
 fn access_builder_components() {
     let mut world = World::new();
     let mut entity = EntityBuilder::new();


### PR DESCRIPTION
This fixes issue #211 without any apparent breakages in the public API, allowing for an immediate patch release.

The commit also adds appropriate tests for the cloneable entity builder which were previously missing.