### PR TITLE
Refactor World::get to take reference types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+### Added
+- `World::satisfies` and `EntityRef::satisfies` to check if an entity would match a query
+
 ### Changed
 - Many generic methods that previously took a `Component` now instead take either a
   `ComponentRef<'a>` or a `Query` to improve consistency with queries and address a common footgun:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
     component types
   - `EntityBuilder` and `EntityBuilderClone`'s `get` and `get_mut` refactored along the same lines
     for consistency
+  - The `With`/`Without` query transformers now take a query that entities must/mustn't match rather
+    than a component type. Additionally, the order of their generic arguments was reversed to place
+    the query whose results will be yielded first.
 - `SerializeContext` traits now take their serializer arguments by value, and must call `end()`
   themselves.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Many generic methods that previously took a `Component` now instead take either a
   `ComponentRef<'a>` or a `Query` to improve consistency with queries and address a common footgun:
   - `World::get` and `EntityRef::get` now take shared or unique references to component types
+  - `EntityBuilder` and `EntityBuilderClone`'s `get` and `get_mut` refactored along the same lines
+    for consistency
 - `SerializeContext` traits now take their serializer arguments by value, and must call `end()`
   themselves.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Changed
 - Many generic methods that previously took a `Component` now instead take either a
   `ComponentRef<'a>` or a `Query` to improve consistency with queries and address a common footgun:
-  - `World::get` and `EntityRef::get` now take shared or unique references to component types
+  - `World::get`, `EntityRef::get`, and `Archetype::get` now take shared or unique references to
+    component types
   - `EntityBuilder` and `EntityBuilderClone`'s `get` and `get_mut` refactored along the same lines
     for consistency
 - `SerializeContext` traits now take their serializer arguments by value, and must call `end()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
 ### Changed
+- Many generic methods that previously took a `Component` now instead take either a
+  `ComponentRef<'a>` or a `Query` to improve consistency with queries and address a common footgun:
+  - `World::get` and `EntityRef::get` now take shared or unique references to component types
 - `SerializeContext` traits now take their serializer arguments by value, and must call `end()`
   themselves.
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ for (id, (number, &flag)) in world.query_mut::<(&mut i32, &bool)>() {
   if flag { *number *= 2; }
 }
 // Random access is simple and safe
