### PR TITLE
Fix `impl Send for Ref<T>`: use `Send` bound, instead of `Sync`

### DIFF
--- a/src/entity_ref.rs
+++ b/src/entity_ref.rs
@@ -136,7 +136,7 @@ impl<'a, T: Component> Ref<'a, T> {
     }
 }
 
-unsafe impl<T: ?Sized + Sync> Send for Ref<'_, T> {}
+unsafe impl<T: ?Sized + Send> Send for Ref<'_, T> {}
 unsafe impl<T: ?Sized + Sync> Sync for Ref<'_, T> {}
 
 impl<'a, T: ?Sized> Ref<'a, T> {


### PR DESCRIPTION
I don't think using `Sync` is the right bound here?