### PR TITLE
Migrate benchmarks to criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ spin = { version = "0.10.0", default-features = false, features = ["mutex", "spi
 foldhash = { version = "0.1.3", default-features = false }
 
 [dev-dependencies]
-bencher = "0.1.5"
+criterion = "0.6.0"
 rand = "0.9.0"
 trybuild = "1.0.23"
 serde = { version = "1.0.117", features = ["derive"] }


### PR DESCRIPTION
bencher is difficult to profile as it exposes no control over runtime.