### PR TITLE
Optimize iteration

### DIFF
--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -104,9 +104,7 @@ impl Archetype {
         assert_eq!(self.types[state].id, TypeId::of::<T>());
 
         unsafe {
-            NonNull::new_unchecked(
-                self.data.get_unchecked(state).storage.as_ptr().cast::<T>() as *mut T
-            )
+            NonNull::new_unchecked(self.data.get_unchecked(state).storage.as_ptr().cast::<T>())
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,18 +41,27 @@ extern crate std;
 
 extern crate alloc;
 
+macro_rules! reverse_apply {
+    ($m: ident [] $($reversed:tt)*) => {
+        $m!{$($reversed),*}  // base case
+    };
+    ($m: ident [$first:tt $($rest:tt)*] $($reversed:tt)*) => {
+        reverse_apply!{$m [$($rest)*] $first $($reversed)*}
+    };
+}
+
 /// Imagine macro parameters, but more like those Russian dolls.
 ///
-/// Calls m!(A, B, C), m!(A, B), m!(B), and m!() for i.e. (m, A, B, C)
+/// Calls m!(), m!(A), m!(A, B), and m!(A, B, C) for i.e. (m, A, B, C)
 /// where m is any macro, for any number of parameters.
 macro_rules! smaller_tuples_too {
-    ($m: ident, $ty: ident) => {
+    ($m: ident, $next: tt) => {
         $m!{}
-        $m!{$ty}
+        $m!{$next}
     };
-    ($m: ident, $ty: ident, $($tt: ident),*) => {
-        smaller_tuples_too!{$m, $($tt),*}
-        $m!{$ty, $($tt),*}
+    ($m: ident, $next: tt, $($rest: tt),*) => {
+        smaller_tuples_too!{$m, $($rest),*}
+        reverse_apply!{$m [$next $($rest)*]}
     };
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -1059,6 +1059,7 @@ macro_rules! tuple_impl {
                 Some(($($name::prepare(archetype)?,)*))
             }
             #[allow(unused_variables, non_snake_case, clippy::unused_unit)]
+            #[inline(always)]
             fn execute(archetype: &Archetype, state: Self::State) -> Self {
                 let ($($name,)*) = state;
                 ($($name::execute(archetype, $name),)*)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1055,6 +1055,7 @@ macro_rules! tuple_impl {
                 $($name::borrow(archetype, $name);)*
             }
             #[allow(unused_variables)]
+            #[cold]
             fn prepare(archetype: &Archetype) -> Option<Self::State> {
                 Some(($($name::prepare(archetype)?,)*))
             }

--- a/src/world.rs
+++ b/src/world.rs
@@ -396,7 +396,7 @@ impl World {
     /// assert!(entities.contains(&(b, 456, false)));
     /// ```
     pub fn query<Q: Query>(&self) -> QueryBorrow<'_, Q> {
-        QueryBorrow::new(&self.entities.meta, &self.archetypes.archetypes)
+        QueryBorrow::new(self)
     }
 
     /// Query a uniquely borrowed world
@@ -405,7 +405,7 @@ impl World {
     /// that, unlike [`query`](Self::query), this returns an `IntoIterator` which can be passed
     /// directly to a `for` loop.
     pub fn query_mut<Q: Query>(&mut self) -> QueryMut<'_, Q> {
-        QueryMut::new(&self.entities.meta, &mut self.archetypes.archetypes)
+        QueryMut::new(self)
     }
 
     pub(crate) fn memo(&self) -> (u64, u32) {

--- a/src/world.rs
+++ b/src/world.rs
@@ -412,10 +412,12 @@ impl World {
         (self.id, self.archetypes.generation())
     }
 
+    #[inline(always)]
     pub(crate) fn entities_meta(&self) -> &[EntityMeta] {
         &self.entities.meta
     }
 
+    #[inline(always)]
     pub(crate) fn archetypes_inner(&self) -> &[Archetype] {
         &self.archetypes.archetypes
     }
@@ -822,6 +824,7 @@ impl World {
     ///
     /// Useful for dynamically scheduling concurrent queries by checking borrows in advance, and for
     /// efficient serialization.
+    #[inline(always)]
     pub fn archetypes(&self) -> impl ExactSizeIterator<Item = &'_ Archetype> + '_ {
         self.archetypes_inner().iter()
     }


### PR DESCRIPTION
Stumbled across some major speedups while chipping away at #334. Iteration of large archetypes is now ~twice as fast, with no significant change elsewhere.

Before:
```
test iterate_100k                   ... bench:     130,153 ns/iter (+/- 12,301)
test iterate_cached_100_by_50       ... bench:       1,010 ns/iter (+/- 75)
test iterate_mut_100k               ... bench:     127,847 ns/iter (+/- 6,311)
test iterate_mut_cached_100_by_50   ... bench:         251 ns/iter (+/- 58)
test iterate_mut_uncached_100_by_50 ... bench:         602 ns/iter (+/- 138)
test iterate_uncached_100_by_50     ... bench:       2,146 ns/iter (+/- 44)
```

After:
```
test iterate_100k                   ... bench:      51,880 ns/iter (+/- 2,813)
test iterate_cached_100_by_50       ... bench:         957 ns/iter (+/- 117)
test iterate_mut_100k               ... bench:      65,218 ns/iter (+/- 5,915)
test iterate_mut_cached_100_by_50   ... bench:         220 ns/iter (+/- 7)
test iterate_mut_uncached_100_by_50 ... bench:         701 ns/iter (+/- 548)
test iterate_uncached_100_by_50     ... bench:       2,340 ns/iter (+/- 205)
```