### PR TITLE
feat: make `T: /*snip */ impl Component` a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["std"]
+default = ["std", "blanket-component"]
 std = []
 # Enables derive(Bundle) and derive(Query)
 macros = ["hecs-macros"]
@@ -27,6 +27,8 @@ macros = ["hecs-macros"]
 column-serialize = ["serde"]
 # Enables the serialize::row module
 row-serialize = ["serde"]
+# enables all T to implement Component
+blanket-component = []
 
 [dependencies]
 hecs-macros = { path = "macros", version = "0.11.1", optional = true }

--- a/src/world.rs
+++ b/src/world.rs
@@ -1047,11 +1047,13 @@ impl From<NoSuchEntity> for QueryOneError {
     }
 }
 
-/// Types that can be components, implemented automatically for all `Send + Sync + 'static` types
+/// Types that can be components.
 ///
-/// This is just a convenient shorthand for `Send + Sync + 'static`, and never needs to be
-/// implemented manually.
+/// With the default features enabled, Component is implemented for all `Send + Sync + 'static` types.
+/// Otherwise, users must implement component for each type on their own.
 pub trait Component: Send + Sync + 'static {}
+
+#[cfg(feature = "blanket-component")]
 impl<T: Send + Sync + 'static> Component for T {}
 
 /// Iterator over all of a world's entities


### PR DESCRIPTION
This is more of a discussion than a full PR -- I think more documentation would be needed to actually merge this.

This PR is about making hecs require a trait to allow a component to be in the ECS.

I explored three different methods of making hecs require a trait to allow a component to be added to the ECS:

1. The first is this PR. It's kind of a hack, but it's relatively clean. The big loss is any library which uses hecs but then re-exports it, where feature unification will make someone unhappy.
2. The second was making a macro which wraps hecs and allows a user to create "MyOwnHecs" by wrapping every method on `hecs::World` with a required feature. It was very boilerplate-y, but entirely external to hecs. That isn't such a bad thing! That may still be the best approach since it rocks the boat the least.
3. The final approach was adding a bound which took a trait which was impled by a ZST directly into hecs, like this:

```
pub trait Satisfies<T: ?Sized> {}

pub struct DefaultPolicy;
impl<T: Send + Sync + 'static + ?Sized> Satisfies<T> for DefaultPolicy {}

pub struct World<P = DefaultPolicy>;

impl<P> World<P> {
    pub fn insert_one<T: Component>(&mut self, e: Entity, c: T) -> Result<(), NoSuchEntity>
    where
        P: Satisfies<T>,
    { /* ... */ }
}
```
This seemed promising at first, but the ergnomics that `P = DefaultPolicy` seem to offer really fall apart, and simple code which currently compiles fails to compile (notably `let world = World::new()`). I think this is the wrong approach right now.

I think it's reasonable to point that this is a non-goal of hecs, but at the same time, every mature game that I know of which uses hecs does seem to wrap hecs such that components must satisfy some trait to be added to the ECS.