### PR TITLE
Extend no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["std", "atomic"]
+default = ["std", "spin"]
 std = []
-atomic = ["spin"]
-atomic-polyfill = ["once_cell/atomic-polyfill", "dep:atomic-polyfill"]
+enable-atomic-polyfill = ["once_cell/atomic-polyfill", "atomic-polyfill"]
 # Enables derive(Bundle)
 macros = ["hecs-macros", "once_cell"]
 # Enables the serialize::column module

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["std"]
+default = ["std", "atomic"]
 std = []
+atomic = ["spin"]
+atomic-polyfill = ["dep:atomic-polyfill"]
 # Enables derive(Bundle)
 macros = ["hecs-macros", "lazy_static"]
 # Enables the serialize::column module
@@ -29,11 +31,12 @@ column-serialize = ["serde"]
 row-serialize = ["serde"]
 
 [dependencies]
+atomic-polyfill = { version = "0.1.7", optional = true }
 hecs-macros = { path = "macros", version = "0.8.2", optional = true }
 hashbrown = { version = "0.12.0", default-features = false, features = ["ahash", "inline-more"] }
 lazy_static = { version = "1.4.0", optional = true, features = ["spin_no_std"] }
 serde = { version = "1.0.117", default-features = false, optional = true }
-spin = { version = "0.9.2", default-features = false, features = ["mutex", "spin_mutex"] }
+spin = { version = "0.9.2", default-features = false, optional = true, features = ["mutex", "spin_mutex"] }
 
 [dev-dependencies]
 bencher = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ maintenance = { status = "actively-developed" }
 default = ["std", "atomic"]
 std = []
 atomic = ["spin"]
-atomic-polyfill = ["dep:atomic-polyfill"]
+atomic-polyfill = ["once_cell/atomic-polyfill", "dep:atomic-polyfill"]
 # Enables derive(Bundle)
-macros = ["hecs-macros", "lazy_static"]
+macros = ["hecs-macros", "once_cell"]
 # Enables the serialize::column module
 column-serialize = ["serde"]
 # Enables the serialize::row module
@@ -34,7 +34,7 @@ row-serialize = ["serde"]
 atomic-polyfill = { version = "0.1.7", optional = true }
 hecs-macros = { path = "macros", version = "0.8.2", optional = true }
 hashbrown = { version = "0.12.0", default-features = false, features = ["ahash", "inline-more"] }