-assert_eq!(*world.get::<i32>(a).unwrap(), 246);
-assert_eq!(*world.get::<i32>(b).unwrap(), 42);
+assert_eq!(*world.get::<&i32>(a).unwrap(), 246);
+assert_eq!(*world.get::<&i32>(b).unwrap(), 42);
 ```
 
 ### Why ECS?

--- a/examples/ffa_simulation.rs
+++ b/examples/ffa_simulation.rs
@@ -102,7 +102,7 @@ fn system_fire_at_closest(world: &mut World) {
         */
 
         // Or like this:
-        let mut hp1 = world.get_mut::<Health>(closest).unwrap();
+        let mut hp1 = world.get::<&mut Health>(closest).unwrap();
 
         // Is target unit still alive?
         if hp1.0 > 0 {

--- a/examples/ffa_simulation.rs
+++ b/examples/ffa_simulation.rs
@@ -73,14 +73,14 @@ fn system_integrate_motion(world: &mut World, query: &mut PreparedQuery<(&mut Po
 // In this system entities find the closest entity and fire at them
 fn system_fire_at_closest(world: &mut World) {
     for (id0, (pos0, dmg0, kc0)) in
-        &mut world.query::<With<Health, (&Position, &Damage, &mut KillCount)>>()
+        &mut world.query::<With<(&Position, &Damage, &mut KillCount), &Health>>()
     {
         // Find closest:
         // Nested queries are O(n^2) and you usually want to avoid that by using some sort of
         // spatial index like a quadtree or more general BVH, which we don't bother with here since
         // it's out of scope for the example.
         let closest = world
-            .query::<With<Health, &Position>>()
+            .query::<With<&Position, &Health>>()
             .iter()
             .filter(|(id1, _)| *id1 != id0)
             .min_by_key(|(_, pos1)| manhattan_dist(pos0.x, pos1.x, pos0.y, pos1.y))

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -3,7 +3,7 @@
 
 fn format_entity(entity: hecs::EntityRef<'_>) -> String {
     fn fmt<T: hecs::Component + std::fmt::Display>(entity: hecs::EntityRef<'_>) -> Option<String> {
-        Some(entity.get::<T>()?.to_string())
+        Some(entity.get::<&T>()?.to_string())
     }
 
     const FUNCTIONS: &[&dyn Fn(hecs::EntityRef<'_>) -> Option<String>] =

--- a/src/command_buffer.rs
+++ b/src/command_buffer.rs
@@ -26,7 +26,7 @@ use crate::{Bundle, Entity};
 /// let mut cmd = CommandBuffer::new();
 /// cmd.insert(entity, (true, 42));
 /// cmd.run_on(&mut world); // cmd can now be reused
-/// assert_eq!(*world.get::<i32>(entity).unwrap(), 42);
+/// assert_eq!(*world.get::<&i32>(entity).unwrap(), 42);
 /// ```
 pub struct CommandBuffer {
     entities: Vec<EntityIndex>,

--- a/src/entity_builder.rs
+++ b/src/entity_builder.rs
@@ -26,8 +26,8 @@ use crate::{align, Component, DynamicBundle};
 /// let mut builder = EntityBuilder::new();
 /// builder.add(123).add("abc");
 /// let e = world.spawn(builder.build()); // builder can now be reused
-/// assert_eq!(*world.get::<i32>(e).unwrap(), 123);
-/// assert_eq!(*world.get::<&str>(e).unwrap(), "abc");
+/// assert_eq!(*world.get::<&i32>(e).unwrap(), 123);
+/// assert_eq!(*world.get::<&&str>(e).unwrap(), "abc");
 /// ```
 #[derive(Default)]
 pub struct EntityBuilder {
@@ -142,10 +142,10 @@ impl Drop for BuiltEntity<'_> {
 /// let bundle = builder.build();
 /// let e = world.spawn(&bundle);
 /// let f = world.spawn(&bundle); // `&bundle` can be used many times
-/// assert_eq!(*world.get::<i32>(e).unwrap(), 123);
-/// assert_eq!(*world.get::<&str>(e).unwrap(), "abc");
-/// assert_eq!(*world.get::<i32>(f).unwrap(), 123);
-/// assert_eq!(*world.get::<&str>(f).unwrap(), "abc");
+/// assert_eq!(*world.get::<&i32>(e).unwrap(), 123);
+/// assert_eq!(*world.get::<&&str>(e).unwrap(), "abc");
+/// assert_eq!(*world.get::<&i32>(f).unwrap(), 123);
+/// assert_eq!(*world.get::<&&str>(f).unwrap(), "abc");
 /// ```
 #[derive(Clone, Default)]
 pub struct EntityBuilderClone {

--- a/src/entity_ref.rs
+++ b/src/entity_ref.rs
@@ -4,7 +4,8 @@ use core::ptr::NonNull;
 
 use crate::archetype::Archetype;
 use crate::{
-    ArchetypeColumn, ArchetypeColumnMut, Component, Entity, MissingComponent, Query, QueryOne,
+    ArchetypeColumn, ArchetypeColumnMut, Component, Entity, Fetch, MissingComponent, Query,
+    QueryOne,
 };
 
 /// Handle to an entity with any component types
@@ -30,7 +31,14 @@ impl<'a> EntityRef<'a> {
         self.entity
     }
 
+    /// Determine whether this entity would satisfy the query `Q`
+    pub fn satisfies<Q: Query>(&self) -> bool {
+        Q::Fetch::access(self.archetype).is_some()
+    }
+
     /// Determine whether this entity has a `T` component without borrowing it
+    ///
+    /// Equivalent to [`satisfies::<&T>`](Self::satisfies)
     pub fn has<T: Component>(&self) -> bool {
         self.archetype.has::<T>()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,8 @@
 //!   if flag { *number *= 2; }
 //! }
 //! // Random access is simple and safe
-//! assert_eq!(*world.get::<i32>(a).unwrap(), 246);
-//! assert_eq!(*world.get::<i32>(b).unwrap(), 42);
+//! assert_eq!(*world.get::<&i32>(a).unwrap(), 246);
+//! assert_eq!(*world.get::<&i32>(b).unwrap(), 42);
 //! ```
 
 #![warn(missing_docs)]
@@ -79,7 +79,7 @@ pub use column::{Column, ColumnMut};
 pub use command_buffer::CommandBuffer;
 pub use entities::{Entity, NoSuchEntity};
 pub use entity_builder::{BuiltEntity, BuiltEntityClone, EntityBuilder, EntityBuilderClone};
-pub use entity_ref::{EntityRef, Ref, RefMut};
+pub use entity_ref::{ComponentRef, EntityRef, Ref, RefMut};
 pub use query::{
     Access, Batch, BatchedIter, Or, PreparedQuery, PreparedQueryBorrow, PreparedQueryIter,
     PreparedView, Query, QueryBorrow, QueryItem, QueryIter, QueryMut, QueryShared, Satisfies, View,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub use column::{Column, ColumnMut};
 pub use command_buffer::CommandBuffer;
 pub use entities::{Entity, NoSuchEntity};
 pub use entity_builder::{BuiltEntity, BuiltEntityClone, EntityBuilder, EntityBuilderClone};
-pub use entity_ref::{ComponentRef, EntityRef, Ref, RefMut};
+pub use entity_ref::{ComponentRef, ComponentRefShared, EntityRef, Ref, RefMut};
 pub use query::{
     Access, Batch, BatchedIter, Or, PreparedQuery, PreparedQueryBorrow, PreparedQueryIter,
     PreparedView, Query, QueryBorrow, QueryItem, QueryIter, QueryMut, QueryShared, Satisfies, View,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub mod serialize;
 mod take;
 mod world;
 
-pub use archetype::{Archetype, ArchetypeColumn};
+pub use archetype::{Archetype, ArchetypeColumn, ArchetypeColumnMut};
 pub use batch::{BatchIncomplete, BatchWriter, ColumnBatch, ColumnBatchBuilder, ColumnBatchType};
 pub use bundle::{Bundle, DynamicBundle, DynamicBundleClone, MissingComponent};
 pub use column::{Column, ColumnMut};

--- a/src/query_one.rs
+++ b/src/query_one.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 use crate::query::{Fetch, With, Without};
-use crate::{Archetype, Component, Query, QueryItem};
+use crate::{Archetype, Query, QueryItem};
 
 /// A borrow of a [`World`](crate::World) sufficient to execute the query `Q` on a single entity
 pub struct QueryOne<'a, Q: Query> {
@@ -44,17 +44,17 @@ impl<'a, Q: Query> QueryOne<'a, Q> {
         unsafe { Some(fetch.get(self.index as usize)) }
     }
 
-    /// Transform the query into one that requires a certain component without borrowing it
+    /// Transform the query into one that requires another query be satisfied
     ///
-    /// See `QueryBorrow::with` for details.
-    pub fn with<T: Component>(self) -> QueryOne<'a, With<T, Q>> {
+    /// See `QueryBorrow::with`
+    pub fn with<R: Query>(self) -> QueryOne<'a, With<Q, R>> {
         self.transform()
     }
 
-    /// Transform the query into one that skips entities having a certain component
+    /// Transform the query into one that skips entities satisfying another
     ///
     /// See `QueryBorrow::without` for details.
-    pub fn without<T: Component>(self) -> QueryOne<'a, Without<T, Q>> {
+    pub fn without<R: Query>(self) -> QueryOne<'a, Without<Q, R>> {
         self.transform()
     }
 

--- a/src/serialize/column.rs
+++ b/src/serialize/column.rs
@@ -757,7 +757,7 @@ mod tests {
     impl PartialEq for SerWorld {
         fn eq(&self, other: &Self) -> bool {
             fn same_components<T: Component + PartialEq>(x: &EntityRef, y: &EntityRef) -> bool {
-                x.get::<T>().as_ref().map(|x| &**x) == y.get::<T>().as_ref().map(|x| &**x)
+                x.get::<&T>().as_ref().map(|x| &**x) == y.get::<&T>().as_ref().map(|x| &**x)
             }
 
             for (x, y) in self.0.iter().zip(other.0.iter()) {
@@ -779,8 +779,8 @@ mod tests {
                     (
                         e.entity(),
                         (
-                            e.get::<Position>().map(|x| *x),
-                            e.get::<Velocity>().map(|x| *x),
+                            e.get::<&Position>().map(|x| *x),
+                            e.get::<&Velocity>().map(|x| *x),
                         ),
                     )
                 }))

--- a/src/serialize/column.rs
+++ b/src/serialize/column.rs
@@ -130,7 +130,7 @@ where
     T: Component + Serialize,
     S: SerializeTuple,
 {
-    if let Some(xs) = archetype.get::<T>() {
+    if let Some(xs) = archetype.get::<&T>() {
         serialize_collection(&*xs, out)?;
     }
     Ok(())

--- a/src/serialize/row.rs
+++ b/src/serialize/row.rs
@@ -82,7 +82,7 @@ pub fn try_serialize<T: Component + Serialize, K: Serialize + ?Sized, S: Seriali
     key: &K,
     map: &mut S,
 ) -> Result<(), S::Error> {
-    if let Some(x) = entity.get::<T>() {
+    if let Some(x) = entity.get::<&T>() {
         map.serialize_key(key)?;
         map.serialize_value(&*x)?;
     }
@@ -270,7 +270,7 @@ mod tests {
     impl PartialEq for SerWorld {
         fn eq(&self, other: &Self) -> bool {
             fn same_components<T: Component + PartialEq>(x: &EntityRef, y: &EntityRef) -> bool {
-                x.get::<T>().as_ref().map(|x| &**x) == y.get::<T>().as_ref().map(|x| &**x)
+                x.get::<&T>().as_ref().map(|x| &**x) == y.get::<&T>().as_ref().map(|x| &**x)
             }
 
             for (x, y) in self.0.iter().zip(other.0.iter()) {
@@ -292,8 +292,8 @@ mod tests {
                     (
                         e.entity(),
                         (
-                            e.get::<Position>().map(|x| *x),
-                            e.get::<Velocity>().map(|x| *x),
+                            e.get::<&Position>().map(|x| *x),
+                            e.get::<&Velocity>().map(|x| *x),
                         ),
                     )
                 }))

--- a/src/world.rs
+++ b/src/world.rs
@@ -479,6 +479,11 @@ impl World {
             .ok_or_else(MissingComponent::new::<T::Component>)?)
     }
 
+    /// Short-hand for [`entity`](Self::entity) followed by [`EntityRef::satisfies`]
+    pub fn satisfies<Q: Query>(&self, entity: Entity) -> Result<bool, NoSuchEntity> {
+        Ok(self.entity(entity)?.satisfies::<Q>())
+    }
+
     /// Access an entity regardless of its component types
     ///
     /// Does not immediately borrow any component.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -326,8 +326,8 @@ fn build_builder_clone() {
     let mut b = EntityBuilderClone::new();
     b.add(String::from("def"));
     b.add_bundle(&a.build());
-    assert_eq!(b.get::<String>(), Some(&String::from("abc")));
-    assert_eq!(b.get::<i32>(), Some(&123));
+    assert_eq!(b.get::<&String>(), Some(&String::from("abc")));
+    assert_eq!(b.get::<&i32>(), Some(&123));
 }
 
 #[test]
@@ -386,12 +386,12 @@ fn access_builder_components() {
     assert!(entity.has::<i32>());
     assert!(!entity.has::<usize>());
 
-    assert_eq!(*entity.get::<&str>().unwrap(), "abc");
-    assert_eq!(*entity.get::<i32>().unwrap(), 123);
-    assert_eq!(entity.get::<usize>(), None);
+    assert_eq!(*entity.get::<&&str>().unwrap(), "abc");
+    assert_eq!(*entity.get::<&i32>().unwrap(), 123);
+    assert_eq!(entity.get::<&usize>(), None);
 
-    *entity.get_mut::<i32>().unwrap() = 456;
-    assert_eq!(*entity.get::<i32>().unwrap(), 456);
+    *entity.get_mut::<&mut i32>().unwrap() = 456;
+    assert_eq!(*entity.get::<&i32>().unwrap(), 456);
 
     let g = world.spawn(entity.build());
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -15,12 +15,12 @@ fn random_access() {
     let mut world = World::new();
     let e = world.spawn(("abc", 123));
     let f = world.spawn(("def", 456, true));
-    assert_eq!(*world.get::<&str>(e).unwrap(), "abc");
-    assert_eq!(*world.get::<i32>(e).unwrap(), 123);
-    assert_eq!(*world.get::<&str>(f).unwrap(), "def");
-    assert_eq!(*world.get::<i32>(f).unwrap(), 456);
-    *world.get_mut::<i32>(f).unwrap() = 42;
-    assert_eq!(*world.get::<i32>(f).unwrap(), 42);
+    assert_eq!(*world.get::<&&str>(e).unwrap(), "abc");
+    assert_eq!(*world.get::<&i32>(e).unwrap(), 123);
+    assert_eq!(*world.get::<&&str>(f).unwrap(), "def");
+    assert_eq!(*world.get::<&i32>(f).unwrap(), 456);
+    *world.get::<&mut i32>(f).unwrap() = 42;
+    assert_eq!(*world.get::<&i32>(f).unwrap(), 42);
 }
 
 #[test]
@@ -31,10 +31,10 @@ fn despawn() {
     assert_eq!(world.query::<()>().iter().count(), 2);
     world.despawn(e).unwrap();
     assert_eq!(world.query::<()>().iter().count(), 1);
-    assert!(world.get::<&str>(e).is_err());
-    assert!(world.get::<i32>(e).is_err());
-    assert_eq!(*world.get::<&str>(f).unwrap(), "def");
-    assert_eq!(*world.get::<i32>(f).unwrap(), 456);
+    assert!(world.get::<&&str>(e).is_err());
+    assert!(world.get::<&i32>(e).is_err());
+    assert_eq!(*world.get::<&&str>(f).unwrap(), "def");
+    assert_eq!(*world.get::<&i32>(f).unwrap(), 456);
 }
 
 #[test]
@@ -282,10 +282,10 @@ fn build_entity() {
     entity.add(456);
     entity.add(789);
     let f = world.spawn(entity.build());
-    assert_eq!(*world.get::<&str>(e).unwrap(), "abc");
-    assert_eq!(*world.get::<i32>(e).unwrap(), 123);
-    assert_eq!(*world.get::<&str>(f).unwrap(), "def");
-    assert_eq!(*world.get::<i32>(f).unwrap(), 789);
+    assert_eq!(*world.get::<&&str>(e).unwrap(), "abc");
+    assert_eq!(*world.get::<&i32>(e).unwrap(), 123);
+    assert_eq!(*world.get::<&&str>(f).unwrap(), "def");
+    assert_eq!(*world.get::<&i32>(f).unwrap(), 789);
 }
 
 #[test]
@@ -308,14 +308,14 @@ fn build_entity_clone() {
         .unwrap();
 
     for e in [e, f, g] {
-        assert_eq!(*world.get::<&str>(e).unwrap(), "yup");
-        assert_eq!(*world.get::<i32>(e).unwrap(), 789);
-        assert_eq!(*world.get::<usize>(e).unwrap(), 42);
-        assert_eq!(*world.get::<f32>(e).unwrap(), 7.0);
-        assert_eq!(*world.get::<String>(e).unwrap(), "Bar");
+        assert_eq!(*world.get::<&&str>(e).unwrap(), "yup");
+        assert_eq!(*world.get::<&i32>(e).unwrap(), 789);
+        assert_eq!(*world.get::<&usize>(e).unwrap(), 42);
+        assert_eq!(*world.get::<&f32>(e).unwrap(), 7.0);
+        assert_eq!(*world.get::<&String>(e).unwrap(), "Bar");
     }
 
-    assert_eq!(*world.get::<Cow<'static, str>>(g).unwrap(), "after");
+    assert_eq!(*world.get::<&Cow<'static, str>>(g).unwrap(), "after");
 }
 
 #[test]
@@ -337,8 +337,8 @@ fn cloned_builder() {
 
     let mut world = World::new();
     let e = world.spawn(&builder.build().clone());
-    assert_eq!(*world.get::<String>(e).unwrap(), "abc");
-    assert_eq!(*world.get::<i32>(e).unwrap(), 123);
+    assert_eq!(*world.get::<&String>(e).unwrap(), "abc");
+    assert_eq!(*world.get::<&i32>(e).unwrap(), 123);
 }
 
 #[test]
@@ -365,13 +365,13 @@ fn build_dynamic_bundle() {
         .unwrap();
 
     for e in [e, f, g] {
-        assert_eq!(*world.get::<i32>(e).unwrap(), 5);
-        assert_eq!(*world.get::<char>(e).unwrap(), 'a');
-        assert_eq!(*world.get::<String>(e).unwrap(), "Bar");
-        assert_eq!(*world.get::<f32>(e).unwrap(), 6.0);
+        assert_eq!(*world.get::<&i32>(e).unwrap(), 5);
+        assert_eq!(*world.get::<&char>(e).unwrap(), 'a');
+        assert_eq!(*world.get::<&String>(e).unwrap(), "Bar");
+        assert_eq!(*world.get::<&f32>(e).unwrap(), 6.0);
     }
 
-    assert_eq!(*world.get::<Cow<'static, str>>(g).unwrap(), "after");
+    assert_eq!(*world.get::<&Cow<'static, str>>(g).unwrap(), "after");
 }
 
 #[test]
@@ -395,8 +395,8 @@ fn access_builder_components() {
 
     let g = world.spawn(entity.build());
 
-    assert_eq!(*world.get::<&str>(g).unwrap(), "abc");
-    assert_eq!(*world.get::<i32>(g).unwrap(), 456);
+    assert_eq!(*world.get::<&&str>(g).unwrap(), "abc");
+    assert_eq!(*world.get::<&i32>(g).unwrap(), 456);
 }
 
 #[test]
@@ -408,10 +408,10 @@ fn build_entity_bundle() {
     entity.add(456);
     entity.add_bundle(("def", [0u8; 1024], 789));
     let f = world.spawn(entity.build());
-    assert_eq!(*world.get::<&str>(e).unwrap(), "abc");
-    assert_eq!(*world.get::<i32>(e).unwrap(), 123);
-    assert_eq!(*world.get::<&str>(f).unwrap(), "def");
-    assert_eq!(*world.get::<i32>(f).unwrap(), 789);
+    assert_eq!(*world.get::<&&str>(e).unwrap(), "abc");
+    assert_eq!(*world.get::<&i32>(e).unwrap(), 123);
+    assert_eq!(*world.get::<&&str>(f).unwrap(), "def");
+    assert_eq!(*world.get::<&i32>(f).unwrap(), 789);
 }
 
 #[test]
@@ -462,11 +462,11 @@ fn spawn_buffered_entity() {
 
     buffer.run_on(&mut world);
 
-    assert_eq!(*world.get::<bool>(ent).unwrap(), true);
-    assert_eq!(*world.get::<&str>(ent1).unwrap(), "hecs");
-    assert_eq!(*world.get::<i32>(ent1).unwrap(), 13);
-    assert_eq!(*world.get::<bool>(ent2).unwrap(), false);
-    assert_eq!(*world.get::<u8>(ent3).unwrap(), 2);
+    assert_eq!(*world.get::<&bool>(ent).unwrap(), true);
+    assert_eq!(*world.get::<&&str>(ent1).unwrap(), "hecs");
+    assert_eq!(*world.get::<&i32>(ent1).unwrap(), 13);
+    assert_eq!(*world.get::<&bool>(ent2).unwrap(), false);
+    assert_eq!(*world.get::<&u8>(ent3).unwrap(), 2);
 }
 
 #[test]
@@ -489,8 +489,8 @@ fn remove_buffered_component() {
     buffer.remove::<(i32, &str)>(ent);
     buffer.run_on(&mut world);
 
-    assert!(world.get::<&str>(ent).is_err());
-    assert!(world.get::<i32>(ent).is_err());
+    assert!(world.get::<&&str>(ent).is_err());
+    assert!(world.get::<&i32>(ent).is_err());
 }
 
 #[test]
@@ -547,8 +547,8 @@ fn shared_borrow() {
 fn illegal_random_access() {
     let mut world = World::new();
     let e = world.spawn(("abc", 123));
-    let _borrow = world.get_mut::<i32>(e).unwrap();
-    world.get::<i32>(e).unwrap();
+    let _borrow = world.get::<&mut i32>(e).unwrap();
+    world.get::<&i32>(e).unwrap();
 }
 
 #[test]
@@ -562,8 +562,8 @@ fn derived_bundle() {
 
     let mut world = World::new();
     let e = world.spawn(Foo { x: 42, y: 'a' });
-    assert_eq!(*world.get::<i32>(e).unwrap(), 42);
-    assert_eq!(*world.get::<char>(e).unwrap(), 'a');
+    assert_eq!(*world.get::<&i32>(e).unwrap(), 42);
+    assert_eq!(*world.get::<&char>(e).unwrap(), 'a');
 }
 
 #[test]
@@ -623,14 +623,14 @@ fn exchange_components() {
     let mut world = World::new();
 
     let entity = world.spawn(("abc".to_owned(), 123));
-    assert!(world.get::<String>(entity).is_ok());
-    assert!(world.get::<i32>(entity).is_ok());
-    assert!(world.get::<bool>(entity).is_err());
+    assert!(world.get::<&String>(entity).is_ok());
+    assert!(world.get::<&i32>(entity).is_ok());
+    assert!(world.get::<&bool>(entity).is_err());
 
     world.exchange_one::<String, _>(entity, true).unwrap();
-    assert!(world.get::<String>(entity).is_err());
-    assert!(world.get::<i32>(entity).is_ok());
-    assert!(world.get::<bool>(entity).is_ok());
+    assert!(world.get::<&String>(entity).is_err());
+    assert!(world.get::<&i32>(entity).is_ok());
+    assert!(world.get::<&bool>(entity).is_ok());
 }
 
 #[test]
@@ -772,9 +772,9 @@ fn spawn_column_batch() {
             .spawn_column_batch(batch.build().unwrap())
             .collect::<Vec<_>>();
         assert_eq!(entities.len(), 2);
-        assert_eq!(*world.get::<i32>(b).unwrap(), 43);
-        assert_eq!(*world.get::<i32>(entities[0]).unwrap(), 44);
-        assert_eq!(*world.get::<i32>(entities[1]).unwrap(), 45);
+        assert_eq!(*world.get::<&i32>(b).unwrap(), 43);
+        assert_eq!(*world.get::<&i32>(entities[0]).unwrap(), 44);
+        assert_eq!(*world.get::<&i32>(entities[1]).unwrap(), 45);
     }
 }
 
@@ -840,7 +840,7 @@ fn column_get_mut() {
         *column.get(ent).unwrap() = 99;
         assert_eq!(*column.get(ent).unwrap(), 99);
     }
-    assert_eq!(*world.get::<i32>(ent).unwrap(), 99);
+    assert_eq!(*world.get::<&i32>(ent).unwrap(), 99);
 }
 
 #[test]
@@ -864,10 +864,10 @@ fn take() {
     let mut world_b = World::new();
     let e2 = world_b.spawn(world_a.take(e).unwrap());
     assert!(!world_a.contains(e));
-    assert_eq!(*world_b.get::<String>(e2).unwrap(), "abc");
-    assert_eq!(*world_b.get::<i32>(e2).unwrap(), 42);
-    assert_eq!(*world_a.get::<String>(f).unwrap(), "def");
-    assert_eq!(*world_a.get::<i32>(f).unwrap(), 17);
+    assert_eq!(*world_b.get::<&String>(e2).unwrap(), "abc");
+    assert_eq!(*world_b.get::<&i32>(e2).unwrap(), 42);
+    assert_eq!(*world_a.get::<&String>(f).unwrap(), "def");
+    assert_eq!(*world_a.get::<&i32>(f).unwrap(), 17);
     world_b.take(e2).unwrap();
     assert!(!world_b.contains(e2));
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -788,11 +788,11 @@ fn columnar_access() {
     let _empty = archetypes.next().unwrap();
     let a = archetypes.next().unwrap();
     assert_eq!(a.ids(), &[e.id()]);
-    assert_eq!(*a.get::<i32>().unwrap(), [123]);
-    assert!(a.get::<bool>().is_none());
+    assert_eq!(*a.get::<&i32>().unwrap(), [123]);
+    assert!(a.get::<&bool>().is_none());
     let b = archetypes.next().unwrap();
     assert_eq!(b.ids(), &[f.id(), g.id()]);
-    assert_eq!(*b.get::<i32>().unwrap(), [456, 789]);
+    assert_eq!(*b.get::<&i32>().unwrap(), [456, 789]);
 }
 
 #[test]


### PR DESCRIPTION
Many users have reported confusion arising from the use of component types in `World::get` in contrast to the use of reference sin `World::query` and friends. This replaces `get` and `get_mut` on `World` and `EntityRef` with a single `get` that is generic over *references to components*, so that the intuitive thing Just Works, and passing an explicit component type generates a trait error.

For consistency, `EntityBuilder:;get` and `get_mut` are both refactored similarly, although they cannot be combined into a single method as they do not perform dynamic borrow checking.

This also resolves the inconsistency between `get_mut` referring to the mutability of the component borrow, while other `_mut` methods on `World` instead refer to the mutability of the world borrow.