### PR TITLE
impl Send and Sync for View

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -684,8 +684,8 @@ impl<'w, Q: Query> QueryBorrow<'w, Q> {
     }
 }
 
-unsafe impl<'w, Q: Query> Send for QueryBorrow<'w, Q> {}
-unsafe impl<'w, Q: Query> Sync for QueryBorrow<'w, Q> {}
+unsafe impl<'w, Q: Query> Send for QueryBorrow<'w, Q> where <Q::Fetch as Fetch<'w>>::Item: Send {}
+unsafe impl<'w, Q: Query> Sync for QueryBorrow<'w, Q> where <Q::Fetch as Fetch<'w>>::Item: Send {}
 
 impl<'w, Q: Query> Drop for QueryBorrow<'w, Q> {
     fn drop(&mut self) {
@@ -729,8 +729,8 @@ impl<'q, Q: Query> QueryIter<'q, Q> {
     }
 }
 
-unsafe impl<'q, Q: Query> Send for QueryIter<'q, Q> {}
-unsafe impl<'q, Q: Query> Sync for QueryIter<'q, Q> {}
+unsafe impl<'q, Q: Query> Send for QueryIter<'q, Q> where <Q::Fetch as Fetch<'q>>::Item: Send {}
+unsafe impl<'q, Q: Query> Sync for QueryIter<'q, Q> where <Q::Fetch as Fetch<'q>>::Item: Send {}
 
 impl<'q, Q: Query> Iterator for QueryIter<'q, Q> {
     type Item = (Entity, QueryItem<'q, Q>);
@@ -912,8 +912,8 @@ impl<'q, Q: Query> BatchedIter<'q, Q> {
     }
 }
 
-unsafe impl<'q, Q: Query> Send for BatchedIter<'q, Q> {}
-unsafe impl<'q, Q: Query> Sync for BatchedIter<'q, Q> {}
+unsafe impl<'q, Q: Query> Send for BatchedIter<'q, Q> where <Q::Fetch as Fetch<'q>>::Item: Send {}
+unsafe impl<'q, Q: Query> Sync for BatchedIter<'q, Q> where <Q::Fetch as Fetch<'q>>::Item: Send {}
 
 impl<'q, Q: Query> Iterator for BatchedIter<'q, Q> {
     type Item = Batch<'q, Q>;
@@ -974,8 +974,8 @@ impl<'q, Q: Query> Iterator for Batch<'q, Q> {
     }
 }
 
-unsafe impl<'q, Q: Query> Send for Batch<'q, Q> {}
-unsafe impl<'q, Q: Query> Sync for Batch<'q, Q> {}
+unsafe impl<'q, Q: Query> Send for Batch<'q, Q> where <Q::Fetch as Fetch<'q>>::Item: Send {}
+unsafe impl<'q, Q: Query> Sync for Batch<'q, Q> where <Q::Fetch as Fetch<'q>>::Item: Send {}
 
 macro_rules! tuple_impl {
     ($($name: ident),*) => {
@@ -1213,8 +1213,10 @@ impl<'q, Q: Query> PreparedQueryIter<'q, Q> {
     }
 }
 
-unsafe impl<Q: Query> Send for PreparedQueryIter<'_, Q> {}
-unsafe impl<Q: Query> Sync for PreparedQueryIter<'_, Q> {}
+unsafe impl<'q, Q: Query> Send for PreparedQueryIter<'q, Q> where <Q::Fetch as Fetch<'q>>::Item: Send
+{}
+unsafe impl<'q, Q: Query> Sync for PreparedQueryIter<'q, Q> where <Q::Fetch as Fetch<'q>>::Item: Send
+{}
 
 impl<'q, Q: Query> Iterator for PreparedQueryIter<'q, Q> {
     type Item = (Entity, QueryItem<'q, Q>);
@@ -1268,6 +1270,9 @@ pub struct View<'q, Q: Query> {
     meta: &'q [EntityMeta],
     fetch: Vec<Option<Q::Fetch>>,
 }
+
+unsafe impl<'q, Q: Query> Send for View<'q, Q> where <Q::Fetch as Fetch<'q>>::Item: Send {}
+unsafe impl<'q, Q: Query> Sync for View<'q, Q> where <Q::Fetch as Fetch<'q>>::Item: Send {}
 
 impl<'q, Q: Query> View<'q, Q> {
     /// # Safety
@@ -1372,6 +1377,9 @@ pub struct PreparedView<'q, Q: Query> {
     meta: &'q [EntityMeta],
     fetch: &'q mut [Option<Q::Fetch>],
 }
+
+unsafe impl<'q, Q: Query> Send for PreparedView<'q, Q> where <Q::Fetch as Fetch<'q>>::Item: Send {}
+unsafe impl<'q, Q: Query> Sync for PreparedView<'q, Q> where <Q::Fetch as Fetch<'q>>::Item: Send {}
 
 impl<'q, Q: Query> PreparedView<'q, Q> {
     /// # Safety


### PR DESCRIPTION
Borrow checking is done at .query() time. Safe to send/share between threads as there is no interior mutability here.