### PR TITLE
Don't borrow-check empty archetypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+### Fixed
+- Empty archetypes no longer participate in dynamic query borrow-checking
+
 # 0.8.0
 
 ### Added

--- a/src/query.rs
+++ b/src/query.rs
@@ -612,6 +612,9 @@ impl<'w, Q: Query> QueryBorrow<'w, Q> {
             return;
         }
         for x in self.archetypes {
+            if x.is_empty() {
+                continue;
+            }
             // TODO: Release prior borrows on failure?
             if let Some(state) = Q::Fetch::prepare(x) {
                 Q::Fetch::borrow(x, state);
@@ -689,6 +692,9 @@ impl<'w, Q: Query> Drop for QueryBorrow<'w, Q> {
     fn drop(&mut self) {
         if self.borrowed {
             for x in self.archetypes {
+                if x.is_empty() {
+                    continue;
+                }
                 if let Some(state) = Q::Fetch::prepare(x) {
                     Q::Fetch::release(x, state);
                 }
@@ -1147,6 +1153,9 @@ impl<'q, Q: Query> PreparedQueryBorrow<'q, Q> {
         fetch: &'q mut [Option<Q::Fetch>],
     ) -> Self {
         for (idx, state) in state {
+            if archetypes[*idx].is_empty() {
+                continue;
+            }
             Q::Fetch::borrow(&archetypes[*idx], *state);
         }
 
@@ -1179,6 +1188,9 @@ impl<'q, Q: Query> PreparedQueryBorrow<'q, Q> {
 impl<Q: Query> Drop for PreparedQueryBorrow<'_, Q> {
     fn drop(&mut self) {
         for (idx, state) in self.state {
+            if self.archetypes[*idx].is_empty() {
+                continue;
+            }
             Q::Fetch::release(&self.archetypes[*idx], *state);
         }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -871,3 +871,15 @@ fn take() {
     world_b.take(e2).unwrap();
     assert!(!world_b.contains(e2));
 }
+
+#[test]
+fn empty_archetype_conflict() {
+    let mut world = World::new();
+    let _ = world.spawn((42, true));
+    let _ = world.spawn((17, "abc"));
+    let e = world.spawn((12, false, "def"));
+    world.despawn(e).unwrap();
+    for _ in world.query::<(&mut i32, &&str)>().iter() {
+        for _ in world.query::<(&mut i32, &bool)>().iter() {}
+    }
+}


### PR DESCRIPTION
Saves some atomics and makes cheeky overlapping queries more reliable.