### PR TITLE
Remove Google boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,6 @@ submitted for inclusion in the work by you, as defined in the
 Apache-2.0 license, shall be dual licensed as above, without any
 additional terms or conditions.
 
-### Disclaimer
-
-This is not an official Google product (experimental or otherwise), it is just
-code that happens to be owned by Google.
-
 [bevy]: https://github.com/bevyengine/bevy
 [specs]: https://github.com/amethyst/specs
 [legion]: https://github.com/TomGillen/legion

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,10 +1,3 @@
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
-
 use bencher::{benchmark_group, benchmark_main, Bencher};
 use hecs::*;
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,10 +1,3 @@
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
-
 extern crate proc_macro;
 
 mod bundle;

--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -1,10 +1,3 @@
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
-
 use crate::alloc::alloc::{alloc, dealloc, Layout};
 use crate::alloc::boxed::Box;
 use crate::alloc::{vec, vec::Vec};

--- a/src/borrow.rs
+++ b/src/borrow.rs
@@ -1,10 +1,3 @@
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
-
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 /// A bit mask used to signal the `AtomicBorrow` has an active mutable borrow.

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -1,10 +1,3 @@
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
-
 use crate::alloc::vec::Vec;
 use core::any::{type_name, TypeId};
 use core::ptr::NonNull;

--- a/src/command_buffer.rs
+++ b/src/command_buffer.rs
@@ -1,10 +1,3 @@
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
-
 use core::any::TypeId;
 use core::mem;
 use core::ops::Range;

--- a/src/entity_builder.rs
+++ b/src/entity_builder.rs
@@ -1,10 +1,3 @@
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
-
 use crate::alloc::alloc::{alloc, dealloc, Layout};
 use crate::alloc::vec::Vec;
 use crate::bundle::{DynamicBundleClone, DynamicClone};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,3 @@
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
-
 //! A handy ECS
 //!
 //! hecs provides a high-performance, minimalist entity-component-system (ECS) world. It is a

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,10 +1,3 @@
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
-
 use core::any::TypeId;
 use core::marker::PhantomData;
 use core::ptr::NonNull;

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,10 +1,3 @@
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
-
 use crate::alloc::{vec, vec::Vec};
 use core::any::TypeId;
 use core::borrow::Borrow;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,10 +1,4 @@
 #![allow(deprecated)]
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
 
 use std::borrow::Cow;
 


### PR DESCRIPTION
Google has disclaimed ownership of hecs copyright, so we can tidy up.