-lazy_static = { version = "1.4.0", optional = true, features = ["spin_no_std"] }
+once_cell = { version = "1.12.0", default-features = false, optional = true, features = ["alloc"] }
 serde = { version = "1.0.117", default-features = false, optional = true }
 spin = { version = "0.9.2", default-features = false, optional = true, features = ["mutex", "spin_mutex"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["std", "spin"]
+default = ["std", "prepared-queries"]
 std = []
+prepared-queries = []
 enable-atomic-polyfill = ["once_cell/atomic-polyfill", "atomic-polyfill"]
 # Enables derive(Bundle)
 macros = ["hecs-macros", "once_cell"]
@@ -35,7 +36,6 @@ hecs-macros = { path = "macros", version = "0.8.2", optional = true }
 hashbrown = { version = "0.12.0", default-features = false, features = ["ahash", "inline-more"] }
 once_cell = { version = "1.12.0", default-features = false, optional = true, features = ["alloc"] }
 serde = { version = "1.0.117", default-features = false, optional = true }
-spin = { version = "0.9.2", default-features = false, optional = true, features = ["mutex", "spin_mutex"] }
 
 [dev-dependencies]
 bencher = "0.1.5"
@@ -48,6 +48,10 @@ serde_test = "1.0.117"
 name = "bench"
 harness = false
 required-features = ["macros"]
+
+[[example]]
+name = "ffa_simulation"
+required-features = ["prepared-queries"]
 
 [profile.release]
 debug = true

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -9,6 +9,10 @@ license = "Apache-2.0"
 [lib]
 proc-macro = true
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
 syn = { version = "1.0", default-features = false, features = ["proc-macro", "parsing", "printing", "derive", "clone-impls", "visit-mut"] }
 quote = "1.0.3"

--- a/macros/src/bundle.rs
+++ b/macros/src/bundle.rs
@@ -1,5 +1,4 @@
-use std::borrow::Cow;
-
+use crate::alloc::borrow::Cow;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{DeriveInput, Error, Result};
@@ -45,19 +44,19 @@ fn gen_dynamic_bundle_impl(
                 ::core::option::Option::Some(::core::any::TypeId::of::<Self>())
             }
 
-            fn with_ids<__hecs__T>(&self, f: impl ::std::ops::FnOnce(&[::std::any::TypeId]) -> __hecs__T) -> __hecs__T {
+            fn with_ids<__hecs__T>(&self, f: impl ::core::ops::FnOnce(&[::core::any::TypeId]) -> __hecs__T) -> __hecs__T {
                 <Self as ::hecs::Bundle>::with_static_ids(f)
             }
 
-            fn type_info(&self) -> ::std::vec::Vec<::hecs::TypeInfo> {
+            fn type_info(&self) -> ::hecs::alloc::vec::Vec<::hecs::TypeInfo> {
                 <Self as ::hecs::Bundle>::with_static_type_info(|info| info.to_vec())
             }
 
             #[allow(clippy::forget_copy, clippy::forget_non_drop)]
-            unsafe fn put(mut self, mut f: impl ::std::ops::FnMut(*mut u8, ::hecs::TypeInfo)) {
+            unsafe fn put(mut self, mut f: impl ::core::ops::FnMut(*mut u8, ::hecs::TypeInfo)) {
                 #(
                     f((&mut self.#field_members as *mut #tys).cast::<u8>(), ::hecs::TypeInfo::of::<#tys>());
-                    ::std::mem::forget(self.#field_members);
+                    ::core::mem::forget(self.#field_members);
                 )*
             }
         }
@@ -75,14 +74,14 @@ fn gen_bundle_impl(
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let with_static_ids_inner = quote! {
         {
-            let mut tys = [#((::std::mem::align_of::<#tys>(), ::std::any::TypeId::of::<#tys>())),*];
+            let mut tys = [#((::core::mem::align_of::<#tys>(), ::core::any::TypeId::of::<#tys>())),*];
             tys.sort_unstable_by(|x, y| {
-                ::std::cmp::Ord::cmp(&x.0, &y.0)
+                ::core::cmp::Ord::cmp(&x.0, &y.0)
                     .reverse()
-                    .then(::std::cmp::Ord::cmp(&x.1, &y.1))
+                    .then(::core::cmp::Ord::cmp(&x.1, &y.1))
             });
-            let mut ids = [::std::any::TypeId::of::<()>(); #num_tys];
-            for (id, info) in ::std::iter::Iterator::zip(ids.iter_mut(), tys.iter()) {
+            let mut ids = [::core::any::TypeId::of::<()>(); #num_tys];
+            for (id, info) in ::core::iter::Iterator::zip(ids.iter_mut(), tys.iter()) {
                 *id = info.1;
             }
             ids
@@ -105,27 +104,27 @@ fn gen_bundle_impl(
     quote! {
         unsafe impl #impl_generics ::hecs::Bundle for #ident #ty_generics #where_clause {
             #[allow(non_camel_case_types)]
-            fn with_static_ids<__hecs__T>(f: impl ::std::ops::FnOnce(&[::std::any::TypeId]) -> __hecs__T) -> __hecs__T {
+            fn with_static_ids<__hecs__T>(f: impl ::core::ops::FnOnce(&[::core::any::TypeId]) -> __hecs__T) -> __hecs__T {
                 #with_static_ids_body
             }
 
             #[allow(non_camel_case_types)]
-            fn with_static_type_info<__hecs__T>(f: impl ::std::ops::FnOnce(&[::hecs::TypeInfo]) -> __hecs__T) -> __hecs__T {
+            fn with_static_type_info<__hecs__T>(f: impl ::core::ops::FnOnce(&[::hecs::TypeInfo]) -> __hecs__T) -> __hecs__T {
                 let mut info: [::hecs::TypeInfo; #num_tys] = [#(::hecs::TypeInfo::of::<#tys>()),*];
                 info.sort_unstable();
                 f(&info)
             }
 
             unsafe fn get(
-                mut f: impl ::std::ops::FnMut(::hecs::TypeInfo) -> ::std::option::Option<::std::ptr::NonNull<u8>>,
-            ) -> ::std::result::Result<Self, ::hecs::MissingComponent> {
+                mut f: impl ::core::ops::FnMut(::hecs::TypeInfo) -> ::core::option::Option<::core::ptr::NonNull<u8>>,
+            ) -> ::core::result::Result<Self, ::hecs::MissingComponent> {
                 #(
                     let #field_idents = f(::hecs::TypeInfo::of::<#tys>())
                             .ok_or_else(::hecs::MissingComponent::new::<#tys>)?
                             .cast::<#tys>()
                             .as_ptr();
                 )*
-                ::std::result::Result::Ok(Self { #( #field_members: #field_idents.read(), )* })
+                ::core::result::Result::Ok(Self { #( #field_members: #field_idents.read(), )* })
             }
         }
     }
@@ -137,14 +136,14 @@ fn gen_unit_struct_bundle_impl(ident: syn::Ident, generics: &syn::Generics) -> T
     quote! {
         unsafe impl #impl_generics ::hecs::Bundle for #ident #ty_generics #where_clause {
             #[allow(non_camel_case_types)]
-            fn with_static_ids<__hecs__T>(f: impl ::std::ops::FnOnce(&[::std::any::TypeId]) -> __hecs__T) -> __hecs__T { f(&[]) }
+            fn with_static_ids<__hecs__T>(f: impl ::core::ops::FnOnce(&[::core::any::TypeId]) -> __hecs__T) -> __hecs__T { f(&[]) }
             #[allow(non_camel_case_types)]
-            fn with_static_type_info<__hecs__T>(f: impl ::std::ops::FnOnce(&[::hecs::TypeInfo]) -> __hecs__T) -> __hecs__T { f(&[]) }
+            fn with_static_type_info<__hecs__T>(f: impl ::core::ops::FnOnce(&[::hecs::TypeInfo]) -> __hecs__T) -> __hecs__T { f(&[]) }
 
             unsafe fn get(
-                mut f: impl ::std::ops::FnMut(::hecs::TypeInfo) -> ::std::option::Option<::std::ptr::NonNull<u8>>,
-            ) -> ::std::result::Result<Self, ::hecs::MissingComponent> {
-                ::std::result::Result::Ok(Self {/* for some reason this works for all unit struct variations */})
+                mut f: impl ::core::ops::FnMut(::hecs::TypeInfo) -> ::core::option::Option<::core::ptr::NonNull<u8>>,
+            ) -> ::core::result::Result<Self, ::hecs::MissingComponent> {
+                ::core::result::Result::Ok(Self {/* for some reason this works for all unit struct variations */})
             }
         }
     }

--- a/macros/src/bundle_clone.rs
+++ b/macros/src/bundle_clone.rs
@@ -32,14 +32,14 @@ fn gen_dynamic_bundle_impl(
     quote! {
         unsafe impl #impl_generics ::hecs::DynamicBundleClone for #ident #ty_generics #where_clause {
             #[allow(clippy::forget_copy)]
-            unsafe fn put_with_clone(mut self, mut f: impl ::std::ops::FnMut(*mut u8, ::hecs::TypeInfo, ::hecs::DynamicClone)) {
+            unsafe fn put_with_clone(mut self, mut f: impl ::core::ops::FnMut(*mut u8, ::hecs::TypeInfo, ::hecs::DynamicClone)) {
                 #(
                     f(
                         (&mut self.#field_members as *mut #tys).cast::<u8>(),
                         ::hecs::TypeInfo::of::<#tys>(),
                         ::hecs::DynamicClone::new::<#tys>()
                     );
-                    ::std::mem::forget(self.#field_members);
+                    ::core::mem::forget(self.#field_members);
                 )*
             }
         }
@@ -51,7 +51,7 @@ fn make_component_trait_bound() -> syn::TraitBound {
         paren_token: None,
         modifier: syn::TraitBoundModifier::None,
         lifetimes: None,
-        path: syn::parse_quote!(::std::clone::Clone),
+        path: syn::parse_quote!(::core::clone::Clone),
     }
 }
 

--- a/macros/src/common.rs
+++ b/macros/src/common.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use crate::alloc::{borrow::Cow, vec::Vec, format};
 
 use proc_macro2::Span;
 

--- a/macros/src/common.rs
+++ b/macros/src/common.rs
@@ -1,4 +1,4 @@
-use crate::alloc::{borrow::Cow, vec::Vec, format};
+use crate::alloc::{borrow::Cow, format, vec::Vec};
 
 use proc_macro2::Span;
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -5,6 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+extern crate alloc;
+
 extern crate proc_macro;
 
 mod bundle;

--- a/macros/src/query.rs
+++ b/macros/src/query.rs
@@ -1,3 +1,5 @@
+use alloc::format;
+use alloc::vec::Vec;
 use proc_macro2::Span;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
@@ -125,12 +127,12 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
             }
 
             #[allow(unused_variables, unused_mut)]
-            fn access(archetype: &::hecs::Archetype) -> ::std::option::Option<::hecs::Access> {
+            fn access(archetype: &::hecs::Archetype) -> ::core::option::Option<::hecs::Access> {
                 let mut access = ::hecs::Access::Iterate;
                 #(
                     access = ::core::cmp::max(access, #fetches::access(archetype)?);
                 )*
-                ::std::option::Option::Some(access)
+                ::core::option::Option::Some(access)
             }
 
             #[allow(unused_variables)]
@@ -139,8 +141,8 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream2> {
             }
 
             #[allow(unused_variables)]
-            fn prepare(archetype: &::hecs::Archetype) -> ::std::option::Option<Self::State> {
-                ::std::option::Option::Some(#state_ident {
+            fn prepare(archetype: &::hecs::Archetype) -> ::core::option::Option<Self::State> {
+                ::core::option::Option::Some(#state_ident {
                     #(
                         #fields: #fetches::prepare(archetype)?,
                     )*

--- a/src/borrow.rs
+++ b/src/borrow.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use core::sync::atomic::{AtomicUsize, Ordering};
+use crate::atomic::{AtomicUsize, Ordering};
 
 /// A bit mask used to signal the `AtomicBorrow` has an active mutable borrow.
 const UNIQUE_BIT: usize = !(usize::max_value() >> 1);

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -4,7 +4,8 @@ use core::convert::TryFrom;
 use core::iter::ExactSizeIterator;
 use core::num::{NonZeroU32, NonZeroU64};
 use core::ops::Range;
-use core::sync::atomic::{AtomicIsize, Ordering};
+
+use crate::atomic::{AtomicIsize, Ordering};
 use core::{fmt, mem};
 #[cfg(feature = "std")]
 use std::error::Error;

--- a/src/entity_builder.rs
+++ b/src/entity_builder.rs
@@ -115,7 +115,6 @@ unsafe impl DynamicBundle for BuiltEntity<'_> {
         f(&self.builder.ids)
     }
 
-    #[doc(hidden)]
     fn type_info(&self) -> Vec<TypeInfo> {
         self.builder.info.iter().map(|x| x.0).collect()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub use archetype::TypeInfo;
 pub use bundle::DynamicClone;
 #[cfg(feature = "macros")]
 #[doc(hidden)]
-pub use lazy_static;
+pub use once_cell;
 #[doc(hidden)]
 pub use query::Fetch;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,13 @@ pub use lazy_static;
 #[doc(hidden)]
 pub use query::Fetch;
 
+#[cfg(feature = "atomic-polyfill")]
+#[doc(hidden)]
+pub use atomic_polyfill as atomic;
+#[cfg(not(feature = "atomic-polyfill"))]
+#[doc(hidden)]
+pub use core::sync::atomic;
+
 #[cfg(feature = "macros")]
 pub use hecs_macros::{Bundle, DynamicBundleClone, Query};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,10 +79,11 @@ pub use entities::{Entity, NoSuchEntity};
 pub use entity_builder::{BuiltEntity, BuiltEntityClone, EntityBuilder, EntityBuilderClone};
 pub use entity_ref::{ComponentRef, ComponentRefShared, EntityRef, Ref, RefMut};
 pub use query::{
-    Access, Batch, BatchedIter, Or, PreparedQuery, PreparedQueryBorrow, PreparedQueryIter,
-    PreparedView, Query, QueryBorrow, QueryItem, QueryIter, QueryMut, QueryShared, Satisfies, View,
+    Access, Batch, BatchedIter, Or, Query, QueryBorrow, QueryItem, QueryIter, QueryMut, QueryShared, Satisfies, View,
     With, Without,
 };
+#[cfg(feature = "prepared-queries")]
+pub use query::{PreparedQuery, PreparedQueryBorrow, PreparedQueryIter, PreparedView};
 pub use query_one::QueryOne;
 pub use take::TakenEntity;
 pub use world::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 #[cfg(feature = "std")]
 extern crate std;
 
-extern crate alloc;
+pub extern crate alloc;
 
 /// Imagine macro parameters, but more like those Russian dolls.
 ///

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -167,6 +167,7 @@ fn query_optional_component() {
 }
 
 #[test]
+#[cfg(feature = "prepared-queries")]
 fn prepare_query() {
     let mut world = World::new();
     let e = world.spawn(("abc", 123));
@@ -193,6 +194,7 @@ fn prepare_query() {
 }
 
 #[test]
+#[cfg(feature = "prepared-queries")]
 fn invalidate_prepared_query() {
     let mut world = World::new();
     let e = world.spawn(("abc", 123));
@@ -223,6 +225,7 @@ fn invalidate_prepared_query() {
 }
 
 #[test]
+#[cfg(feature = "prepared-queries")]
 fn random_access_via_view() {
     let mut world = World::new();
     let e = world.spawn(("abc", 123));
@@ -240,6 +243,7 @@ fn random_access_via_view() {
 }
 
 #[test]
+#[cfg(feature = "prepared-queries")]
 fn random_access_via_view_mut() {
     let mut world = World::new();
     let e = world.spawn(("abc", 123));


### PR DESCRIPTION
Feedback very much welcome as I haven't studied this library in close enough detail to see the full consequences of this PR.

I've changed a few things:
1. Switched from std to core and alloc in macros, fixing #106.
2. Added atomic-polyfill as an optional feature to support targets which don't have full atomic CAS support.
3. As lazy_static does not support atomic-polyfill, I changed over to using once_cell::race::OnceBox instead. The downside to using a OnceBox is that multiple threads can start generating the same cell, but in the end only the first completed cell is used. The upside is that it requires simpler synchronization primitives.
4. Added a default-enabled feature `atomic` which enables creating worlds with the atomically increasing ID that is currently used in `World::new()` and `World::default()`. When disabled the function `World::new_with_id(id: u64)` must be used instead.

1 and 2 feel pretty natural, but 3 and 4 definitely requires some scrutiny to ensure I didn't mess something up. The tests run green and the Bundle derive macro seems to work as well.