### PR TITLE
Fix `Satisfies` query access mode

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -547,8 +547,8 @@ unsafe impl<F: Fetch> Fetch for FetchSatisfies<F> {
         Self(false, PhantomData)
     }
 
-    fn access(archetype: &Archetype) -> Option<Access> {
-        F::access(archetype).map(|_| Access::Iterate)
+    fn access(_archetype: &Archetype) -> Option<Access> {
+        Some(Access::Iterate)
     }
 
     fn borrow(_archetype: &Archetype, _state: Self::State) {}


### PR DESCRIPTION
`Satisfies` does not exclude any entities.