### PR TITLE
Add fold method to Batch and PreparedQueryIter

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -175,6 +175,41 @@ fn for_each_100k(c: &mut Criterion) {
     });
 }
 
+fn for_each_prepared_100k(c: &mut Criterion) {
+    let mut world = World::new();
+    for i in 0..100_000 {
+        world.spawn((Position(-(i as f32)), Velocity(i as f32)));
+    }
+    let mut query = PreparedQuery::<(&mut Position, &Velocity)>::new();
+    let mut query = query.query(&world);
+    c.bench_function("for_each_prepared 100k", |b| {
+        b.iter(|| {
+            query.iter().for_each(|(pos, vel)| {
+                pos.0 += vel.0;
+            });
+        })
+    });
+}
+
+fn for_each_batched_100k(c: &mut Criterion) {
+    let mut world = World::new();
+    for i in 0..100_000 {
+        world.spawn((Position(-(i as f32)), Velocity(i as f32)));
+    }
+    c.bench_function("for_each_batched 100k", |b| {
+        b.iter(|| {
+            world
+                .query::<(&mut Position, &Velocity)>()
+                .iter_batched(4096)
+                .for_each(|batch| {
+                    batch.for_each(|(pos, vel)| {
+                        pos.0 += vel.0;
+                    });
+                });
+        })
+    });
+}
+
 fn spawn_100_by_50(world: &mut World) {
     fn spawn_two<const N: usize>(world: &mut World, i: i32) {
         world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); N]));
@@ -341,6 +376,8 @@ criterion_group!(
     iterate_100k,
     iterate_mut_100k,
     for_each_100k,
+    for_each_prepared_100k,
+    for_each_batched_100k,
     iterate_uncached_100_by_50,
     iterate_uncached_1_of_100_by_50,
     iterate_cached_100_by_50,

--- a/src/query.rs
+++ b/src/query.rs
@@ -845,7 +845,7 @@ impl<'q, Q: Query> Iterator for QueryIter<'q, Q> {
     //
     // TODO: Once `Try` is stable, implement `Iterator::try_fold` instead. This
     // will make *all* `Iterator`-consuming methods rely on that
-    // implementation.
+    // implementation. Also implement it for `PreparedQueryIter` and `Batch`
     fn fold<B, F>(mut self, mut init: B, mut f: F) -> B
     where
         Self: Sized,
@@ -1102,6 +1102,14 @@ impl<'q, Q: Query> Iterator for Batch<'q, Q> {
 
     fn next(&mut self) -> Option<Self::Item> {
         unsafe { self.state.next(self.meta) }
+    }
+
+    fn fold<B, F>(mut self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        unsafe { self.state.fold(self.meta, init, f) }
     }
 }
 
@@ -1371,6 +1379,23 @@ impl<'q, Q: Query> Iterator for PreparedQueryIter<'q, Q> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         let n = self.len();
         (n, Some(n))
+    }
+
+    fn fold<B, F>(mut self, mut init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        loop {
+            init = unsafe { self.iter.fold(self.meta, init, &mut f) };
+
+            if let Some((idx, state)) = self.state.next() {
+                let archetype = &self.archetypes[*idx];
+                self.iter = ChunkIter::new(archetype, Q::Fetch::execute(archetype, *state));
+            } else {
+                break init;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Add their fold implementation and benchmarks.

For `PreparedQueryIter`, there is a −67% time decrease: from 25us to 8.1us.
For `Batch`, there is basically no improvement. But due to the uncertainty of compiler optimization, I think this may still be useful.