### PR TITLE
RFC: Streamline computation of component removal target archetype

### DIFF
--- a/macros/src/bundle.rs
+++ b/macros/src/bundle.rs
@@ -50,7 +50,7 @@ fn gen_dynamic_bundle_impl(
             }
 
             fn type_info(&self) -> ::std::vec::Vec<::hecs::TypeInfo> {
-                <Self as ::hecs::Bundle>::static_type_info()
+                <Self as ::hecs::Bundle>::with_static_type_info(|info| info.to_vec())
             }
 
             #[allow(clippy::forget_copy)]
@@ -109,10 +109,11 @@ fn gen_bundle_impl(
                 #with_static_ids_body
             }
 
-            fn static_type_info() -> ::std::vec::Vec<::hecs::TypeInfo> {
-                let mut info = ::std::vec![#(::hecs::TypeInfo::of::<#tys>()),*];
+            #[allow(non_camel_case_types)]
+            fn with_static_type_info<__hecs__T>(f: impl ::std::ops::FnOnce(&[::hecs::TypeInfo]) -> __hecs__T) -> __hecs__T {
+                let mut info: [::hecs::TypeInfo; #num_tys] = [#(::hecs::TypeInfo::of::<#tys>()),*];
                 info.sort_unstable();
-                info
+                f(&info)
             }
 
             unsafe fn get(
@@ -137,7 +138,8 @@ fn gen_unit_struct_bundle_impl(ident: syn::Ident, generics: &syn::Generics) -> T
         unsafe impl #impl_generics ::hecs::Bundle for #ident #ty_generics #where_clause {
             #[allow(non_camel_case_types)]
             fn with_static_ids<__hecs__T>(f: impl ::std::ops::FnOnce(&[::std::any::TypeId]) -> __hecs__T) -> __hecs__T { f(&[]) }
-            fn static_type_info() -> ::std::vec::Vec<::hecs::TypeInfo> { ::std::vec::Vec::new() }
+            #[allow(non_camel_case_types)]
+            fn with_static_type_info<__hecs__T>(f: impl ::std::ops::FnOnce(&[::hecs::TypeInfo]) -> __hecs__T) -> __hecs__T { f(&[]) }
 
             unsafe fn get(
                 mut f: impl ::std::ops::FnMut(::hecs::TypeInfo) -> ::std::option::Option<::std::ptr::NonNull<u8>>,

--- a/src/world.rs
+++ b/src/world.rs
@@ -18,10 +18,7 @@ use core::{fmt, ptr};
 #[cfg(feature = "std")]
 use std::error::Error;
 
-use hashbrown::{
-    hash_map::{Entry, HashMap},
-    HashSet,
-};
+use hashbrown::hash_map::{Entry, HashMap};
 
 use crate::alloc::boxed::Box;
 use crate::archetype::{Archetype, TypeIdMap, TypeInfo};
@@ -721,12 +718,12 @@ impl World {
         match remove_edges.entry((old_archetype, TypeId::of::<T>())) {
             Entry::Occupied(entry) => *entry.into_mut(),
             Entry::Vacant(entry) => {
-                let removed = T::with_static_ids(|ids| ids.iter().copied().collect::<HashSet<_>>());
+                let removed = T::static_type_info();
                 let info = archetypes.archetypes[old_archetype as usize]
                     .types()
                     .iter()
+                    .filter(|x| removed.binary_search(x).is_err())
                     .cloned()
-                    .filter(|x| !removed.contains(&x.id()))
                     .collect::<Vec<_>>();
                 let elements = info.iter().map(|x| x.id()).collect::<Box<_>>();
                 let index = archetypes.get(&*elements, move || info);


### PR DESCRIPTION
I think the first commit is almost certainly an improvement as the bundles will usually contain very few types so the binary search almost certainly preferable to the ahash-based `HashSet` in terms of code size and thereby performance. The second one might be pushing it though as the dynamic allocation is done only in the slow path in the first place. The modified method `Bundle::with_static_type_info` might become generally useful in the future though, at the cost of changing the theoretically user-facing API now.