### PR TITLE
Add `Ref::map` and `RefMut::map`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### Added
 - `Ref::map` and `RefMut::map` to reborrow a subfield of a component, or cast it to an unsized type
 
+### Fixed
+- `Ref::clone()` is now callable when containing types which do not implement `Clone`
+- `Ref::clone()` could cause a panic as internal state wasn't being updated correctly
+
 # 0.10.2
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+### Added
+- `Ref::map` and `RefMut::map` to reborrow a subfield of a component, or cast it to an unsized type
+
 # 0.10.2
 
 ### Fixed

--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -127,6 +127,12 @@ impl Archetype {
         }
     }
 
+    pub(crate) unsafe fn borrow_raw(&self, state: usize) {
+        if !self.data[state].state.borrow() {
+            panic!("state index {} already borrowed uniquely", state);
+        }
+    }
+
     pub(crate) fn borrow_mut<T: Component>(&self, state: usize) {
         assert_eq!(self.types[state].id, TypeId::of::<T>());
 
@@ -142,6 +148,14 @@ impl Archetype {
 
     pub(crate) fn release_mut<T: Component>(&self, state: usize) {
         assert_eq!(self.types[state].id, TypeId::of::<T>());
+        self.data[state].state.release_mut();
+    }
+
+    pub(crate) unsafe fn release_raw(&self, state: usize) {
+        self.data[state].state.release();
+    }
+
+    pub(crate) unsafe fn release_raw_mut(&self, state: usize) {
         self.data[state].state.release_mut();
     }
 

--- a/src/entity_ref.rs
+++ b/src/entity_ref.rs
@@ -1,6 +1,7 @@
 use core::any::TypeId;
 use core::fmt::{self, Debug, Formatter};
-use core::ops::{Deref, DerefMut};
+use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut, FnOnce};
 use core::ptr::NonNull;
 
 use crate::archetype::Archetype;
@@ -109,12 +110,10 @@ unsafe impl<'a> Send for EntityRef<'a> {}
 unsafe impl<'a> Sync for EntityRef<'a> {}
 
 /// Shared borrow of an entity's component
-#[derive(Clone)]
-pub struct Ref<'a, T: Component> {
-    archetype: &'a Archetype,
-    /// State index for `T` in `archetype`
-    state: usize,
+pub struct Ref<'a, T: ?Sized> {
+    borrow: ComponentBorrow<'a>,
     target: NonNull<T>,
+    _phantom: PhantomData<&'a T>,
 }
 
 impl<'a, T: Component> Ref<'a, T> {
@@ -122,48 +121,80 @@ impl<'a, T: Component> Ref<'a, T> {
         archetype: &'a Archetype,
         index: u32,
     ) -> Result<Self, MissingComponent> {
-        let state = archetype
-            .get_state::<T>()
-            .ok_or_else(MissingComponent::new::<T>)?;
-        let target =
-            NonNull::new_unchecked(archetype.get_base::<T>(state).as_ptr().add(index as usize));
-        archetype.borrow::<T>(state);
+        let (target, borrow) = ComponentBorrow::for_component::<T>(archetype, index)?;
         Ok(Self {
-            archetype,
-            state,
+            borrow,
             target,
+            _phantom: PhantomData,
         })
     }
 }
 
-unsafe impl<T: Component> Send for Ref<'_, T> {}
-unsafe impl<T: Component> Sync for Ref<'_, T> {}
+unsafe impl<T: ?Sized + Sync> Send for Ref<'_, T> {}
+unsafe impl<T: ?Sized + Sync> Sync for Ref<'_, T> {}
 
