### PR TITLE
clippy yells no more

### DIFF
--- a/tests/no-std-test-crates/macros/src/lib.rs
+++ b/tests/no-std-test-crates/macros/src/lib.rs
@@ -1,6 +1,7 @@
 //! This is a test crate to ensure that the macro crate and the macro-expanded code can work in a `no_std` environment.
 
 #![no_std]
+#![allow(clippy::disallowed_names)]
 
 use hecs::{Bundle, Query};
 


### PR DESCRIPTION
very minor change, but makes working in the repo nicer if you have clippy auto-running since there aren't 2 warnings always