### PR TITLE
clippy lints fixed

### DIFF
--- a/examples/format.rs
+++ b/examples/format.rs
@@ -1,19 +1,20 @@
 //! One way to the contents of an entity, as you might do for debugging. A similar pattern could
 //! also be useful for serialization, or other row-oriented generic operations.
 
+type FormattingFunction = &'static dyn Fn(hecs::EntityRef<'_>) -> Option<String>;
+
 fn format_entity(entity: hecs::EntityRef<'_>) -> String {
     fn fmt<T: hecs::Component + std::fmt::Display>(entity: hecs::EntityRef<'_>) -> Option<String> {
         Some(entity.get::<&T>()?.to_string())
     }
 
-    const FUNCTIONS: &[&dyn Fn(hecs::EntityRef<'_>) -> Option<String>] =
-        &[&fmt::<i32>, &fmt::<bool>, &fmt::<f64>];
+    const FUNCTIONS: &[FormattingFunction] = &[&fmt::<i32>, &fmt::<bool>, &fmt::<f64>];
 
     let mut out = String::new();
     for f in FUNCTIONS {
         if let Some(x) = f(entity) {
             if out.is_empty() {
-                out.push_str("[");
+                out.push('[');
             } else {
                 out.push_str(", ");
             }
@@ -21,7 +22,7 @@ fn format_entity(entity: hecs::EntityRef<'_>) -> String {
         }
     }
     if out.is_empty() {
-        out.push_str(&"[]");
+        out.push_str("[]");
     } else {
         out.push(']');
     }

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -17,9 +17,9 @@ fn derive() {
         "export.rs",
     ];
     for &passing_test in successes {
-        t.pass(&format!("{}/{}", TEST_DIR, passing_test));
+        t.pass(format!("{}/{}", TEST_DIR, passing_test));
     }
     for &failing_test in failures {
-        t.compile_fail(&format!("{}/{}", TEST_DIR, failing_test));
+        t.compile_fail(format!("{}/{}", TEST_DIR, failing_test));
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -331,12 +331,13 @@ fn build_builder_clone() {
 }
 
 #[test]
+#[allow(clippy::redundant_clone)]
 fn cloned_builder() {
     let mut builder = EntityBuilderClone::new();
     builder.add(String::from("abc")).add(123);
 
     let mut world = World::new();
-    let e = world.spawn(&builder.build());
+    let e = world.spawn(&builder.build().clone());
     assert_eq!(*world.get::<&String>(e).unwrap(), "abc");
     assert_eq!(*world.get::<&i32>(e).unwrap(), 123);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -336,7 +336,7 @@ fn cloned_builder() {
     builder.add(String::from("abc")).add(123);
 
     let mut world = World::new();
-    let e = world.spawn(&builder.build().clone());
+    let e = world.spawn(&builder.build());
     assert_eq!(*world.get::<&String>(e).unwrap(), "abc");
     assert_eq!(*world.get::<&i32>(e).unwrap(), 123);
 }
@@ -457,15 +457,16 @@ fn spawn_buffered_entity() {
 
     buffer.insert(ent, (1, true));
     buffer.insert(ent1, (13, 7.11, "hecs"));
-    buffer.insert(ent2, (17 as i8, false, 'o'));
-    buffer.insert(ent3, (2 as u8, "qwe", 101.103, false));
+    buffer.insert(ent2, (17i8, false, 'o'));
+    buffer.insert(ent3, (2u8, "qwe", 101.103, false));
 
     buffer.run_on(&mut world);
 
-    assert_eq!(*world.get::<&bool>(ent).unwrap(), true);
+    assert!(*world.get::<&bool>(ent).unwrap());
+    assert!(!*world.get::<&bool>(ent2).unwrap());
+
     assert_eq!(*world.get::<&&str>(ent1).unwrap(), "hecs");
     assert_eq!(*world.get::<&i32>(ent1).unwrap(), 13);
-    assert_eq!(*world.get::<&bool>(ent2).unwrap(), false);
     assert_eq!(*world.get::<&u8>(ent3).unwrap(), 2);
 }
 
@@ -724,12 +725,8 @@ fn query_mut_batched() {
 fn spawn_batch() {
     let mut world = World::new();
     world.spawn_batch((0..10).map(|x| (x, "abc")));
-    let entities = world
-        .query::<&i32>()
-        .iter()
-        .map(|(_, &x)| x)
-        .collect::<Vec<_>>();
-    assert_eq!(entities.len(), 10);
+    let entity_count = world.query::<&i32>().iter().count();
+    assert_eq!(entity_count, 10);
 }
 
 #[test]


### PR DESCRIPTION
Fixed the various lints clippy throws right now. Some of these are uglier fixes, but it makes working in this repo nicer by reducing warnings.
