### PR TITLE
Fix panic on inserting with some dangling Entity handles

### DIFF
--- a/src/world.rs
+++ b/src/world.rs
@@ -1406,4 +1406,10 @@ mod tests {
         let a = world.spawn(("abc", 123));
         world.remove::<()>(a).unwrap();
     }
+
+    #[test]
+    fn bad_insert() {
+        let mut world = World::new();
+        assert!(world.insert_one(Entity::DANGLING, ()).is_err());
+    }
 }


### PR DESCRIPTION
When the `id` of a dangling Entity is larger than any previously allocated from the world, `Entities::get` would erroneously judge it to be pending, leading `insert` to attempt access to out-of-bounds location or archetype data.

Replicates the same fix applied in https://github.com/Ralith/hecs/pull/244 to `Entities::get`. `get_mut` is left as-is as it doesn't handle pending entities.