### PR TITLE
Added an Iterator::fold implementation for QueryIter.

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -158,6 +158,23 @@ fn iterate_mut_100k(c: &mut Criterion) {
     });
 }
 
+fn for_each_100k(c: &mut Criterion) {
+    let mut world = World::new();
+    for i in 0..100_000 {
+        world.spawn((Position(-(i as f32)), Velocity(i as f32)));
+    }
+    c.bench_function("for_each 100k", |b| {
+        b.iter(|| {
+            world
+                .query::<(&mut Position, &Velocity)>()
+                .iter()
+                .for_each(|(pos, vel)| {
+                    pos.0 += vel.0;
+                });
+        })
+    });
+}
+
 fn spawn_100_by_50(world: &mut World) {
     fn spawn_two<const N: usize>(world: &mut World, i: i32) {
         world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); N]));
@@ -323,6 +340,7 @@ criterion_group!(
     exchange,
     iterate_100k,
     iterate_mut_100k,
+    for_each_100k,
     iterate_uncached_100_by_50,
     iterate_uncached_1_of_100_by_50,
     iterate_cached_100_by_50,

--- a/src/query.rs
+++ b/src/query.rs
@@ -836,6 +836,32 @@ impl<'q, Q: Query> Iterator for QueryIter<'q, Q> {
         let n = self.len();
         (n, Some(n))
     }
+
+    // We're implementing this because some `Iterator`-consuming methods are
+    // implemented using `Iterator::fold`. With an optmized version implemented
+    // without actually calling `Iterator::next`, they all benefit from
+    // improved performance. See `for_each_100k` bench.
+    //
+    // TODO: Once `Try` is stable, implement `Iterator::try_fold` instead. This
+    // will make *all* `Iterator`-consuming methods rely on that
+    // implementation.
+    fn fold<B, F>(mut self, mut init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        loop {
+            while let Some(components) = unsafe { self.iter.next(self.world.entities_meta()) } {
+                init = f(init, components);
+            }
+
+            if let Some(iter) = unsafe { self.archetypes.next(self.world) } {
+                self.iter = iter;
+            } else {
+                break init;
+            }
+        }
+    }
 }
 
 impl<Q: Query> ExactSizeIterator for QueryIter<'_, Q> {


### PR DESCRIPTION
This implementation enables internal iteration for many Iterator methods that are implemented using `Iterator::fold` which greatly improves their performance.

Unfortunately, `Iterator::try_fold` cannot be implemented instead until `Try` becomes stable.

Improvements for the `for_each_100k` benchmark:

```
for_each 100k           time:   [32.154 µs 32.188 µs 32.221 µs]
                        change: [−79.807% −79.750% −79.704%] (p = 0.00 < 0.05)
                        Performance has improved.
```