### PR TITLE
Use range for instead of next in fold

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -852,9 +852,7 @@ impl<'q, Q: Query> Iterator for QueryIter<'q, Q> {
         F: FnMut(B, Self::Item) -> B,
     {
         loop {
-            while let Some(components) = unsafe { self.iter.next(self.world.entities_meta()) } {
-                init = f(init, components);
-            }
+            init = unsafe { self.iter.fold(self.world.entities_meta(), init, &mut f) };
 
             if let Some(iter) = unsafe { self.archetypes.next(self.world) } {
                 self.iter = iter;
@@ -997,6 +995,20 @@ impl<Q: Query> ChunkIter<Q> {
         let item = Q::get(meta, &self.fetch, self.position);
         self.position += 1;
         Some(item)
+    }
+
+    #[inline]
+    unsafe fn fold<'a, B, F>(&mut self, meta: &[EntityMeta], mut init: B, mut f: F) -> B
+    where
+        F: FnMut(B, Q::Item<'a>) -> B,
+    {
+        for i in self.position..self.len {
+            let components = unsafe { Q::get(meta, &self.fetch, i) };
+
+            init = f(init, components);
+        }
+
+        init
     }
 
     fn remaining(&self) -> usize {

--- a/src/query.rs
+++ b/src/query.rs
@@ -1002,7 +1002,11 @@ impl<Q: Query> ChunkIter<Q> {
     where
         F: FnMut(B, Q::Item<'a>) -> B,
     {
-        for i in self.position..self.len {
+        let start = self.position;
+        // Fold should consume the iterator, even if F panics.
+        self.position = self.len;
+
+        for i in start..self.len {
             let components = unsafe { Q::get(meta, &self.fetch, i) };
 
             init = f(init, components);


### PR DESCRIPTION
Related (but doesn't fix): #351

Allows the compiler to optimise more by giving it extra information to work with, namely giving it proper length information instead of hoping it peeks through repeated while let calls.

By all rights it should be able to optimise without this change but possibly due to some non-optimal optimisation ordering it doesn't end up being able to vectorize loops, even though it inlines everything to essentially a range for in the end.

The for_each 100k benchmark goes from 100 µs to 22 µs on my system, about a 4x speedup (which tracks with using 128-bit SIMD instructions). Now this is a very contrived benchmark and I suspect actual gains will be much less impactful, but might as well..?

This doesn't change the speed of the iterate mut 100k benchmark, which doesn't use fold (perhaps there should be more documentation explaining that fold/for_each should be used when possible).