### PR TITLE
Add query map providing random access to query results

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -218,6 +218,21 @@ fn access_column(b: &mut Bencher) {
         let _comp = bencher::black_box(column.get(entc).unwrap());
     });
 }
+
+fn access_view(b: &mut Bencher) {
+    let mut world = World::new();
+    let _enta = world.spawn((Position(0.0), Velocity(0.0)));
+    let _entb = world.spawn((true, 12));
+    let entc = world.spawn((Position(3.0),));
+    let _entd = world.spawn((13, true, 4.0));
+    let mut query = PreparedQuery::<&Position>::new();
+    let mut query = query.query(&world);
+    let view = query.view();
+    b.iter(|| {
+        let _comp = bencher::black_box(view.get(entc).unwrap());
+    });
+}
+
 fn spawn_buffered(b: &mut Bencher) {
     let mut world = World::new();
     let mut buffer = CommandBuffer::new();
@@ -244,6 +259,7 @@ benchmark_group!(
     build,
     build_cloneable,
     access_column,
+    access_view,
     spawn_buffered,
 );
 benchmark_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub use entity_builder::{BuiltEntity, BuiltEntityClone, EntityBuilder, EntityBui
 pub use entity_ref::{EntityRef, Ref, RefMut};
 pub use query::{
     Access, Batch, BatchedIter, Or, PreparedQuery, PreparedQueryBorrow, PreparedQueryIter, Query,
-    QueryBorrow, QueryItem, QueryIter, QueryMut, Satisfies, With, Without,
+    QueryBorrow, QueryItem, QueryIter, QueryMut, QueryShared, Satisfies, With, Without,
 };
 pub use query_one::QueryOne;
 pub use world::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,9 @@ pub use entities::{Entity, NoSuchEntity};
 pub use entity_builder::{BuiltEntity, BuiltEntityClone, EntityBuilder, EntityBuilderClone};
 pub use entity_ref::{EntityRef, Ref, RefMut};
 pub use query::{
-    Access, Batch, BatchedIter, Or, PreparedQuery, PreparedQueryBorrow, PreparedQueryIter, Query,
-    QueryBorrow, QueryItem, QueryIter, QueryMut, QueryShared, Satisfies, With, Without,
+    Access, Batch, BatchedIter, Or, PreparedQuery, PreparedQueryBorrow, PreparedQueryIter,
+    PreparedView, Query, QueryBorrow, QueryItem, QueryIter, QueryMut, QueryShared, Satisfies, With,
+    Without,
 };
 pub use query_one::QueryOne;
 pub use world::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,9 +80,8 @@ pub use entities::{Entity, NoSuchEntity};
 pub use entity_builder::{BuiltEntity, BuiltEntityClone, EntityBuilder, EntityBuilderClone};
 pub use entity_ref::{EntityRef, Ref, RefMut};
 pub use query::{
-    Access, Batch, BatchedIter, Or, PreparedQuery, PreparedQueryBorrow, PreparedQueryIter,
-    PreparedView, Query, QueryBorrow, QueryItem, QueryIter, QueryMut, QueryShared, Satisfies, With,
-    Without,
+    Access, Batch, BatchedIter, Or, PreparedQuery, PreparedQueryBorrow, PreparedQueryIter, Query,
+    QueryBorrow, QueryItem, QueryIter, QueryMut, QueryShared, Satisfies, View, With, Without,
 };
 pub use query_one::QueryOne;
 pub use world::{

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -222,6 +222,23 @@ fn invalidate_prepared_query() {
 }
 
 #[test]
+fn random_access_via_view() {
+    let mut world = World::new();
+    let e = world.spawn(("abc", 123));
+    let f = world.spawn(("def",));
+
+    let mut query = PreparedQuery::<(&i32, &&str)>::default();
+    let mut query = query.query(&world);
+    let mut view = query.view();
+
+    let (i, s) = view.get(e).unwrap();
+    assert_eq!(*i, 123);
+    assert_eq!(*s, "abc");
+
+    assert!(view.get_mut(f).is_none());
+}
+
+#[test]
 fn build_entity() {
     let mut world = World::new();
     let mut entity = EntityBuilder::new();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -239,6 +239,22 @@ fn random_access_via_view() {
 }
 
 #[test]
+fn random_access_via_view_mut() {
+    let mut world = World::new();
+    let e = world.spawn(("abc", 123));
+    let f = world.spawn(("def",));
+
+    let mut query = PreparedQuery::<(&i32, &&str)>::default();
+    let mut view = query.view_mut(&mut world);
+
+    let (i, s) = view.get(e).unwrap();
+    assert_eq!(*i, 123);
+    assert_eq!(*s, "abc");
+
+    assert!(view.get_mut(f).is_none());
+}
+
+#[test]
 fn build_entity() {
     let mut world = World::new();
     let mut entity = EntityBuilder::new();


### PR DESCRIPTION
This is basically a generalisation of the `World::column(_mut)` API for arbitrary queries involving multiple components and/or query combinators.