### PR TITLE
Implement updating components in command buffers

### DIFF
--- a/src/command_buffer.rs
+++ b/src/command_buffer.rs
@@ -137,7 +137,7 @@ impl CommandBuffer {
         })));
     }
 
-    /// Updates all entities satisfying the query with the given function
+    /// Updates an entity with the given function if it satisfies the query
     pub fn update_one<Q, F>(&mut self, ent: Entity, update_fn: F)
     where
         Q: Query,

--- a/src/command_buffer.rs
+++ b/src/command_buffer.rs
@@ -137,6 +137,19 @@ impl CommandBuffer {
         })));
     }
 
+    /// Updates all entities satisfying the query with the given function
+    pub fn update_one<Q, F>(&mut self, ent: Entity, update_fn: F)
+    where
+        Q: Query,
+        F: for<'a> Fn(Q::Item<'a>) + Send + Sync + 'static,
+    {
+        self.update_comps.push(UpdatedComps(Box::new(move |world| {
+            if let Ok(components) = world.query_one_mut::<Q>(ent) {
+                update_fn(components);
+            }
+        })));
+    }
+
     /// Despawn `entity` from World
     pub fn despawn(&mut self, entity: Entity) {
         self.despawn_ent.push(entity);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -521,6 +521,27 @@ fn update_buffered_component() {
 }
 
 #[test]
+fn upsert_buffered_component() {
+    let mut world = World::new();
+    let ent = world.reserve_entity();
+    world.insert(ent, ("test",)).unwrap();
+
+    let mut buffer = CommandBuffer::new();
+    for i in 1..4 {
+        buffer.upsert_one::<(&mut Vec<u32>,), _, _, _>(
+            ent,
+            move || (vec![i],),
+            move |(vec,)| {
+                vec.push(i);
+            },
+        );
+    }
+    buffer.run_on(&mut world);
+
+    assert_eq!(*world.get::<&Vec<u32>>(ent).unwrap(), vec![1, 2, 3]);
+}
+
+#[test]
 #[should_panic(expected = "already borrowed")]
 fn illegal_borrow() {
     let mut world = World::new();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -499,7 +499,9 @@ fn remove_buffered_component() {
 fn update_buffered_component() {
     let mut world = World::new();
     let ent = world.reserve_entity();
+    let ent2 = world.reserve_entity();
     world.insert(ent, (true, 0i32)).unwrap();
+    world.insert(ent2, (true, 0i32)).unwrap();
 
     let mut buffer = CommandBuffer::new();
     for i in 1..5 {
@@ -507,9 +509,15 @@ fn update_buffered_component() {
             *num += i;
         });
     }
+    for i in 2..6 {
+        buffer.update_one::<(&mut i32,), _>(ent, move |(num,)| {
+            *num += i;
+        });
+    }
     buffer.run_on(&mut world);
 
-    assert_eq!(*world.get::<&i32>(ent).unwrap(), 10);
+    assert_eq!(*world.get::<&i32>(ent).unwrap(), 24);
+    assert_eq!(*world.get::<&i32>(ent2).unwrap(), 10);
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -496,7 +496,7 @@ fn remove_buffered_component() {
 }
 
 #[test]
-fn update_buffered_component() {
+fn buffered_commands() {
     let mut world = World::new();
     let ent = world.reserve_entity();
     let ent2 = world.reserve_entity();
@@ -505,40 +505,16 @@ fn update_buffered_component() {
 
     let mut buffer = CommandBuffer::new();
     for i in 1..5 {
-        buffer.update::<(&mut i32,), _>(move |_ent, (num,)| {
-            *num += i;
-        });
-    }
-    for i in 2..6 {
-        buffer.update_one::<(&mut i32,), _>(ent, move |(num,)| {
-            *num += i;
+        buffer.command(move |world| {
+            for (_ent, (num,)) in world.query_mut::<(&mut i32,)>() {
+                *num += i;
+            }
         });
     }
     buffer.run_on(&mut world);
 
-    assert_eq!(*world.get::<&i32>(ent).unwrap(), 24);
+    assert_eq!(*world.get::<&i32>(ent).unwrap(), 10);
     assert_eq!(*world.get::<&i32>(ent2).unwrap(), 10);
-}
-
-#[test]
-fn upsert_buffered_component() {
-    let mut world = World::new();
-    let ent = world.reserve_entity();
-    world.insert(ent, ("test",)).unwrap();
-
-    let mut buffer = CommandBuffer::new();
-    for i in 1..4 {
-        buffer.upsert_one::<(&mut Vec<u32>,), _, _, _>(
-            ent,
-            move || (vec![i],),
-            move |(vec,)| {
-                vec.push(i);
-            },
-        );
-    }
-    buffer.run_on(&mut world);
-
-    assert_eq!(*world.get::<&Vec<u32>>(ent).unwrap(), vec![1, 2, 3]);
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -496,6 +496,23 @@ fn remove_buffered_component() {
 }
 
 #[test]
+fn update_buffered_component() {
+    let mut world = World::new();
+    let ent = world.reserve_entity();
+    world.insert(ent, (true, 0i32)).unwrap();
+
+    let mut buffer = CommandBuffer::new();
+    for i in 1..5 {
+        buffer.update::<(&mut i32,), _>(move |_ent, (num,)| {
+            *num += i;
+        });
+    }
+    buffer.run_on(&mut world);
+
+    assert_eq!(*world.get::<&i32>(ent).unwrap(), 10);
+}
+
+#[test]
 #[should_panic(expected = "already borrowed")]
 fn illegal_borrow() {
     let mut world = World::new();


### PR DESCRIPTION
Adds the ability to command buffers to update entities' components. This can be used to implement operations on components such as incrementing a counter or appending to an array.