### PR TITLE
implemented `has`

### DIFF
--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -59,19 +59,6 @@ pub unsafe trait DynamicBundle {
 /// interface of this trait, except `has_static`, is a private implementation detail.
 #[allow(clippy::missing_safety_doc)]
 pub unsafe trait Bundle: DynamicBundle {
-    /// Checks if the Bundle contains the given `T`:
-    ///
-    /// ```
-    /// fn test_bundle<T: hecs::Bundle>(input: T) {
-    ///     assert!(T::has_static::<i32>());
-    ///     assert!(T::has_static::<f32>());
-    ///     assert!(!T::has_static::<usize>());
-    /// }
-    /// ```
-    fn has_static<T: Component>() -> bool {
-        Self::with_static_ids(|types| types.contains(&TypeId::of::<T>()))
-    }
-
     #[doc(hidden)]
     fn with_static_ids<T>(f: impl FnOnce(&[TypeId]) -> T) -> T;
 
@@ -144,6 +131,16 @@ impl std::error::Error for MissingComponent {}
 macro_rules! tuple_impl {
     ($($name: ident),*) => {
         unsafe impl<$($name: Component),*> DynamicBundle for ($($name,)*) {
+            fn has<T: Component>(&self) -> bool {
+                $(
+                    if TypeId::of::<$name>() == TypeId::of::<T>() {
+                        return true;
+                    }
+                )*
+
+                false
+            }
+
             fn key(&self) -> Option<TypeId> {
                 Some(TypeId::of::<Self>())
             }

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -16,13 +16,27 @@ use crate::Component;
 /// A dynamically typed collection of components
 ///
 /// Bundles composed of exactly the same types are semantically equivalent, regardless of order. The
-/// interface of this trait is a private implementation detail.
+/// interface of this trait, except `has` is a private implementation detail.
 #[allow(clippy::missing_safety_doc)]
 pub unsafe trait DynamicBundle {
     /// Returns a `TypeId` uniquely identifying the set of components, if known
     #[doc(hidden)]
     fn key(&self) -> Option<TypeId> {
         None
+    }
+
+    /// Checks if the Bundle contains the given `T`:
+    ///
+    /// ```
+    /// # use hecs::DynamicBundle;
+    ///
+    /// let my_bundle = (0i32, 10.0f32);
+    /// assert!(my_bundle.has::<i32>());
+    /// assert!(my_bundle.has::<f32>());
+    /// assert!(!my_bundle.has::<usize>());
+    /// ```
+    fn has<T: Component>(&self) -> bool {
+        self.with_ids(|types| types.contains(&TypeId::of::<T>()))
     }
 
     /// Invoke a callback on the fields' type IDs, sorted by descending alignment then id
@@ -42,9 +56,22 @@ pub unsafe trait DynamicBundle {
 /// A statically typed collection of components
 ///
 /// Bundles composed of exactly the same types are semantically equivalent, regardless of order. The
-/// interface of this trait is a private implementation detail.
+/// interface of this trait, except `has_static`, is a private implementation detail.
 #[allow(clippy::missing_safety_doc)]
 pub unsafe trait Bundle: DynamicBundle {
+    /// Checks if the Bundle contains the given `T`:
+    ///
+    /// ```
+    /// fn test_bundle<T: hecs::Bundle>(input: T) {
+    ///     assert!(T::has_static::<i32>());
+    ///     assert!(T::has_static::<f32>());
+    ///     assert!(!T::has_static::<usize>());
+    /// }
+    /// ```
+    fn has_static<T: Component>() -> bool {
+        Self::with_static_ids(|types| types.contains(&TypeId::of::<T>()))
+    }
+
     #[doc(hidden)]
     fn with_static_ids<T>(f: impl FnOnce(&[TypeId]) -> T) -> T;
 


### PR DESCRIPTION
Added `has` and `has_static`. I went with `has_static` instead of `static_has` for the sake of autocompletion, but not sure if you have a preference.

Moreover, adjusted documentation to make these two functions a public member of the interface.