-impl<'a, T: Component> Drop for Ref<'a, T> {
-    fn drop(&mut self) {
-        self.archetype.release::<T>(self.state);
+impl<'a, T: ?Sized> Ref<'a, T> {
+    /// Makes a new `Ref<'_>` for a component of the borrowed component, e.g.
+    /// a struct field or enum variant.
+    ///
+    /// The `Ref<'_>` is already borrowed, so this cannot fail.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use hecs::{EntityRef, Ref};
+    /// struct Component {
+    ///     member: i32,
+    /// }
+    ///
+    /// # fn example(entity_ref: EntityRef<'_>) {
+    /// let component_ref = entity_ref.get::<&Component>()
+    ///     .expect("Entity does not contain an instance of \"Component\"");
+    /// let member_ref = Ref::map(component_ref, |component| &component.member);
+    /// println!("member = {:?}", *member_ref);
+    /// # }
+    /// ```
+    pub fn map<U: ?Sized, F>(orig: Ref<'a, T>, f: F) -> Ref<'a, U>
+    where
+        F: FnOnce(&T) -> &U,
+    {
+        let target = NonNull::from(f(&*orig));
+        Ref {
+            borrow: orig.borrow,
+            target,
+            _phantom: PhantomData,
+        }
     }
 }
 
-impl<'a, T: Component> Deref for Ref<'a, T> {
+impl<'a, T: ?Sized> Deref for Ref<'a, T> {
     type Target = T;
     fn deref(&self) -> &T {
         unsafe { self.target.as_ref() }
     }
 }
 
-impl<'a, T: Component + Debug> Debug for Ref<'a, T> {
+impl<'a, T: ?Sized + Debug> Debug for Ref<'a, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Debug::fmt(self.deref(), f)
     }
 }
 
+impl<'a, T: ?Sized> Clone for Ref<'a, T> {
+    fn clone(&self) -> Self {
+        Self {
+            borrow: self.borrow.clone(),
+            target: self.target.clone(),
+            _phantom: self._phantom.clone(),
+        }
+    }
+}
+
 /// Unique borrow of an entity's component
-pub struct RefMut<'a, T: Component> {
-    archetype: &'a Archetype,
-    /// State index for `T` in `archetype`
-    state: usize,
+pub struct RefMut<'a, T: ?Sized> {
+    borrow: ComponentBorrowMut<'a>,
     target: NonNull<T>,
+    _phantom: PhantomData<&'a mut T>,
 }
 
 impl<'a, T: Component> RefMut<'a, T> {
@@ -171,43 +202,67 @@ impl<'a, T: Component> RefMut<'a, T> {
         archetype: &'a Archetype,
         index: u32,
     ) -> Result<Self, MissingComponent> {
-        let state = archetype
-            .get_state::<T>()
-            .ok_or_else(MissingComponent::new::<T>)?;
-        let target =
-            NonNull::new_unchecked(archetype.get_base::<T>(state).as_ptr().add(index as usize));
-        archetype.borrow_mut::<T>(state);
+        let (target, borrow) = ComponentBorrowMut::for_component::<T>(archetype, index)?;
         Ok(Self {
-            archetype,
-            state,
+            borrow,
             target,
+            _phantom: PhantomData,
         })
     }
 }
 
-unsafe impl<T: Component> Send for RefMut<'_, T> {}
-unsafe impl<T: Component> Sync for RefMut<'_, T> {}
+unsafe impl<T: ?Sized + Send> Send for RefMut<'_, T> {}
+unsafe impl<T: ?Sized + Sync> Sync for RefMut<'_, T> {}
 
-impl<'a, T: Component> Drop for RefMut<'a, T> {
-    fn drop(&mut self) {
-        self.archetype.release_mut::<T>(self.state);
+impl<'a, T: ?Sized> RefMut<'a, T> {
+    /// Makes a new `RefMut<'_>` for a component of the borrowed component, e.g.
+    /// a struct field or enum variant.
+    ///
+    /// The `RefMut<'_>` is already mutably borrowed, so this cannot fail.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use hecs::{EntityRef, RefMut};
+    /// struct Component {
+    ///     member: i32,
+    /// }
+    ///
+    /// # fn example(entity_ref: EntityRef<'_>) {
+    /// let component_ref = entity_ref.get::<&mut Component>()
+    ///     .expect("Entity does not contain an instance of \"Component\"");
+    /// let mut member_ref = RefMut::map(component_ref, |component| &mut component.member);
+    /// *member_ref = 21;
+    /// println!("member = {:?}", *member_ref);
+    /// # }
+    /// ```
+    pub fn map<U: ?Sized, F>(mut orig: RefMut<'a, T>, f: F) -> RefMut<'a, U>
+    where
+        F: FnOnce(&mut T) -> &mut U,
+    {
+        let target = NonNull::from(f(&mut *orig));
+        RefMut {
+            borrow: orig.borrow,
+            target,
+            _phantom: PhantomData,
+        }
     }
 }
 
-impl<'a, T: Component> Deref for RefMut<'a, T> {
+impl<'a, T: ?Sized> Deref for RefMut<'a, T> {
     type Target = T;
     fn deref(&self) -> &T {
         unsafe { self.target.as_ref() }
     }
 }
 
-impl<'a, T: Component> DerefMut for RefMut<'a, T> {
+impl<'a, T: ?Sized> DerefMut for RefMut<'a, T> {
     fn deref_mut(&mut self) -> &mut T {
         unsafe { self.target.as_mut() }
     }
 }
 
-impl<'a, T: Component + Debug> Debug for RefMut<'a, T> {
+impl<'a, T: ?Sized + Debug> Debug for RefMut<'a, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Debug::fmt(self.deref(), f)
     }
@@ -294,3 +349,79 @@ impl<'a, T: Component> ComponentRef<'a> for &'a mut T {
 pub trait ComponentRefShared<'a>: ComponentRef<'a> {}
 
 impl<'a, T: Component> ComponentRefShared<'a> for &'a T {}
+
+struct ComponentBorrow<'a> {
+    archetype: &'a Archetype,
+    /// State index for `component` in `archetype`
+    state: usize,
+}
+
+impl<'a> ComponentBorrow<'a> {
+    unsafe fn for_component<T: Component>(
+        archetype: &'a Archetype,
+        index: u32,
+    ) -> Result<(NonNull<T>, Self), MissingComponent> {
+        let state = archetype
+            .get_state::<T>()
+            .ok_or_else(MissingComponent::new::<T>)?;
+
+        let target =
+            NonNull::new_unchecked(archetype.get_base::<T>(state).as_ptr().add(index as usize));
+
+        archetype.borrow::<T>(state);
+
+        Ok((target, Self { archetype, state }))
+    }
+}
+
+impl<'a> Clone for ComponentBorrow<'a> {
+    fn clone(&self) -> Self {
+        unsafe {
+            self.archetype.borrow_raw(self.state);
+        }
+        Self {
+            archetype: self.archetype,
+            state: self.state,
+        }
+    }
+}
+
+impl<'a> Drop for ComponentBorrow<'a> {
+    fn drop(&mut self) {
+        unsafe {
+            self.archetype.release_raw(self.state);
+        }
+    }
+}
+
+struct ComponentBorrowMut<'a> {
+    archetype: &'a Archetype,
+    /// State index for `component` in `archetype`
+    state: usize,
+}
+
+impl<'a> ComponentBorrowMut<'a> {
+    unsafe fn for_component<T: Component>(
+        archetype: &'a Archetype,
+        index: u32,
+    ) -> Result<(NonNull<T>, Self), MissingComponent> {
+        let state = archetype
+            .get_state::<T>()
+            .ok_or_else(MissingComponent::new::<T>)?;
+
+        let target =
+            NonNull::new_unchecked(archetype.get_base::<T>(state).as_ptr().add(index as usize));
+
+        archetype.borrow_mut::<T>(state);
+
+        Ok((target, Self { archetype, state }))
+    }
+}
+
+impl<'a> Drop for ComponentBorrowMut<'a> {
+    fn drop(&mut self) {
+        unsafe {
+            self.archetype.release_raw_mut(self.state);
+        }
+    }
+}

--- a/src/entity_ref.rs
+++ b/src/entity_ref.rs
@@ -134,10 +134,10 @@ unsafe impl<T: ?Sized + Sync> Send for Ref<'_, T> {}
 unsafe impl<T: ?Sized + Sync> Sync for Ref<'_, T> {}
 
 impl<'a, T: ?Sized> Ref<'a, T> {
-    /// Transform the `Ref<'_>` to point to a part of the borrowed data, e.g.
+    /// Transform the `Ref<'_, T>` to point to a part of the borrowed data, e.g.
     /// a struct field.
     ///
-    /// The `Ref<'_>` is already borrowed, so this cannot fail.
+    /// The `Ref<'_, T>` is already borrowed, so this cannot fail.
     ///
     /// # Examples
     ///
@@ -215,10 +215,10 @@ unsafe impl<T: ?Sized + Send> Send for RefMut<'_, T> {}
 unsafe impl<T: ?Sized + Sync> Sync for RefMut<'_, T> {}
 
 impl<'a, T: ?Sized> RefMut<'a, T> {
-    /// Transform the `RefMut<'_>` to point to a part of the borrowed data, e.g.
+    /// Transform the `RefMut<'_, T>` to point to a part of the borrowed data, e.g.
     /// a struct field.
     ///
-    /// The `RefMut<'_>` is already mutably borrowed, so this cannot fail.
+    /// The `RefMut<'_, T>` is already mutably borrowed, so this cannot fail.
     ///
     /// # Examples
     ///

--- a/src/entity_ref.rs
+++ b/src/entity_ref.rs
@@ -134,7 +134,7 @@ unsafe impl<T: ?Sized + Sync> Send for Ref<'_, T> {}
 unsafe impl<T: ?Sized + Sync> Sync for Ref<'_, T> {}
 
 impl<'a, T: ?Sized> Ref<'a, T> {
-    /// Transform the `Ref<'_>` to point to to a part of the borrowed data, e.g.
+    /// Transform the `Ref<'_>` to point to a part of the borrowed data, e.g.
     /// a struct field.
     ///
     /// The `Ref<'_>` is already borrowed, so this cannot fail.
@@ -215,7 +215,7 @@ unsafe impl<T: ?Sized + Send> Send for RefMut<'_, T> {}
 unsafe impl<T: ?Sized + Sync> Sync for RefMut<'_, T> {}
 
 impl<'a, T: ?Sized> RefMut<'a, T> {
-    /// Transform the `RefMut<'_>` to point to to a part of the borrowed data, e.g.
+    /// Transform the `RefMut<'_>` to point to a part of the borrowed data, e.g.
     /// a struct field.
     ///
     /// The `RefMut<'_>` is already mutably borrowed, so this cannot fail.

--- a/src/entity_ref.rs
+++ b/src/entity_ref.rs
@@ -134,8 +134,8 @@ unsafe impl<T: ?Sized + Sync> Send for Ref<'_, T> {}
 unsafe impl<T: ?Sized + Sync> Sync for Ref<'_, T> {}
 
 impl<'a, T: ?Sized> Ref<'a, T> {
-    /// Makes a new `Ref<'_>` for a component of the borrowed component, e.g.
-    /// a struct field or enum variant.
+    /// Transform the `Ref<'_>` to point to to a part of the borrowed data, e.g.
+    /// a struct field.
     ///
     /// The `Ref<'_>` is already borrowed, so this cannot fail.
     ///
@@ -215,8 +215,8 @@ unsafe impl<T: ?Sized + Send> Send for RefMut<'_, T> {}
 unsafe impl<T: ?Sized + Sync> Sync for RefMut<'_, T> {}
 
 impl<'a, T: ?Sized> RefMut<'a, T> {
-    /// Makes a new `RefMut<'_>` for a component of the borrowed component, e.g.
-    /// a struct field or enum variant.
+    /// Transform the `RefMut<'_>` to point to to a part of the borrowed data, e.g.
+    /// a struct field.
     ///
     /// The `RefMut<'_>` is already mutably borrowed, so this cannot fail.
     ///
@@ -352,11 +352,13 @@ impl<'a, T: Component> ComponentRefShared<'a> for &'a T {}
 
 struct ComponentBorrow<'a> {
     archetype: &'a Archetype,
-    /// State index for `component` in `archetype`
+    /// State index for the borrowed component in the `archetype`.
     state: usize,
 }
 
 impl<'a> ComponentBorrow<'a> {
+    // This method is unsafe as the `index` parameter is not validated
+    // to actually point to the correct component in the `archetype`.
     unsafe fn for_component<T: Component>(
         archetype: &'a Archetype,
         index: u32,
@@ -396,11 +398,13 @@ impl<'a> Drop for ComponentBorrow<'a> {
 
 struct ComponentBorrowMut<'a> {
     archetype: &'a Archetype,
-    /// State index for `component` in `archetype`
+    /// State index for the borrowed component in the `archetype`.
     state: usize,
 }
 
 impl<'a> ComponentBorrowMut<'a> {
+    // This method is unsafe as the `index` parameter is not validated
+    // to actually point to the correct component in the `archetype`.
     unsafe fn for_component<T: Component>(
         archetype: &'a Archetype,
         index: u32,

--- a/src/entity_ref.rs
+++ b/src/entity_ref.rs
@@ -357,8 +357,9 @@ struct ComponentBorrow<'a> {
 }
 
 impl<'a> ComponentBorrow<'a> {
-    // This method is unsafe as the `index` parameter is not validated
-    // to actually point to the correct component in the `archetype`.
+    // This method is unsafe as if the `index` is out of bounds,
+    // then this will cause undefined behavior as the returned
+    // `target` will point to undefined memory.
     unsafe fn for_component<T: Component>(
         archetype: &'a Archetype,
         index: u32,
@@ -403,8 +404,9 @@ struct ComponentBorrowMut<'a> {
 }
 
 impl<'a> ComponentBorrowMut<'a> {
-    // This method is unsafe as the `index` parameter is not validated
-    // to actually point to the correct component in the `archetype`.
+    // This method is unsafe as if the `index` is out of bounds,
+    // then this will cause undefined behavior as the returned
+    // `target` will point to undefined memory.
     unsafe fn for_component<T: Component>(
         archetype: &'a Archetype,
         index: u32,

--- a/src/entity_ref.rs
+++ b/src/entity_ref.rs
@@ -184,8 +184,8 @@ impl<'a, T: ?Sized> Clone for Ref<'a, T> {
     fn clone(&self) -> Self {
         Self {
             borrow: self.borrow.clone(),
-            target: self.target.clone(),
-            _phantom: self._phantom.clone(),
+            target: self.target,
+            _phantom: self._phantom,
         }
     }
 }


### PR DESCRIPTION
This commit adds analogues of [std::cell::Ref::map](https://doc.rust-lang.org/stable/std/cell/struct.Ref.html#method.map) and [std::cell::RefMut::map](https://doc.rust-lang.org/stable/std/cell/struct.RefMut.html#method.map), which allow the contents of a `Ref`/`RefMut` to be transformed without reborrowing. This can make it easier to write certain kinds of functions which return data borrowed from components.

An example of this kind of code is below:

```rust
trait MyComponentTrait {
    fn get_state(&self) -> &dyn MyState;
}

fn entity_get_state<T: MyComponentTrait>(ent: EntityRef<'_>) -> Option<Ref<'_, dyn MyState>> {
    let component = ent.get::<&'_ T>();
    component.map(|comp_ref| Ref::map(comp_ref, |comp| comp.get_state()))
}

struct MyComponentInstance {
    // state unspecified...
}

impl MyComponentTrait for MyComponmentInstance {
    // implementation unspecified...
}

let mut comp_ty_to_state_getter: HashMap<TypeId, fn(EntityRef<'_>) -> Option<Ref<'_, dyn MyState>> = Default::default();
comp_ty_to_state_getter.insert(TypeId::of::<MyComponmentInstance>(), entity_get_state::<MyComponmentInstance>);
```

From there, when you have an entity, you could iterate over the `TypeId`s of the components in that entity, and then
call use the `comp_ty_to_state_getter` to call common functionality on all of them. Examples of where this could
be useful include serialisation, or visiting component fields to render them in a GUI inspector.

As part of this change, the sizes of the `Ref` and `RefMut` types have increased to store the `TypeId` of the original
component, and the `Archetype` can now be released polymorphically using that `TypeId`.

Let me know if there is anything else I should change or if there are any tests I should add.
