### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ hecs-macros = { path = "macros", version = "0.9.0", optional = true }
 hashbrown = { version = "0.14", default-features = false, features = ["ahash", "inline-more"] }
 lazy_static = { version = "1.4.0", optional = true, features = ["spin_no_std"] }
 serde = { version = "1.0.117", default-features = false, optional = true }
-spin = { version = "0.9.2", default-features = false, features = ["mutex", "spin_mutex"] }
+spin = { version = "0.9.8", default-features = false, features = ["mutex", "spin_mutex"] }
 
 [dev-dependencies]
 bencher = "0.1.5"


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)