### PR TITLE
Determinism for Serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ spin = { version = "0.9.8", default-features = false, features = ["mutex", "spin
 bencher = "0.1.5"
 rand = "0.8.3"
 trybuild = "1.0.23"
-serde_json = "1.0"
 serde = { version = "1.0.117", features = ["derive"] }
 serde_test = "1.0.117"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,14 @@ row-serialize = ["serde"]
 [dependencies]
 hecs-macros = { path = "macros", version = "0.10.0", optional = true }
 hashbrown = { version = "0.14", default-features = false, features = ["ahash", "inline-more"] }
-serde = { version = "1.0.117", default-features = false, optional = true }
+serde = { version = "1.0.117", default-features = false, features = ["alloc"], optional = true }
 spin = { version = "0.9.8", default-features = false, features = ["mutex", "spin_mutex", "lazy"] }
 
 [dev-dependencies]
 bencher = "0.1.5"
 rand = "0.8.3"
 trybuild = "1.0.23"
+serde_json = "1.0"
 serde = { version = "1.0.117", features = ["derive"] }
 serde_test = "1.0.117"
 

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -109,6 +109,12 @@ impl<'de> serde::Deserialize<'de> for Entity {
     }
 }
 
+#[derive(Debug)]
+pub enum PendingPushError {
+    MetaTooSmall,
+    EntityNotPending
+}
+
 /// An iterator returning a sequence of Entity values from `Entities::reserve_entities`.
 pub struct ReserveEntitiesIterator<'a> {
     // Metas, so we can recover the current generation for anything in the freelist.
@@ -146,6 +152,12 @@ impl<'a> Iterator for ReserveEntitiesIterator<'a> {
 }
 
 impl<'a> ExactSizeIterator for ReserveEntitiesIterator<'a> {}
+
+
+pub struct Freelist<'a> {
+    pub pending: &'a [u32],
+    pub free_cursor: isize,
+}
 
 #[derive(Default)]
 pub(crate) struct Entities {
@@ -192,6 +204,13 @@ pub(crate) struct Entities {
 }
 
 impl Entities {
+    pub fn freelist(&self) -> Freelist {
+        Freelist {
+            pending: &self.pending,
+            free_cursor: self.free_cursor.load(Ordering::Relaxed),
+        }
+    }
+
     /// Reserve entity IDs concurrently
     ///
     /// Storage for entity generation and location is lazily allocated by calling `flush`.
@@ -343,10 +362,7 @@ impl Entities {
         self.verify_flushed();
 
         let loc = if entity.id as usize >= self.meta.len() {
-            self.pending.extend((self.meta.len() as u32)..entity.id);
-            let new_free_cursor = self.pending.len() as isize;
-            *self.free_cursor.get_mut() = new_free_cursor;
-            self.meta.resize(entity.id as usize + 1, EntityMeta::EMPTY);
+            self.extend_meta((entity.id + 1) as usize, false);
             self.len += 1;
             None
         } else if let Some(index) = self.pending.iter().position(|item| *item == entity.id) {
@@ -494,7 +510,7 @@ impl Entities {
         }
     }
 
-    fn needs_flush(&mut self) -> bool {
+    pub fn needs_flush(&mut self) -> bool {
         *self.free_cursor.get_mut() != self.pending.len() as isize
     }
 
@@ -523,6 +539,51 @@ impl Entities {
         for id in self.pending.drain(new_free_cursor..) {
             init(id, &mut self.meta[id as usize].location);
         }
+    }
+
+    fn extend_meta(&mut self, new_len: usize, include_last: bool) {
+        let upper_limit = if include_last {
+            new_len as u32
+        } else {
+            new_len as u32 - 1
+        };
+
+        self.pending.extend((self.meta.len() as u32)..upper_limit);
+        let new_free_cursor = self.pending.len() as isize;
+        *self.free_cursor.get_mut() = new_free_cursor;
+        self.meta.resize(new_len, EntityMeta::EMPTY);
+    }
+
+    pub fn push_generations(&mut self, generations: &[u32]) {
+        if self.meta.len() < generations.len() {
+            self.extend_meta(generations.len(), true);
+        }
+
+        for (index, meta) in self.meta.iter_mut().enumerate() {
+            meta.generation = NonZeroU32::new(generations[index]).unwrap();
+        }
+    }
+
+    pub fn push_freelist(&mut self, freelist: Freelist)-> Result<(), PendingPushError> {
+        self.pending.clear();
+
+        let meta_length = self.meta.len();
+
+        for pending in freelist.pending {
+            if meta_length <= *pending as usize {
+                return Result::Err(PendingPushError::MetaTooSmall);
+            }
+
+            if self.meta[*pending as usize].location.index != u32::MAX  {
+                return Result::Err(PendingPushError::EntityNotPending);
+            }
+
+            self.pending.push(*pending);
+        }
+
+        *self.free_cursor.get_mut() = freelist.free_cursor;
+
+        return Result::Ok(());
     }
 
     #[inline]

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -153,7 +153,10 @@ impl<'a> Iterator for ReserveEntitiesIterator<'a> {
 
 impl<'a> ExactSizeIterator for ReserveEntitiesIterator<'a> {}
 
-
+/// Represents a list of free/pending entities.
+/// 
+/// `pending` contains a list of ids. Entities left (index <=) of the free_cursor
+/// are free and entities right of the free_cursor are pending (reserved).
 pub struct Freelist<'a> {
     pub pending: &'a [u32],
     pub free_cursor: isize,

--- a/src/world.rs
+++ b/src/world.rs
@@ -67,10 +67,10 @@ impl World {
         // For compatibility, use Mutex<u64>
         static ID: Mutex<u64> = Mutex::new(1);
         let id = {
-        let mut id = ID.lock();
-        let next = id.checked_add(1).unwrap();
-        *id = next;
-        next
+            let mut id = ID.lock();
+            let next = id.checked_add(1).unwrap();
+            *id = next;
+            next
         };
         Self {
             entities: Entities::default(),

--- a/src/world.rs
+++ b/src/world.rs
@@ -928,11 +928,6 @@ impl World {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
-
-    /// Whether there are unallocated reserved entities 
-    pub fn is_flushed(&mut self) -> bool {
-        !self.entities.needs_flush()
-    }
 }
 
 unsafe impl Send for World {}

--- a/src/world.rs
+++ b/src/world.rs
@@ -439,7 +439,7 @@ impl World {
         self.entities_meta().iter().map(|m| m.generation.get()).collect()
     }
 
-    /// Set a custom list of generations
+    /// Set a custom generations and freelist 
     pub fn push_entity_states(&mut self, generations: &[u32], freelist: Freelist) -> Result<(), PendingPushError>{
         self.entities.push_generations(generations);
         self.entities.push_freelist(freelist)


### PR DESCRIPTION
This a draft for making the serialization of a world deterministic by adding the necessary information to the serialization.
It works by saving the free list and all the generations of all alive and de spawned entities.

### TODOs

- [x] Fix the 2 serialize test cases
- [x] Remove column serialize from default features
- [x] Make sure everything works as intended
- [x] ~~Maybe add this to row serialization aswell~~ (Out of scope for this PR)

