### PR TITLE
Add `#[cold]` to `QueryIter::next_archetype`

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -773,6 +773,7 @@ impl<'q, Q: Query> QueryIter<'q, Q> {
     /// Advance query to the next archetype
     ///
     /// Outlined from `Iterator::next` for improved iteration performance.
+    #[cold]
     fn next_archetype(&mut self) -> Option<()> {
         let archetype = self.archetypes.next()?;
         let archetype = unsafe { self.world.archetypes_inner().get_unchecked(archetype) };


### PR DESCRIPTION
Push further on the path opened by #336 by adding `#[cold]` to `QueryIter::next_archetype`

Results on my machine:

Before
```
test iterate_100k                    ... bench:      43,868 ns/iter (+/- 511)
test iterate_cached_100_by_50        ... bench:       1,003 ns/iter (+/- 13)
test iterate_mut_100k                ... bench:      44,154 ns/iter (+/- 601)
test iterate_mut_cached_100_by_50    ... bench:         142 ns/iter (+/- 42)
test iterate_mut_uncached_100_by_50  ... bench:         386 ns/iter (+/- 14)
test iterate_uncached_100_by_50      ... bench:       1,350 ns/iter (+/- 67)
test iterate_uncached_1_of_100_by_50 ... bench:         675 ns/iter (+/- 5)
```

After
```
test iterate_100k                    ... bench:      26,146 ns/iter (+/- 177)
test iterate_cached_100_by_50        ... bench:         595 ns/iter (+/- 9)
test iterate_mut_100k                ... bench:      26,362 ns/iter (+/- 363)
test iterate_mut_cached_100_by_50    ... bench:         141 ns/iter (+/- 3)
test iterate_mut_uncached_100_by_50  ... bench:         390 ns/iter (+/- 17)
test iterate_uncached_100_by_50      ... bench:       1,369 ns/iter (+/- 81)
test iterate_uncached_1_of_100_by_50 ... bench:         684 ns/iter (+/- 8)
```