### PR TITLE
Implement queries that add/remove components

### DIFF
--- a/src/entities.rs
+++ b/src/entities.rs
@@ -548,8 +548,10 @@ impl EntityMeta {
     };
 }
 
+/// Addresses storage for an entity's components within a world
 #[derive(Copy, Clone)]
-pub(crate) struct Location {
+#[doc(hidden)]
+pub struct Location {
     pub archetype: u32,
     pub index: u32,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,8 @@ pub use entity_builder::{BuiltEntity, BuiltEntityClone, EntityBuilder, EntityBui
 pub use entity_ref::{ComponentRef, ComponentRefShared, EntityRef, Ref, RefMut};
 pub use query::{
     Access, Batch, BatchedIter, Or, PreparedQuery, PreparedQueryBorrow, PreparedQueryIter,
-    PreparedView, Query, QueryBorrow, QueryIter, QueryMut, QueryShared, Satisfies, View, With,
-    Without,
+    PreparedView, Query, QueryBorrow, QueryInPlace, QueryIter, QueryMut, QueryShared, Satisfies,
+    VacantBundle, View, With, Without,
 };
 pub use query_one::QueryOne;
 pub use take::TakenEntity;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -966,3 +966,13 @@ fn component_ref_map() {
         assert_eq!(*id, 31);
     }
 }
+
+#[test]
+fn vacant_bundle() {
+    let mut world = World::new();
+    let e = world.spawn((42,));
+    for (_, mut entry) in world.query_mut::<VacantBundle<(bool,)>>() {
+        entry.set(Some((true,)));
+    }
+    assert!(*world.get::<&bool>(e).unwrap());
+}


### PR DESCRIPTION
Fixes #334.

TODO:
- [ ] Move side effects into a guard object exposed via a new API (`query_with_effect`?) to fix unsoundness
- [ ] Work out why this machinery is 10x slower in the `iterate_mut_100k` benchmark than `query_mut` in master. Nothing's jumping out at be in the disassembly; input would be welcome.