### PR TITLE
Introduce QueryBorrow::iter_combinations

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -985,3 +985,69 @@ fn query_many_duplicate() {
     let e = world.spawn(());
     _ = world.query_many_mut::<(), 2>([e, e]);
 }
+
+#[test]
+fn query_combination() {
+    let mut world = World::new();
+    let a = world.spawn((42, true));
+    let b = world.spawn((17,));
+    let c = world.spawn((21,));
+    let mut query = world.query::<&mut i32>();
+    let mut iter = query.iter_combinations::<2>();
+    assert_eq!(iter.next(), Some([(a, &mut 42), (b, &mut 17)]));
+    assert_eq!(iter.next(), Some([(a, &mut 42), (c, &mut 21)]));
+    assert_eq!(iter.next(), Some([(b, &mut 17), (c, &mut 21)]));
+    assert_eq!(iter.next(), None);
+}
+
+#[test]
+fn query_combination_exact() {
+    let mut world = World::new();
+    let a = world.spawn((42, true));
+    let b = world.spawn((17,));
+    let c = world.spawn((21,));
+    let mut query = world.query::<&mut i32>();
+    let mut iter = query.iter_combinations::<3>();
+    assert_eq!(iter.next(), Some([(a, &mut 42), (b, &mut 17), (c, &mut 21)]));
+    assert_eq!(iter.next(), None);
+}
+
+#[test]
+fn query_combination_zero() {
+    let mut world = World::new();
+    let _ = world.spawn((42, true));
+    let _ = world.spawn((17,));
+    let _ = world.spawn((21,));
+    let mut query = world.query::<&mut i32>();
+    let mut iter = query.iter_combinations::<0>();
+    assert_eq!(iter.next(), None);
+}
+
+#[test]
+fn query_combination_not_enough_entities() {
+    let mut world = World::new();
+    let _ = world.spawn((42, true));
+    let _ = world.spawn((17,));
+    let _ = world.spawn((21,));
+    let mut query = world.query::<&mut i32>();
+    
+    let mut iter = query.iter_combinations::<4>();
+    assert_eq!(iter.next(), None);
+
+    let mut iter = query.iter_combinations::<5>();
+    assert_eq!(iter.next(), None);
+
+    let mut iter = query.iter_combinations::<100>();
+    assert_eq!(iter.next(), None);
+}
+
+#[test]
+fn query_combination_no_match() {
+    let mut world = World::new();
+    let _ = world.spawn((42, true));
+    let _ = world.spawn((17,));
+    let _ = world.spawn((21,));
+    let mut query = world.query::<&String>();
+    let mut iter = query.iter_combinations::<2>();
+    assert_eq!(iter.next(), None);
+}


### PR DESCRIPTION
Hey there, very nice project. As far as I'm aware, there currently isn't a way to safely and efficiently iterate over combinations of entities. This PR introduces QueryBorrow::iter_combinations, allowing for just that.

The operation is useful in situations where you need entities to interact with each other eg. collision between entities.

This implementation is based on the description of the same operation in bevy_ecs: <https://github.com/bevyengine/bevy/blob/31d91466b4fb99786a8c61b82417372a42a3f531/crates/bevy_ecs/src/query/iter.rs#L546>.

The API currently returns `[(Entity, Q::Item); K]` as I felt it was consistent with the other query iterator. This can easily be changed to `([Entity; K], [Q::Item; K])` for consistency with the query_many family of functions

Please let me know if you have any questions or changes.

I have signed the Google CLA linked in the CONTRIBUTING.md

Cheers,
Moulberry


