### PR TITLE
Entity as Query

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -137,7 +137,7 @@ fn iterate_100k(c: &mut Criterion) {
     }
     c.bench_function("iterate 100k", |b| {
         b.iter(|| {
-            for (_, (pos, vel)) in &mut world.query::<(&mut Position, &Velocity)>() {
+            for (pos, vel) in &mut world.query::<(&mut Position, &Velocity)>() {
                 pos.0 += vel.0;
             }
         })
@@ -151,7 +151,7 @@ fn iterate_mut_100k(c: &mut Criterion) {
     }
     c.bench_function("iterate mut 100k", |b| {
         b.iter(|| {
-            for (_, (pos, vel)) in world.query_mut::<(&mut Position, &Velocity)>() {
+            for (pos, vel) in world.query_mut::<(&mut Position, &Velocity)>() {
                 pos.0 += vel.0;
             }
         })
@@ -198,7 +198,7 @@ fn iterate_uncached_100_by_50(c: &mut Criterion) {
     spawn_100_by_50(&mut world);
     c.bench_function("iterate_uncached_100_by_50", |b| {
         b.iter(|| {
-            for (_, (pos, vel)) in world.query::<(&mut Position, &Velocity)>().iter() {
+            for (pos, vel) in world.query::<(&mut Position, &Velocity)>().iter() {
                 pos.0 += vel.0;
             }
         })
@@ -210,7 +210,7 @@ fn iterate_uncached_1_of_100_by_50(c: &mut Criterion) {
     spawn_100_by_50(&mut world);
     c.bench_function("iterate_uncached_1_of_100_by_50", |b| {
         b.iter(|| {
-            for (_, (pos, vel)) in world
+            for (pos, vel) in world
                 .query::<(&mut Position, &Velocity)>()
                 .with::<&[(); 0]>()
                 .iter()
@@ -228,7 +228,7 @@ fn iterate_cached_100_by_50(c: &mut Criterion) {
     let _ = query.query(&world).iter();
     c.bench_function("iterate_cached_100_by_50", |b| {
         b.iter(|| {
-            for (_, (pos, vel)) in query.query(&world).iter() {
+            for (pos, vel) in query.query(&world).iter() {
                 pos.0 += vel.0;
             }
         })
@@ -240,7 +240,7 @@ fn iterate_mut_uncached_100_by_50(c: &mut Criterion) {
     spawn_100_by_50(&mut world);
     c.bench_function("iterate_mut_uncached_100_by_50", |b| {
         b.iter(|| {
-            for (_, (pos, vel)) in world.query_mut::<(&mut Position, &Velocity)>() {
+            for (pos, vel) in world.query_mut::<(&mut Position, &Velocity)>() {
                 pos.0 += vel.0;
             }
         })
@@ -254,7 +254,7 @@ fn iterate_mut_cached_100_by_50(c: &mut Criterion) {
     let _ = query.query_mut(&mut world);
     c.bench_function("iterate_mut_cached_100_by_50", |b| {
         b.iter(|| {
-            for (_, (pos, vel)) in query.query_mut(&mut world) {
+            for (pos, vel) in query.query_mut(&mut world) {
                 pos.0 += vel.0;
             }
         })

--- a/examples/serialize_to_disk.rs
+++ b/examples/serialize_to_disk.rs
@@ -165,10 +165,10 @@ fn main() {
             println!("Loaded world \'{}\' from disk.", path.display());
             print!("Validating world data... ");
             assert_eq!(world.len(), 2);
-            for (_, t) in &mut world.query::<&ComponentA>() {
+            for t in &mut world.query::<&ComponentA>() {
                 assert_eq!(t, &input_data1);
             }
-            for (_, t) in &mut world.query::<&ComponentB>() {
+            for t in &mut world.query::<&ComponentB>() {
                 assert_eq!(t, &input_data2);
             }
             println!("Ok!");

--- a/examples/transform_hierarchy.rs
+++ b/examples/transform_hierarchy.rs
@@ -79,7 +79,7 @@ fn evaluate_relative_transforms(world: &mut World) {
     // references because the inclusion of `&Parent` in the query, and its exclusion from the view,
     // guarantees that they will never overlap. Similarly, it can coexist with `parents` because
     // that view does not reference `Transform`s at all.
-    for (_entity, (parent, absolute)) in world.query::<(&Parent, &mut Transform)>().iter() {
+    for (parent, absolute) in world.query::<(&Parent, &mut Transform)>().iter() {
         // Walk the hierarchy from this entity to the root, accumulating the entity's absolute
         // transform. This does a small amount of redundant work for intermediate levels of deeper
         // hierarchies, but unlike a top-down traversal, avoids tracking entity child lists and is

--- a/macros/src/query.rs
+++ b/macros/src/query.rs
@@ -139,9 +139,9 @@ fn derive_struct(
                 type Fetch = #fetch_ident;
 
                 #[allow(unused_variables)]
-                unsafe fn get<'q>(fetch: &Self::Fetch, n: usize) -> Self::Item<'q> {
+                unsafe fn get<'q>(generation: ::core::num::NonZeroU32, fetch: &Self::Fetch, n: usize) -> Self::Item<'q> {
                     #(
-                        let #intermediates: <#queries as ::hecs::Query>::Item<'q> = <#queries as ::hecs::Query>::get(&fetch.#fields, n);
+                        let #intermediates: <#queries as ::hecs::Query>::Item<'q> = <#queries as ::hecs::Query>::get(generation, &fetch.#fields, n);
                     )*
                     #ident {#(#fields: #intermediates,)*}
                 }
@@ -303,7 +303,7 @@ fn derive_enum(
         query_get_variants.extend(quote! {
             Self::Fetch::#ident { #(#named_fields),* } => {
                 #(
-                    let #named_fields: <#queries as ::hecs::Query>::Item<'q> = <#queries as ::hecs::Query>::get(#named_fields, n);
+                    let #named_fields: <#queries as ::hecs::Query>::Item<'q> = <#queries as ::hecs::Query>::get(generation, #named_fields, n);
                 )*
                 Self::Item::#ident { #( #fields: #named_fields,)* }
             },
@@ -406,7 +406,7 @@ fn derive_enum(
                 type Fetch = #fetch_ident;
 
                 #[allow(unused_variables)]
-                unsafe fn get<'q>(fetch: &Self::Fetch, n: usize) -> Self::Item<'q> {
+                unsafe fn get<'q>(generation: ::core::num::NonZeroU32, fetch: &Self::Fetch, n: usize) -> Self::Item<'q> {
                     match fetch {
                         #query_get_variants
                     }

--- a/src/entity_ref.rs
+++ b/src/entity_ref.rs
@@ -82,7 +82,7 @@ impl<'a> EntityRef<'a> {
     /// assert_eq!(*number, 246);
     /// ```
     pub fn query<Q: Query>(&self) -> QueryOne<'a, Q> {
-        unsafe { QueryOne::new(self.archetype, self.index) }
+        unsafe { QueryOne::new(self.entity.generation, self.archetype, self.index) }
     }
 
     /// Enumerate the types of the entity's components

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! let a = world.spawn((123, true, "abc"));
 //! let b = world.spawn((42, false));
 //! // Systems can be simple for loops
-//! for (id, (number, &flag)) in world.query_mut::<(&mut i32, &bool)>() {
+//! for (number, &flag) in world.query_mut::<(&mut i32, &bool)>() {
 //!   if flag { *number *= 2; }
 //! }
 //! // Random access is simple and safe

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "std")]
 use core::any::Any;
-use core::any::TypeId;
 use core::marker::PhantomData;
 use core::ptr::NonNull;
 use core::slice::Iter as SliceIter;
+use core::{any::TypeId, num::NonZeroU32};
 #[cfg(feature = "std")]
 use std::sync::{Arc, RwLock};
 
@@ -30,14 +30,14 @@ pub trait Query {
     type Fetch: Fetch;
 
     #[doc(hidden)]
-    /// Access the `n`th item in this archetype without bounds checking
+    /// Access the `n`th item in this archetype, an entity with generation `generation`, without bounds checking
     ///
     /// # Safety
     /// - Must only be called after [`Fetch::borrow`] or with exclusive access to the archetype
     /// - [`Fetch::release`] must not be called while `'a` is still live
     /// - Bounds-checking must be performed externally
     /// - Any resulting borrows must be legal (e.g. no &mut to something another iterator might access)
-    unsafe fn get<'a>(fetch: &Self::Fetch, n: usize) -> Self::Item<'a>;
+    unsafe fn get<'a>(generation: NonZeroU32, fetch: &Self::Fetch, n: usize) -> Self::Item<'a>;
 }
 
 /// Marker trait indicating whether a given [`Query`] will not produce unique references
@@ -81,12 +81,54 @@ pub enum Access {
     Write,
 }
 
+impl Query for Entity {
+    type Item<'q> = Entity;
+    type Fetch = FetchEntity;
+
+    unsafe fn get<'q>(generation: NonZeroU32, fetch: &Self::Fetch, n: usize) -> Self::Item<'q> {
+        Entity {
+            id: fetch.0.as_ptr().add(n).read(),
+            generation,
+        }
+    }
+}
+
+#[doc(hidden)]
+#[derive(Clone)]
+pub struct FetchEntity(NonNull<u32>);
+
+unsafe impl Fetch for FetchEntity {
+    type State = ();
+
+    fn dangling() -> Self {
+        Self(NonNull::dangling())
+    }
+
+    fn access(_: &Archetype) -> Option<Access> {
+        Some(Access::Iterate)
+    }
+
+    fn borrow(_: &Archetype, (): Self::State) {}
+
+    fn prepare(_: &Archetype) -> Option<Self::State> {
+        Some(())
+    }
+
+    fn execute(archetype: &Archetype, (): Self::State) -> Self {
+        Self(archetype.entities())
+    }
+
+    fn release(_: &Archetype, (): Self::State) {}
+
+    fn for_each_borrow(_: impl FnMut(TypeId, bool)) {}
+}
+
 impl<T: Component> Query for &'_ T {
     type Item<'q> = &'q T;
 
     type Fetch = FetchRead<T>;
 
-    unsafe fn get<'q>(fetch: &FetchRead<T>, n: usize) -> &'q T {
+    unsafe fn get<'q>(_: NonZeroU32, fetch: &FetchRead<T>, n: usize) -> &'q T {
         &*fetch.0.as_ptr().add(n)
     }
 }
@@ -141,7 +183,7 @@ impl<T: Component> Query for &'_ mut T {
 
     type Fetch = FetchWrite<T>;
 
-    unsafe fn get<'q>(fetch: &FetchWrite<T>, n: usize) -> &'q mut T {
+    unsafe fn get<'q>(_: NonZeroU32, fetch: &FetchWrite<T>, n: usize) -> &'q mut T {
         &mut *fetch.0.as_ptr().add(n)
     }
 }
@@ -195,8 +237,12 @@ impl<T: Query> Query for Option<T> {
 
     type Fetch = TryFetch<T::Fetch>;
 
-    unsafe fn get<'q>(fetch: &TryFetch<T::Fetch>, n: usize) -> Option<T::Item<'q>> {
-        Some(T::get(fetch.0.as_ref()?, n))
+    unsafe fn get<'q>(
+        generation: NonZeroU32,
+        fetch: &TryFetch<T::Fetch>,
+        n: usize,
+    ) -> Option<T::Item<'q>> {
+        Some(T::get(generation, fetch.0.as_ref()?, n))
     }
 }
 
@@ -336,8 +382,11 @@ impl<L: Query, R: Query> Query for Or<L, R> {
 
     type Fetch = FetchOr<L::Fetch, R::Fetch>;
 
-    unsafe fn get<'q>(fetch: &Self::Fetch, n: usize) -> Self::Item<'q> {
-        fetch.0.as_ref().map(|l| L::get(l, n), |r| R::get(r, n))
+    unsafe fn get<'q>(generation: NonZeroU32, fetch: &Self::Fetch, n: usize) -> Self::Item<'q> {
+        fetch
+            .0
+            .as_ref()
+            .map(|l| L::get(generation, l, n), |r| R::get(generation, r, n))
     }
 }
 
@@ -391,7 +440,7 @@ unsafe impl<L: Fetch, R: Fetch> Fetch for FetchOr<L, R> {
 /// let a = world.spawn((123, true, "abc"));
 /// let b = world.spawn((456, false));
 /// let c = world.spawn((42, "def"));
-/// let entities = world.query::<Without<&i32, &bool>>()
+/// let entities = world.query::<Without<(Entity, &i32), &bool>>()
 ///     .iter()
 ///     .map(|(e, &i)| (e, i))
 ///     .collect::<Vec<_>>();
@@ -404,8 +453,8 @@ impl<Q: Query, R: Query> Query for Without<Q, R> {
 
     type Fetch = FetchWithout<Q::Fetch, R::Fetch>;
 
-    unsafe fn get<'q>(fetch: &Self::Fetch, n: usize) -> Self::Item<'q> {
-        Q::get(&fetch.0, n)
+    unsafe fn get<'q>(generation: NonZeroU32, fetch: &Self::Fetch, n: usize) -> Self::Item<'q> {
+        Q::get(generation, &fetch.0, n)
     }
 }
 
@@ -468,7 +517,7 @@ impl<F: Clone, G> Clone for FetchWithout<F, G> {
 /// let a = world.spawn((123, true, "abc"));
 /// let b = world.spawn((456, false));
 /// let c = world.spawn((42, "def"));
-/// let entities = world.query::<With<&i32, &bool>>()
+/// let entities = world.query::<With<(Entity, &i32), &bool>>()
 ///     .iter()
 ///     .map(|(e, &i)| (e, i))
 ///     .collect::<Vec<_>>();
@@ -483,8 +532,8 @@ impl<Q: Query, R: Query> Query for With<Q, R> {
 
     type Fetch = FetchWith<Q::Fetch, R::Fetch>;
 
-    unsafe fn get<'q>(fetch: &Self::Fetch, n: usize) -> Self::Item<'q> {
-        Q::get(&fetch.0, n)
+    unsafe fn get<'q>(generation: NonZeroU32, fetch: &Self::Fetch, n: usize) -> Self::Item<'q> {
+        Q::get(generation, &fetch.0, n)
     }
 }
 
@@ -545,9 +594,8 @@ impl<F: Clone, G> Clone for FetchWith<F, G> {
 /// let a = world.spawn((123, true, "abc"));
 /// let b = world.spawn((456, false));
 /// let c = world.spawn((42, "def"));
-/// let entities = world.query::<Satisfies<&bool>>()
+/// let entities = world.query::<(Entity, Satisfies<&bool>)>()
 ///     .iter()
-///     .map(|(e, x)| (e, x))
 ///     .collect::<Vec<_>>();
 /// assert_eq!(entities.len(), 3);
 /// assert!(entities.contains(&(a, true)));
@@ -561,7 +609,7 @@ impl<Q: Query> Query for Satisfies<Q> {
 
     type Fetch = FetchSatisfies<Q::Fetch>;
 
-    unsafe fn get<'q>(fetch: &Self::Fetch, _: usize) -> Self::Item<'q> {
+    unsafe fn get<'q>(_: NonZeroU32, fetch: &Self::Fetch, _: usize) -> Self::Item<'q> {
         fetch.0
     }
 }
@@ -670,7 +718,7 @@ impl<'w, Q: Query> QueryBorrow<'w, Q> {
     /// let a = world.spawn((123, true, "abc"));
     /// let b = world.spawn((456, false));
     /// let c = world.spawn((42, "def"));
-    /// let entities = world.query::<&i32>()
+    /// let entities = world.query::<(Entity, &i32)>()
     ///     .with::<&bool>()
     ///     .iter()
     ///     .map(|(e, &i)| (e, i)) // Copy out of the world
@@ -694,7 +742,7 @@ impl<'w, Q: Query> QueryBorrow<'w, Q> {
     /// let a = world.spawn((123, true, "abc"));
     /// let b = world.spawn((456, false));
     /// let c = world.spawn((42, "def"));
-    /// let entities = world.query::<&i32>()
+    /// let entities = world.query::<(Entity, &i32)>()
     ///     .without::<&bool>()
     ///     .iter()
     ///     .map(|(e, &i)| (e, i)) // Copy out of the world
@@ -726,7 +774,7 @@ impl<Q: Query> Drop for QueryBorrow<'_, Q> {
 }
 
 impl<'q, Q: Query> IntoIterator for &'q mut QueryBorrow<'_, Q> {
-    type Item = (Entity, Q::Item<'q>);
+    type Item = Q::Item<'q>;
     type IntoIter = QueryIter<'q, Q>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -760,12 +808,12 @@ unsafe impl<Q: Query> Send for QueryIter<'_, Q> where for<'a> Q::Item<'a>: Send 
 unsafe impl<Q: Query> Sync for QueryIter<'_, Q> where for<'a> Q::Item<'a>: Send {}
 
 impl<'q, Q: Query> Iterator for QueryIter<'q, Q> {
-    type Item = (Entity, Q::Item<'q>);
+    type Item = Q::Item<'q>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            match unsafe { self.iter.next() } {
+            match unsafe { self.iter.next(self.world.entities_meta()) } {
                 None => {
                     // Safety: `self.world` is the same one we passed to `ArchetypeIter::new` just above
                     unsafe {
@@ -773,19 +821,8 @@ impl<'q, Q: Query> Iterator for QueryIter<'q, Q> {
                     }
                     continue;
                 }
-                Some((id, components)) => {
-                    return Some((
-                        Entity {
-                            id,
-                            generation: unsafe {
-                                self.world
-                                    .entities_meta()
-                                    .get_unchecked(id as usize)
-                                    .generation
-                            },
-                        },
-                        components,
-                    ));
+                Some(components) => {
+                    return Some(components);
                 }
             }
         }
@@ -899,7 +936,6 @@ pub(crate) fn assert_borrow<Q: Query>() {
 }
 
 struct ChunkIter<Q: Query> {
-    entities: NonNull<u32>,
     fetch: Q::Fetch,
     position: usize,
     len: usize,
@@ -908,7 +944,6 @@ struct ChunkIter<Q: Query> {
 impl<Q: Query> ChunkIter<Q> {
     fn new(archetype: &Archetype, fetch: Q::Fetch) -> Self {
         Self {
-            entities: archetype.entities(),
             fetch,
             position: 0,
             len: archetype.len() as usize,
@@ -917,7 +952,6 @@ impl<Q: Query> ChunkIter<Q> {
 
     fn empty() -> Self {
         Self {
-            entities: NonNull::dangling(),
             fetch: Q::Fetch::dangling(),
             position: 0,
             len: 0,
@@ -925,14 +959,17 @@ impl<Q: Query> ChunkIter<Q> {
     }
 
     #[inline]
-    unsafe fn next<'a>(&mut self) -> Option<(u32, Q::Item<'a>)> {
+    unsafe fn next<'a>(&mut self, meta: &[EntityMeta]) -> Option<Q::Item<'a>> {
         if self.position == self.len {
             return None;
         }
-        let entity = self.entities.as_ptr().add(self.position);
-        let item = Q::get(&self.fetch, self.position);
+        let item = Q::get(
+            meta.get_unchecked(self.position).generation,
+            &self.fetch,
+            self.position,
+        );
         self.position += 1;
-        Some((*entity, item))
+        Some(item)
     }
 
     fn remaining(&self) -> usize {
@@ -1018,17 +1055,10 @@ pub struct Batch<'q, Q: Query> {
 }
 
 impl<'q, Q: Query> Iterator for Batch<'q, Q> {
-    type Item = (Entity, Q::Item<'q>);
+    type Item = Q::Item<'q>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (id, components) = unsafe { self.state.next()? };
-        Some((
-            Entity {
-                id,
-                generation: self.meta[id as usize].generation,
-            },
-            components,
-        ))
+        unsafe { self.state.next(self.meta) }
     }
 }
 
@@ -1088,10 +1118,10 @@ macro_rules! tuple_impl {
             type Fetch = ($($name::Fetch,)*);
 
             #[allow(unused_variables, clippy::unused_unit)]
-            unsafe fn get<'q>(fetch: &Self::Fetch, n: usize) -> Self::Item<'q> {
+            unsafe fn get<'q>(generation: NonZeroU32, fetch: &Self::Fetch, n: usize) -> Self::Item<'q> {
                 #[allow(non_snake_case)]
                 let ($(ref $name,)*) = *fetch;
-                ($($name::get($name, n),)*)
+                ($($name::get(generation, $name, n),)*)
             }
         }
 
@@ -1271,26 +1301,20 @@ unsafe impl<Q: Query> Send for PreparedQueryIter<'_, Q> where for<'a> Q::Item<'a
 unsafe impl<Q: Query> Sync for PreparedQueryIter<'_, Q> where for<'a> Q::Item<'a>: Send {}
 
 impl<'q, Q: Query> Iterator for PreparedQueryIter<'q, Q> {
-    type Item = (Entity, Q::Item<'q>);
+    type Item = Q::Item<'q>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            match unsafe { self.iter.next() } {
+            match unsafe { self.iter.next(self.meta) } {
                 None => {
                     let (idx, state) = self.state.next()?;
                     let archetype = &self.archetypes[*idx];
                     self.iter = ChunkIter::new(archetype, Q::Fetch::execute(archetype, *state));
                     continue;
                 }
-                Some((id, components)) => {
-                    return Some((
-                        Entity {
-                            id,
-                            generation: unsafe { self.meta.get_unchecked(id as usize).generation },
-                        },
-                        components,
-                    ));
+                Some(components) => {
+                    return Some(components);
                 }
             }
         }
@@ -1359,7 +1383,7 @@ impl<'q, Q: Query> View<'q, Q> {
 
         self.fetch[meta.location.archetype as usize]
             .as_ref()
-            .map(|fetch| unsafe { Q::get(fetch, meta.location.index as usize) })
+            .map(|fetch| unsafe { Q::get(entity.generation, fetch, meta.location.index as usize) })
     }
 
     /// Retrieve the query results corresponding to `entity`
@@ -1393,7 +1417,7 @@ impl<'q, Q: Query> View<'q, Q> {
 
         self.fetch[meta.location.archetype as usize]
             .as_ref()
-            .map(|fetch| Q::get(fetch, meta.location.index as usize))
+            .map(|fetch| Q::get(entity.generation, fetch, meta.location.index as usize))
     }
 
     /// Like `get_mut`, but allows checked simultaneous access to multiple entities
@@ -1456,7 +1480,7 @@ impl<'q, Q: Query> View<'q, Q> {
 
 impl<'a, Q: Query> IntoIterator for &'a mut View<'_, Q> {
     type IntoIter = ViewIter<'a, Q>;
-    type Item = (Entity, Q::Item<'a>);
+    type Item = Q::Item<'a>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
@@ -1472,12 +1496,12 @@ pub struct ViewIter<'a, Q: Query> {
 }
 
 impl<'a, Q: Query> Iterator for ViewIter<'a, Q> {
-    type Item = (Entity, Q::Item<'a>);
+    type Item = Q::Item<'a>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            match unsafe { self.iter.next() } {
+            match unsafe { self.iter.next(self.meta) } {
                 None => {
                     let archetype = self.archetypes.next()?;
                     let fetch = self.fetches.next()?;
@@ -1486,14 +1510,8 @@ impl<'a, Q: Query> Iterator for ViewIter<'a, Q> {
                         .map_or(ChunkIter::empty(), |fetch| ChunkIter::new(archetype, fetch));
                     continue;
                 }
-                Some((id, components)) => {
-                    return Some((
-                        Entity {
-                            id,
-                            generation: unsafe { self.meta.get_unchecked(id as usize).generation },
-                        },
-                        components,
-                    ));
+                Some(components) => {
+                    return Some(components);
                 }
             }
         }
@@ -1551,7 +1569,7 @@ impl<'q, Q: Query> PreparedView<'q, Q> {
 
         self.fetch[meta.location.archetype as usize]
             .as_ref()
-            .map(|fetch| unsafe { Q::get(fetch, meta.location.index as usize) })
+            .map(|fetch| unsafe { Q::get(entity.generation, fetch, meta.location.index as usize) })
     }
 
     /// Retrieve the query results corresponding to `entity`
@@ -1585,7 +1603,7 @@ impl<'q, Q: Query> PreparedView<'q, Q> {
 
         self.fetch[meta.location.archetype as usize]
             .as_ref()
-            .map(|fetch| Q::get(fetch, meta.location.index as usize))
+            .map(|fetch| Q::get(entity.generation, fetch, meta.location.index as usize))
     }
 
     /// Like `get_mut`, but allows checked simultaneous access to multiple entities
@@ -1629,7 +1647,7 @@ impl<'q, Q: Query> PreparedView<'q, Q> {
 
 impl<'a, Q: Query> IntoIterator for &'a mut PreparedView<'_, Q> {
     type IntoIter = ViewIter<'a, Q>;
-    type Item = (Entity, Q::Item<'a>);
+    type Item = Q::Item<'a>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
@@ -1749,7 +1767,7 @@ impl<Q: Query> Drop for ViewBorrow<'_, Q> {
 
 impl<'a, Q: Query> IntoIterator for &'a mut ViewBorrow<'_, Q> {
     type IntoIter = ViewIter<'a, Q>;
-    type Item = (Entity, Q::Item<'a>);
+    type Item = Q::Item<'a>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {

--- a/src/query_one.rs
+++ b/src/query_one.rs
@@ -1,10 +1,12 @@
 use core::marker::PhantomData;
+use core::num::NonZeroU32;
 
 use crate::query::{assert_borrow, Fetch, With, Without};
 use crate::{Archetype, Query};
 
 /// A borrow of a [`World`](crate::World) sufficient to execute the query `Q` on a single entity
 pub struct QueryOne<'a, Q: Query> {
+    generation: NonZeroU32,
     archetype: &'a Archetype,
     index: u32,
     borrowed: bool,
@@ -17,10 +19,11 @@ impl<'a, Q: Query> QueryOne<'a, Q> {
     /// # Safety
     ///
     /// `index` must be in-bounds for `archetype`
-    pub(crate) unsafe fn new(archetype: &'a Archetype, index: u32) -> Self {
+    pub(crate) unsafe fn new(generation: NonZeroU32, archetype: &'a Archetype, index: u32) -> Self {
         assert_borrow::<Q>();
 
         Self {
+            generation,
             archetype,
             index,
             borrowed: false,
@@ -43,7 +46,7 @@ impl<'a, Q: Query> QueryOne<'a, Q> {
         Q::Fetch::borrow(self.archetype, state);
         let fetch = Q::Fetch::execute(self.archetype, state);
         self.borrowed = true;
-        unsafe { Some(Q::get(&fetch, self.index as usize)) }
+        unsafe { Some(Q::get(self.generation, &fetch, self.index as usize)) }
     }
 
     /// Transform the query into one that requires another query be satisfied
@@ -63,6 +66,7 @@ impl<'a, Q: Query> QueryOne<'a, Q> {
     /// Helper to change the type of the query
     fn transform<R: Query>(mut self) -> QueryOne<'a, R> {
         let x = QueryOne {
+            generation: self.generation,
             archetype: self.archetype,
             index: self.index,
             borrowed: self.borrowed,

--- a/src/world.rs
+++ b/src/world.rs
@@ -357,11 +357,11 @@ impl World {
     ///
     /// Prefer [`query_mut`](Self::query_mut) when concurrent access to the [`World`] is not required.
     ///
-    /// Calling `iter` on the returned value yields `(Entity, Q)` tuples, where `Q` is some query
-    /// type. A query type is any type for which an implementation of [`Query`] exists, e.g. `&T`,
-    /// `&mut T`, a tuple of query types, or an `Option` wrapping a query type, where `T` is any
-    /// component type. Components queried with `&mut` must only appear once. Entities which do not
-    /// have a component type referenced outside of an `Option` will be skipped.
+    /// Calling `iter` on the returned value yields values of type `Q`, where `Q` is some query
+    /// type. A query type is any type which implements [`Query`], e.g. `Entity`, `&T`, `&mut T`, a
+    /// tuple of query types, or an `Option` wrapping a query type, where `T` is any component type.
+    /// Components queried with `&mut` must only appear once. Entities which do not have a component
+    /// type referenced outside of an `Option` will be skipped.
     ///
     /// Entities are yielded in arbitrary order.
     ///
@@ -386,9 +386,9 @@ impl World {
     /// let a = world.spawn((123, true, "abc"));
     /// let b = world.spawn((456, false));
     /// let c = world.spawn((42, "def"));
-    /// let entities = world.query::<(&i32, &bool)>()
+    /// let entities = world.query::<(Entity, &i32, &bool)>()
     ///     .iter()
-    ///     .map(|(e, (&i, &b))| (e, i, b)) // Copy out of the world
+    ///     .map(|(e, &i, &b)| (e, i, b)) // Copy out of the world
     ///     .collect::<Vec<_>>();
     /// assert_eq!(entities.len(), 2);
     /// assert!(entities.contains(&(a, 123, true)));
@@ -465,6 +465,7 @@ impl World {
         let loc = self.entities.get(entity)?;
         Ok(unsafe {
             QueryOne::new(
+                entity.generation,
                 &self.archetypes.archetypes[loc.archetype as usize],
                 loc.index,
             )
@@ -486,7 +487,7 @@ impl World {
         let archetype = &self.archetypes.archetypes[loc.archetype as usize];
         let state = Q::Fetch::prepare(archetype).ok_or(QueryOneError::Unsatisfied)?;
         let fetch = Q::Fetch::execute(archetype, state);
-        unsafe { Ok(Q::get(&fetch, loc.index as usize)) }
+        unsafe { Ok(Q::get(entity.generation, &fetch, loc.index as usize)) }
     }
 
     /// Query a fixed number of distinct entities in a uniquely borrowed world
@@ -506,7 +507,7 @@ impl World {
             let archetype = &self.archetypes.archetypes[loc.archetype as usize];
             let state = Q::Fetch::prepare(archetype).ok_or(QueryOneError::Unsatisfied)?;
             let fetch = Q::Fetch::execute(archetype, state);
-            unsafe { Ok(Q::get(&fetch, loc.index as usize)) }
+            unsafe { Ok(Q::get(entity.generation, &fetch, loc.index as usize)) }
         })
     }
 


### PR DESCRIPTION
Fixes #234.

By plumbing the generation of each entity down through `Query::get`, we can implement `Query` for `Entity`, allowing us to stop unconditionally yielding `Entity` from every query, improving ergonomics in the common case where the `Entity` handle is unwanted, and reducing tuple unwrapping even when it's wanted.

TODO:
- Verify that this doesn't mess up codegen too much. It *should* optimize out trivially, but you never know.
- Think harder/gather feedback about which behavior is desirable for `ViewIter`. Consider offering both.
- Prominently document this non-obvious `Query` implementation