### PR TITLE
Require manual Component implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Unreleased
+
+### Changed
+
+- `Component` is no longer automatically implemented for all `Send + Sync + 'static` types. Types
+  must now implement it explicitly, either by hand (`impl Component for Position {}`) or with the
+  new `#[derive(Component)]` macro from the `hecs-macros` crate (enabled by the `macros` feature).
+  This rules out accidental use of third-party types as components and leaves the door open for
+  future trait extensions.
+
 # 0.11.1
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,16 +13,24 @@ your application however you like!
 
 ```rust
 let mut world = hecs::World::new();
-// Nearly any type can be used as a component with zero boilerplate
-let a = world.spawn((123, true, "abc"));
-let b = world.spawn((42, false));
+
+// Component types can be defined with minimal boilerplate
+struct Name(&'static str);
+impl hecs::Component for Name {}
+struct Weight(u32);
+impl hecs::Component for Weight {}
+struct Price(u32);
+impl hecs::Component for Price {}
+
+let a = world.spawn((Name("abc"), Weight(12), Price(123)));
+let b = world.spawn((Weight(38), Price(42)));
 // Systems can be simple for loops
-for (number, &flag) in world.query_mut::<(&mut i32, &bool)>() {
-  if flag { *number *= 2; }
+for (price, weight) in world.query_mut::<(&mut Price, &Weight)>() {
+  if weight.0 < 20 { price.0 *= 2; }
 }
 // Random access is simple and safe
-assert_eq!(*world.get::<&i32>(a).unwrap(), 246);
-assert_eq!(*world.get::<&i32>(b).unwrap(), 42);
+assert_eq!(world.get::<&Price>(a).unwrap().0, 246);
+assert_eq!(world.get::<&Price>(b).unwrap().0, 42);
 ```
 
 ### Why ECS?

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -7,8 +7,14 @@ use hecs::*;
 
 #[derive(Clone)]
 struct Position(f32);
+impl Component for Position {}
 #[derive(Clone)]
 struct Velocity(f32);
+impl Component for Velocity {}
+
+/// Stand-in component used to populate worlds with interesting archetype shapes
+struct Extra<const N: usize>;
+impl<const N: usize> Component for Extra<N> {}
 
 fn spawn_tuple(c: &mut Criterion) {
     let mut world = World::new();
@@ -108,8 +114,8 @@ fn insert_remove(c: &mut Criterion) {
         b.iter(|| {
             let e = *entities.next().unwrap();
             world.remove_one::<Velocity>(e).unwrap();
-            world.insert_one(e, true).unwrap();
-            world.remove_one::<bool>(e).unwrap();
+            world.insert_one(e, Extra::<0>).unwrap();
+            world.remove_one::<Extra<0>>(e).unwrap();
             world.insert_one(e, Velocity(0.0)).unwrap();
         })
     });
@@ -124,8 +130,8 @@ fn exchange(c: &mut Criterion) {
     c.bench_function("exchange", |b| {
         b.iter(|| {
             let e = *entities.next().unwrap();
-            world.exchange_one::<Velocity, _>(e, true).unwrap();
-            world.exchange_one::<bool, _>(e, Velocity(0.0)).unwrap();
+            world.exchange_one::<Velocity, _>(e, Extra::<0>).unwrap();
+            world.exchange_one::<Extra<0>, _>(e, Velocity(0.0)).unwrap();
         })
     });
 }
@@ -212,8 +218,8 @@ fn for_each_batched_100k(c: &mut Criterion) {
 
 fn spawn_100_by_50(world: &mut World) {
     fn spawn_two<const N: usize>(world: &mut World, i: i32) {
-        world.spawn((Position(-(i as f32)), Velocity(i as f32), [(); N]));
-        world.spawn((Position(-(i as f32)), [(); N]));
+        world.spawn((Position(-(i as f32)), Velocity(i as f32), Extra::<N>));
+        world.spawn((Position(-(i as f32)), Extra::<N>));
     }
 
     for i in 0..2 {
@@ -264,7 +270,7 @@ fn iterate_uncached_1_of_100_by_50(c: &mut Criterion) {
         b.iter(|| {
             for (pos, vel) in world
                 .query::<(&mut Position, &Velocity)>()
-                .with::<&[(); 0]>()
+                .with::<&Extra<0>>()
                 .iter()
             {
                 pos.0 += vel.0;
@@ -339,9 +345,9 @@ fn build_cloneable(c: &mut Criterion) {
 fn access_view(c: &mut Criterion) {
     let mut world = World::new();
     let _enta = world.spawn((Position(0.0), Velocity(0.0)));
-    let _entb = world.spawn((true, 12));
+    let _entb = world.spawn((Extra::<0>, Extra::<1>));
     let entc = world.spawn((Position(3.0),));
-    let _entd = world.spawn((13, true, 4.0));
+    let _entd = world.spawn((Extra::<1>, Extra::<2>, Extra::<3>));
     let mut query = PreparedQuery::<&Position>::new();
     let mut query = query.query(&world);
     let view = query.view();

--- a/examples/cloning.rs
+++ b/examples/cloning.rs
@@ -10,6 +10,19 @@ use std::any::TypeId;
 
 use hecs::{Archetype, ColumnBatchBuilder, ColumnBatchType, Component, TypeIdMap, TypeInfo, World};
 
+#[derive(Clone, Debug, PartialEq)]
+struct Count(i32);
+impl Component for Count {}
+
+#[derive(Clone, Debug, PartialEq)]
+struct Name(String);
+impl Component for Name {}
+
+/// A component that will not be registered with the [`WorldCloner`]
+#[derive(Clone, Debug, PartialEq)]
+struct Marker(u8);
+impl Component for Marker {}
+
 struct ComponentCloneMetadata {
     type_info: TypeInfo,
     insert_into_batch_func: &'static dyn Fn(&Archetype, &mut ColumnBatchBuilder),
@@ -75,21 +88,15 @@ impl WorldCloner {
 }
 
 pub fn main() {
-    let int0 = 0;
-    let int1 = 1;
-    let str0 = "Ada".to_owned();
-    let str1 = "Bob".to_owned();
-    let str2 = "Cal".to_owned();
-
     let mut world0 = World::new();
-    let entity0 = world0.spawn((int0, str0));
-    let entity1 = world0.spawn((int1, str1));
-    let entity2 = world0.spawn((str2,));
-    let entity3 = world0.spawn((0u8,)); // unregistered component
+    let entity0 = world0.spawn((Count(0), Name("Ada".to_owned())));
+    let entity1 = world0.spawn((Count(1), Name("Bob".to_owned())));
+    let entity2 = world0.spawn((Name("Cal".to_owned()),));
+    let entity3 = world0.spawn((Marker(0),)); // unregistered component
 
     let mut cloner = WorldCloner::default();
-    cloner.register::<i32>();
-    cloner.register::<String>();
+    cloner.register::<Count>();
+    cloner.register::<Name>();
 
     let world1 = cloner.clone_world(&world0);
 
@@ -104,18 +111,18 @@ pub fn main() {
         world0
             .entity(entity3)
             .expect("w0 entity3 should exist")
-            .has::<u8>(),
-        "original world entity has u8 component"
+            .has::<Marker>(),
+        "original world entity has Marker component"
     );
     assert!(
         !world1
             .entity(entity3)
             .expect("w1 entity3 should exist")
-            .has::<u8>(),
-        "cloned world entity does not have u8 component because it was not registered"
+            .has::<Marker>(),
+        "cloned world entity does not have Marker component because it was not registered"
     );
 
-    type AllRegisteredComponentsQuery = (&'static i32, &'static String);
+    type AllRegisteredComponentsQuery = (&'static Count, &'static Name);
     for entity in [entity0, entity1] {
         let w0_e = world0.entity(entity).expect("w0 entity should exist");
         let w1_e = world1.entity(entity).expect("w1 entity should exist");
@@ -128,7 +135,7 @@ pub fn main() {
         );
     }
 
-    type SomeRegisteredComponentsQuery = (&'static String,);
+    type SomeRegisteredComponentsQuery = (&'static Name,);
     let w0_e = world0.entity(entity2).expect("w0 entity2 should exist");
     let w1_e = world1.entity(entity2).expect("w1 entity2 should exist");
     assert!(w0_e.satisfies::<SomeRegisteredComponentsQuery>());

--- a/examples/ffa_simulation.rs
+++ b/examples/ffa_simulation.rs
@@ -19,18 +19,23 @@ struct Position {
     x: i32,
     y: i32,
 }
+impl Component for Position {}
 
 #[derive(Debug)]
 struct Health(i32);
+impl Component for Health {}
 
 #[derive(Debug)]
 struct Speed(i32);
+impl Component for Speed {}
 
 #[derive(Debug)]
 struct Damage(i32);
+impl Component for Damage {}
 
 #[derive(Debug)]
 struct KillCount(i32);
+impl Component for KillCount {}
 
 fn manhattan_dist(x0: i32, x1: i32, y0: i32, y1: i32) -> i32 {
     let dx = (x0 - x1).abs();

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -3,12 +3,36 @@
 
 type FormattingFunction = &'static dyn Fn(hecs::EntityRef<'_>) -> Option<String>;
 
+struct Number(i32);
+impl hecs::Component for Number {}
+impl std::fmt::Display for Number {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+struct Flag(bool);
+impl hecs::Component for Flag {}
+impl std::fmt::Display for Flag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+struct Ratio(f64);
+impl hecs::Component for Ratio {}
+impl std::fmt::Display for Ratio {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 fn format_entity(entity: hecs::EntityRef<'_>) -> String {
     fn fmt<T: hecs::Component + std::fmt::Display>(entity: hecs::EntityRef<'_>) -> Option<String> {
         Some(entity.get::<&T>()?.to_string())
     }
 
-    const FUNCTIONS: &[FormattingFunction] = &[&fmt::<i32>, &fmt::<bool>, &fmt::<f64>];
+    const FUNCTIONS: &[FormattingFunction] = &[&fmt::<Number>, &fmt::<Flag>, &fmt::<Ratio>];
 
     let mut out = String::new();
     for f in FUNCTIONS {
@@ -31,6 +55,6 @@ fn format_entity(entity: hecs::EntityRef<'_>) -> String {
 
 fn main() {
     let mut world = hecs::World::new();
-    let e = world.spawn((42, true));
+    let e = world.spawn((Number(42), Flag(true)));
     println!("{}", format_entity(world.entity(e).unwrap()));
 }

--- a/examples/serialize_to_disk.rs
+++ b/examples/serialize_to_disk.rs
@@ -35,16 +35,19 @@ struct SaveContextDeserialize {
 }
 
 // Components of our world.
-// Only Serialize and Deserialize derives are necessary.
+// In addition to implementing `Component`, types need Serialize and Deserialize derives to be
+// included in the serialization process.
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]
 struct ComponentA {
     data: usize,
 }
+impl hecs::Component for ComponentA {}
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]
 struct ComponentB {
     some_other_data: String,
 }
+impl hecs::Component for ComponentB {}
 
 impl DeserializeContext for SaveContextDeserialize {
     fn deserialize_component_ids<'de, A>(&mut self, mut seq: A) -> Result<ColumnBatchType, A::Error>

--- a/examples/transform_hierarchy.rs
+++ b/examples/transform_hierarchy.rs
@@ -12,6 +12,7 @@ struct Parent {
     /// Converts child-relative coordinates to parent-relative coordinates
     from_child: Transform,
 }
+impl Component for Parent {}
 
 fn main() {
     let mut world = World::new();
@@ -100,6 +101,7 @@ fn evaluate_relative_transforms(world: &mut World) {
 // In practice this would usually also include rotation, or even be a general homogeneous matrix
 #[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
 struct Transform(i32, i32);
+impl Component for Transform {}
 
 impl std::ops::Mul for Transform {
     type Output = Transform;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -7,6 +7,7 @@ mod query;
 pub(crate) mod common;
 
 use proc_macro::TokenStream;
+use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
 /// Implement `Bundle` for a struct
@@ -17,15 +18,23 @@ use syn::{parse_macro_input, DeriveInput};
 /// # Example
 /// ```
 /// # use hecs::*;
+/// #[derive(Debug, PartialEq)]
+/// struct X(i32);
+/// impl Component for X {}
+///
+/// #[derive(Debug, PartialEq)]
+/// struct Y(char);
+/// impl Component for Y {}
+///
 /// #[derive(Bundle)]
 /// struct Foo {
-///     x: i32,
-///     y: char,
+///     x: X,
+///     y: Y,
 /// }
 ///
 /// let mut world = World::new();
-/// let e = world.spawn(Foo { x: 42, y: 'a' });
-/// assert_eq!(*world.get::<&i32>(e).unwrap(), 42);
+/// let e = world.spawn(Foo { x: X(42), y: Y('a') });
+/// assert_eq!(*world.get::<&X>(e).unwrap(), X(42));
 /// ```
 #[proc_macro_derive(Bundle)]
 pub fn derive_bundle(input: TokenStream) -> TokenStream {
@@ -68,19 +77,27 @@ pub fn derive_dynamic_bundle_clone(input: TokenStream) -> TokenStream {
 /// # Example
 /// ```
 /// # use hecs::*;
+/// #[derive(Debug, PartialEq)]
+/// struct X(i32);
+/// impl Component for X {}
+///
+/// #[derive(Debug, PartialEq)]
+/// struct Y(bool);
+/// impl Component for Y {}
+///
 /// #[derive(Query, Debug, PartialEq)]
 /// struct Foo<'a> {
-///     x: &'a i32,
-///     y: &'a mut bool,
+///     x: &'a X,
+///     y: &'a mut Y,
 /// }
 ///
 /// let mut world = World::new();
-/// let e = world.spawn((42, false));
+/// let e = world.spawn((X(42), Y(false)));
 /// assert_eq!(
 ///     world.query_one_mut::<Foo>(e).unwrap(),
 ///     Foo {
-///         x: &42,
-///         y: &mut false
+///         x: &X(42),
+///         y: &mut Y(false)
 ///     }
 /// );
 /// ```
@@ -92,4 +109,25 @@ pub fn derive_query(input: TokenStream) -> TokenStream {
         Err(e) => e.to_compile_error(),
     }
     .into()
+}
+
+/// Implement `Component` for some type.
+///
+/// Convenience short-hand for `impl Component for T {}`.
+///
+/// Generic type parameters automatically receive the `Send + Sync + 'static` bounds required by the
+/// trait's supertraits. When this is inappropriate, use a manual implementation instead.
+#[proc_macro_derive(Component)]
+pub fn derive_component(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let ident = input.ident;
+    let mut generics = input.generics;
+    for param in generics.type_params_mut() {
+        param.bounds.push(syn::parse_quote!(::core::marker::Send));
+        param.bounds.push(syn::parse_quote!(::core::marker::Sync));
+        param.bounds.push(syn::parse_quote!('static));
+    }
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    quote! { impl #impl_generics ::hecs::Component for #ident #ty_generics #where_clause {} }.into()
 }

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -199,43 +199,55 @@ impl fmt::Display for BatchIncomplete {
 mod tests {
     use super::*;
 
+    #[derive(Debug, PartialEq)]
+    struct Idx(usize);
+    impl Component for Idx {}
+    #[derive(Debug)]
+    struct Flag;
+    impl Component for Flag {}
+    #[cfg(feature = "std")]
+    #[derive(Debug)]
+    struct Counted(#[allow(dead_code)] std::sync::Arc<()>);
+    #[cfg(feature = "std")]
+    impl Component for Counted {}
+
     #[test]
     fn empty_batch() {
         let mut types = ColumnBatchType::new();
-        types.add::<usize>();
+        types.add::<Idx>();
         let builder = types.into_batch(0);
-        let mut writer = builder.writer::<usize>().unwrap();
-        assert!(writer.push(42).is_err());
+        let mut writer = builder.writer::<Idx>().unwrap();
+        assert!(writer.push(Idx(42)).is_err());
     }
 
     #[test]
     fn writer_continues_from_last_fill() {
         let mut types = ColumnBatchType::new();
-        types.add::<usize>();
+        types.add::<Idx>();
         let builder = types.into_batch(2);
         {
-            let mut writer = builder.writer::<usize>().unwrap();
-            writer.push(42).unwrap();
+            let mut writer = builder.writer::<Idx>().unwrap();
+            writer.push(Idx(42)).unwrap();
         }
 
-        let mut writer = builder.writer::<usize>().unwrap();
+        let mut writer = builder.writer::<Idx>().unwrap();
 
-        assert_eq!(writer.push(42), Ok(()));
-        assert_eq!(writer.push(42), Err(42));
+        assert_eq!(writer.push(Idx(42)), Ok(()));
+        assert_eq!(writer.push(Idx(42)), Err(Idx(42)));
     }
 
     #[test]
     fn concurrent_writers() {
         let mut types = ColumnBatchType::new();
-        types.add::<usize>();
-        types.add::<u32>();
+        types.add::<Idx>();
+        types.add::<Flag>();
         let builder = types.into_batch(2);
         {
-            let mut a = builder.writer::<usize>().unwrap();
-            let mut b = builder.writer::<u32>().unwrap();
+            let mut a = builder.writer::<Idx>().unwrap();
+            let mut b = builder.writer::<Flag>().unwrap();
             for i in 0..2 {
-                a.push(i as usize).unwrap();
-                b.push(i).unwrap();
+                a.push(Idx(i)).unwrap();
+                b.push(Flag).unwrap();
             }
         }
         builder.build().unwrap();
@@ -245,10 +257,10 @@ mod tests {
     #[should_panic(expected = "writer still exists")]
     fn aliasing_writers() {
         let mut types = ColumnBatchType::new();
-        types.add::<usize>();
+        types.add::<Idx>();
         let builder = types.into_batch(2);
-        let _a = builder.writer::<usize>().unwrap();
-        let _b = builder.writer::<usize>().unwrap();
+        let _a = builder.writer::<Idx>().unwrap();
+        let _b = builder.writer::<Idx>().unwrap();
     }
 
     #[test]
@@ -257,13 +269,13 @@ mod tests {
         use std::sync::Arc;
 
         let mut types = ColumnBatchType::new();
-        types.add::<Arc<()>>();
+        types.add::<Counted>();
         let builder = types.into_batch(1);
         let value = Arc::new(());
         builder
-            .writer::<Arc<()>>()
+            .writer::<Counted>()
             .unwrap()
-            .push(value.clone())
+            .push(Counted(value.clone()))
             .unwrap();
         assert_eq!(Arc::strong_count(&value), 2);
         drop(builder);

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -38,12 +38,19 @@ pub unsafe trait DynamicBundle {
     /// Checks if the Bundle contains the given `T`:
     ///
     /// ```
-    /// # use hecs::DynamicBundle;
+    /// # use hecs::{Component, DynamicBundle};
+    /// struct Idx(i32);
+    /// impl Component for Idx {}
+    /// struct Size(f32);
+    /// impl Component for Size {}
     ///
-    /// let my_bundle = (0i32, 10.0f32);
-    /// assert!(my_bundle.has::<i32>());
-    /// assert!(my_bundle.has::<f32>());
-    /// assert!(!my_bundle.has::<usize>());
+    /// struct Other;
+    /// impl Component for Other {}
+    ///
+    /// let my_bundle = (Idx(0), Size(10.0));
+    /// assert!(my_bundle.has::<Idx>());
+    /// assert!(my_bundle.has::<Size>());
+    /// assert!(!my_bundle.has::<Other>());
     /// ```
     fn has<T: Component>(&self) -> bool {
         self.with_ids(|types| types.contains(&TypeId::of::<T>()))

--- a/src/change_tracker.rs
+++ b/src/change_tracker.rs
@@ -60,6 +60,7 @@ impl<T: Component> Default for ChangeTracker<T> {
 }
 
 struct Previous<T>(T);
+impl<T: Component> Component for Previous<T> {}
 
 /// Collection of iterators over changes in `T` components
 pub struct Changes<'a, T>
@@ -174,33 +175,39 @@ impl<T: Iterator> Drop for DrainOnDrop<T> {
 mod tests {
     use super::*;
 
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    struct I(i32);
+    impl Component for I {}
+    struct B;
+    impl Component for B {}
+
     #[test]
     fn smoke() {
         let mut world = World::new();
 
-        let a = world.spawn((42,));
-        let b = world.spawn((17, false));
-        let c = world.spawn((true,));
+        let a = world.spawn((I(42),));
+        let b = world.spawn((I(17), B));
+        let c = world.spawn((B,));
 
-        let mut tracker = ChangeTracker::<i32>::new();
+        let mut tracker = ChangeTracker::<I>::new();
         {
             let mut changes = tracker.track(&mut world);
             let added = changes.added().collect::<Vec<_>>();
             assert_eq!(added.len(), 2);
-            assert!(added.contains(&(a, &42)));
-            assert!(added.contains(&(b, &17)));
+            assert!(added.contains(&(a, &I(42))));
+            assert!(added.contains(&(b, &I(17))));
             assert_eq!(changes.changed().count(), 0);
             assert_eq!(changes.removed().count(), 0);
         }
 
-        world.remove_one::<i32>(a).unwrap();
-        *world.get::<&mut i32>(b).unwrap() = 26;
-        world.insert_one(c, 74).unwrap();
+        world.remove_one::<I>(a).unwrap();
+        *world.get::<&mut I>(b).unwrap() = I(26);
+        world.insert_one(c, I(74)).unwrap();
         {
             let mut changes = tracker.track(&mut world);
-            assert_eq!(changes.removed().collect::<Vec<_>>(), [(a, 42)]);
-            assert_eq!(changes.changed().collect::<Vec<_>>(), [(b, 17, &26)]);
-            assert_eq!(changes.added().collect::<Vec<_>>(), [(c, &74)]);
+            assert_eq!(changes.removed().collect::<Vec<_>>(), [(a, I(42))]);
+            assert_eq!(changes.changed().collect::<Vec<_>>(), [(b, I(17), &I(26))]);
+            assert_eq!(changes.added().collect::<Vec<_>>(), [(c, &I(74))]);
         }
         {
             let mut changes = tracker.track(&mut world);

--- a/src/command_buffer.rs
+++ b/src/command_buffer.rs
@@ -17,12 +17,17 @@ use crate::{Component, World};
 ///
 /// ```
 /// # use hecs::*;
+/// struct Flag(bool);
+/// impl Component for Flag {}
+/// struct Idx(i32);
+/// impl Component for Idx {}
+///
 /// let mut world = World::new();
 /// let entity = world.reserve_entity();
 /// let mut cmd = CommandBuffer::new();
-/// cmd.insert(entity, (true, 42));
+/// cmd.insert(entity, (Flag(true), Idx(42)));
 /// cmd.run_on(&mut world); // cmd can now be reused
-/// assert_eq!(*world.get::<&i32>(entity).unwrap(), 42);
+/// assert_eq!(world.get::<&Idx>(entity).unwrap().0, 42);
 /// ```
 pub struct CommandBuffer {
     cmds: Vec<Cmd>,
@@ -304,6 +309,18 @@ enum Cmd {
 mod tests {
     use super::*;
 
+    struct A;
+    impl Component for A {}
+    struct B;
+    impl Component for B {}
+    struct C;
+    impl Component for C {}
+    struct D;
+    impl Component for D {}
+    #[derive(Debug, PartialEq)]
+    struct I(i32);
+    impl Component for I {}
+
     #[test]
     fn populate_archetypes() {
         let mut world = World::new();
@@ -312,10 +329,10 @@ mod tests {
         let enta = world.reserve_entity();
         let entb = world.reserve_entity();
         let entc = world.reserve_entity();
-        buffer.insert(ent, (true, "a"));
-        buffer.insert(entc, (true, "a"));
-        buffer.insert(enta, (1, 1.0));
-        buffer.insert(entb, (1.0, "a"));
+        buffer.insert(ent, (A, B));
+        buffer.insert(entc, (A, B));
+        buffer.insert(enta, (C, D));
+        buffer.insert(entb, (D, B));
         buffer.run_on(&mut world);
         assert_eq!(world.archetypes().len(), 4);
     }
@@ -326,6 +343,7 @@ mod tests {
         // together
         #[derive(Clone)]
         struct A;
+        impl Component for A {}
 
         let mut world = World::new();
 
@@ -354,21 +372,21 @@ mod tests {
         let mut world = World::new();
         let a = world.spawn(());
         let mut cmd = CommandBuffer::new();
-        cmd.insert_one(a, 42i32);
-        cmd.remove_one::<i32>(a);
+        cmd.insert_one(a, I(42));
+        cmd.remove_one::<I>(a);
         cmd.run_on(&mut world);
-        assert!(!world.satisfies::<&i32>(a));
+        assert!(!world.satisfies::<&I>(a));
     }
 
     #[test]
     fn remove_then_insert() {
         let mut world = World::new();
-        let a = world.spawn((17i32,));
+        let a = world.spawn((I(17),));
         let mut cmd = CommandBuffer::new();
-        cmd.remove_one::<i32>(a);
-        cmd.insert_one(a, 42i32);
+        cmd.remove_one::<I>(a);
+        cmd.insert_one(a, I(42));
         cmd.run_on(&mut world);
-        assert_eq!(*world.get::<&i32>(a).unwrap(), 42);
+        assert_eq!(*world.get::<&I>(a).unwrap(), I(42));
     }
 
     #[test]
@@ -376,13 +394,13 @@ mod tests {
         let mut world = World::new();
         let a = world.spawn(());
         let mut cmd = CommandBuffer::new();
-        cmd.insert_one(a, 42i32);
+        cmd.insert_one(a, I(42));
         cmd.queue(move |world| {
-            let _ = world.insert_one(a, 123i32);
+            let _ = world.insert_one(a, I(123));
         });
         cmd.run_on(&mut world);
 
-        assert_eq!(*world.get::<&i32>(a).unwrap(), 123);
+        assert_eq!(*world.get::<&I>(a).unwrap(), I(123));
     }
 
     /// Verify that CommandBuffer neither leaks nor double-frees inserted components
@@ -391,6 +409,9 @@ mod tests {
     fn ownership_sanity() {
         use std::sync::Arc;
 
+        struct Counted(#[allow(dead_code)] Arc<()>);
+        impl Component for Counted {}
+
         let refcount = Arc::new(());
 
         let mut world = World::new();
@@ -398,7 +419,7 @@ mod tests {
 
         {
             let mut cmd = CommandBuffer::new();
-            cmd.insert_one(entity, refcount.clone());
+            cmd.insert_one(entity, Counted(refcount.clone()));
             assert_eq!(Arc::strong_count(&refcount), 2);
             cmd.run_on(&mut world);
         }

--- a/src/entity_builder.rs
+++ b/src/entity_builder.rs
@@ -15,12 +15,17 @@ use crate::{align, Component, ComponentRef, ComponentRefShared, DynamicBundle};
 ///
 /// ```
 /// # use hecs::*;
+/// struct Idx(i32);
+/// impl Component for Idx {}
+/// struct Name(&'static str);
+/// impl Component for Name {}
+///
 /// let mut world = World::new();
 /// let mut builder = EntityBuilder::new();
-/// builder.add(123).add("abc");
+/// builder.add(Idx(123)).add(Name("abc"));
 /// let e = world.spawn(builder.build()); // builder can now be reused
-/// assert_eq!(*world.get::<&i32>(e).unwrap(), 123);
-/// assert_eq!(*world.get::<&&str>(e).unwrap(), "abc");
+/// assert_eq!(world.get::<&Idx>(e).unwrap().0, 123);
+/// assert_eq!(world.get::<&Name>(e).unwrap().0, "abc");
 /// ```
 #[derive(Default)]
 pub struct EntityBuilder {
@@ -137,16 +142,23 @@ impl Drop for BuiltEntity<'_> {
 ///
 /// ```
 /// # use hecs::*;
+/// #[derive(Clone)]
+/// struct Idx(i32);
+/// impl Component for Idx {}
+/// #[derive(Clone)]
+/// struct Name(&'static str);
+/// impl Component for Name {}
+///
 /// let mut world = World::new();
 /// let mut builder = EntityBuilderClone::new();
-/// builder.add(123).add("abc");
+/// builder.add(Idx(123)).add(Name("abc"));
 /// let bundle = builder.build();
 /// let e = world.spawn(&bundle);
 /// let f = world.spawn(&bundle); // `&bundle` can be used many times
-/// assert_eq!(*world.get::<&i32>(e).unwrap(), 123);
-/// assert_eq!(*world.get::<&&str>(e).unwrap(), "abc");
-/// assert_eq!(*world.get::<&i32>(f).unwrap(), 123);
-/// assert_eq!(*world.get::<&&str>(f).unwrap(), "abc");
+/// assert_eq!(world.get::<&Idx>(e).unwrap().0, 123);
+/// assert_eq!(world.get::<&Name>(e).unwrap().0, "abc");
+/// assert_eq!(world.get::<&Idx>(f).unwrap().0, 123);
+/// assert_eq!(world.get::<&Name>(f).unwrap().0, "abc");
 /// ```
 #[derive(Clone, Default)]
 pub struct EntityBuilderClone {

--- a/src/entity_ref.rs
+++ b/src/entity_ref.rs
@@ -58,11 +58,14 @@ impl<'a> EntityRef<'a> {
     /// # Example
     /// ```
     /// # use hecs::*;
+    /// struct Size(i32);
+    /// impl Component for Size {}
+    ///
     /// let mut world = World::new();
-    /// let a = world.spawn((42, "abc"));
+    /// let a = world.spawn((Size(42),));
     /// let e = world.entity(a).unwrap();
-    /// *e.get::<&mut i32>().unwrap() = 17;
-    /// assert_eq!(*e.get::<&i32>().unwrap(), 17);
+    /// e.get::<&mut Size>().unwrap().0 = 17;
+    /// assert_eq!(e.get::<&Size>().unwrap().0, 17);
     /// ```
     ///
     /// Panics if `T` is a unique reference and the component is already borrowed, or if the
@@ -79,13 +82,18 @@ impl<'a> EntityRef<'a> {
     /// # Example
     /// ```
     /// # use hecs::*;
+    /// struct Age(i32);
+    /// impl Component for Age {}
+    /// struct Tall(bool);
+    /// impl Component for Tall {}
+    ///
     /// let mut world = World::new();
-    /// let a = world.spawn((123, true, "abc"));
+    /// let a = world.spawn((Age(123), Tall(true)));
     /// // The returned query must outlive the borrow made by `get`
-    /// let mut query = world.entity(a).unwrap().query::<(&mut i32, &bool)>();
-    /// let (number, flag) = query.get().unwrap();
-    /// if *flag { *number *= 2; }
-    /// assert_eq!(*number, 246);
+    /// let mut query = world.entity(a).unwrap().query::<(&mut Age, &Tall)>();
+    /// let (age, tall) = query.get().unwrap();
+    /// if tall.0 { age.0 *= 2; }
+    /// assert_eq!(age.0, 246);
     /// ```
     pub fn query<Q: Query>(&self) -> QueryOne<'a, Q> {
         unsafe { QueryOne::new(self.meta, self.archetype, self.index) }
@@ -148,14 +156,15 @@ impl<'a, T: ?Sized> Ref<'a, T> {
     /// # Examples
     ///
     /// ```no_run
-    /// # use hecs::{EntityRef, Ref};
-    /// struct Component {
+    /// # use hecs::{Component, EntityRef, Ref};
+    /// struct Data {
     ///     member: i32,
     /// }
+    /// impl Component for Data {}
     ///
     /// # fn example(entity_ref: EntityRef<'_>) {
-    /// let component_ref = entity_ref.get::<&Component>()
-    ///     .expect("Entity does not contain an instance of \"Component\"");
+    /// let component_ref = entity_ref.get::<&Data>()
+    ///     .expect("Entity does not contain an instance of \"Data\"");
     /// let member_ref = Ref::map(component_ref, |component| &component.member);
     /// println!("member = {:?}", *member_ref);
     /// # }
@@ -235,14 +244,15 @@ impl<'a, T: ?Sized> RefMut<'a, T> {
     /// # Examples
     ///
     /// ```no_run
-    /// # use hecs::{EntityRef, RefMut};
-    /// struct Component {
+    /// # use hecs::{Component, EntityRef, RefMut};
+    /// struct Data {
     ///     member: i32,
     /// }
+    /// impl Component for Data {}
     ///
     /// # fn example(entity_ref: EntityRef<'_>) {
-    /// let component_ref = entity_ref.get::<&mut Component>()
-    ///     .expect("Entity does not contain an instance of \"Component\"");
+    /// let component_ref = entity_ref.get::<&mut Data>()
+    ///     .expect("Entity does not contain an instance of \"Data\"");
     /// let mut member_ref = RefMut::map(component_ref, |component| &mut component.member);
     /// *member_ref = 21;
     /// println!("member = {:?}", *member_ref);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,16 +13,21 @@
 //! ```
 //! # use hecs::*;
 //! let mut world = World::new();
-//! // Nearly any type can be used as a component with zero boilerplate
-//! let a = world.spawn((123, true, "abc"));
-//! let b = world.spawn((42, false));
+//! // Component types can be defined with minimal boilerplate
+//! struct Weight(u32);
+//! impl Component for Weight {}
+//! struct Price(u32);
+//! impl Component for Price {}
+//!
+//! let a = world.spawn((Weight(12), Price(123)));
+//! let b = world.spawn((Weight(38), Price(42)));
 //! // Systems can be simple for loops
-//! for (number, &flag) in world.query_mut::<(&mut i32, &bool)>() {
-//!   if flag { *number *= 2; }
+//! for (price, weight) in world.query_mut::<(&mut Price, &Weight)>() {
+//!   if weight.0 < 20 { price.0 *= 2; }
 //! }
 //! // Random access is simple and safe
-//! assert_eq!(*world.get::<&i32>(a).unwrap(), 246);
-//! assert_eq!(*world.get::<&i32>(b).unwrap(), 42);
+//! assert_eq!(world.get::<&Price>(a).unwrap().0, 246);
+//! assert_eq!(world.get::<&Price>(b).unwrap().0, 42);
 //! ```
 
 #![warn(missing_docs)]
@@ -113,7 +118,7 @@ pub use entities::EntityMeta;
 pub use query::Fetch;
 
 #[cfg(feature = "macros")]
-pub use hecs_macros::{Bundle, DynamicBundleClone, Query};
+pub use hecs_macros::{Bundle, Component, DynamicBundleClone, Query};
 
 fn align(x: usize, alignment: usize) -> usize {
     debug_assert!(alignment.is_power_of_two());

--- a/src/query.rs
+++ b/src/query.rs
@@ -440,15 +440,21 @@ unsafe impl<L: Fetch, R: Fetch> Fetch for FetchOr<L, R> {
 /// # Example
 /// ```
 /// # use hecs::*;
+/// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// struct Idx(i32);
+/// impl Component for Idx {}
+/// struct Flag(bool);
+/// impl Component for Flag {}
+///
 /// let mut world = World::new();
-/// let a = world.spawn((123, true, "abc"));
-/// let b = world.spawn((456, false));
-/// let c = world.spawn((42, "def"));
-/// let entities = world.query::<Without<(Entity, &i32), &bool>>()
+/// let a = world.spawn((Idx(123), Flag(true)));
+/// let b = world.spawn((Idx(456), Flag(false)));
+/// let c = world.spawn((Idx(42),));
+/// let entities = world.query::<Without<(Entity, &Idx), &Flag>>()
 ///     .iter()
-///     .map(|(e, &i)| (e, i))
+///     .map(|(e, i)| (e, *i))
 ///     .collect::<Vec<_>>();
-/// assert_eq!(entities, &[(c, 42)]);
+/// assert_eq!(entities, &[(c, Idx(42))]);
 /// ```
 pub struct Without<Q, R>(PhantomData<(Q, fn(R))>);
 
@@ -517,17 +523,23 @@ impl<F: Clone, G> Clone for FetchWithout<F, G> {
 /// # Example
 /// ```
 /// # use hecs::*;
+/// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// struct Idx(i32);
+/// impl Component for Idx {}
+/// struct Flag(bool);
+/// impl Component for Flag {}
+///
 /// let mut world = World::new();
-/// let a = world.spawn((123, true, "abc"));
-/// let b = world.spawn((456, false));
-/// let c = world.spawn((42, "def"));
-/// let entities = world.query::<With<(Entity, &i32), &bool>>()
+/// let a = world.spawn((Idx(123), Flag(true)));
+/// let b = world.spawn((Idx(456), Flag(false)));
+/// let c = world.spawn((Idx(42),));
+/// let entities = world.query::<With<(Entity, &Idx), &Flag>>()
 ///     .iter()
-///     .map(|(e, &i)| (e, i))
+///     .map(|(e, i)| (e, *i))
 ///     .collect::<Vec<_>>();
 /// assert_eq!(entities.len(), 2);
-/// assert!(entities.contains(&(a, 123)));
-/// assert!(entities.contains(&(b, 456)));
+/// assert!(entities.contains(&(a, Idx(123))));
+/// assert!(entities.contains(&(b, Idx(456))));
 /// ```
 pub struct With<Q, R>(PhantomData<(Q, fn(R))>);
 
@@ -594,11 +606,16 @@ impl<F: Clone, G> Clone for FetchWith<F, G> {
 /// # Example
 /// ```
 /// # use hecs::*;
+/// struct Idx(i32);
+/// impl Component for Idx {}
+/// struct Flag(bool);
+/// impl Component for Flag {}
+///
 /// let mut world = World::new();
-/// let a = world.spawn((123, true, "abc"));
-/// let b = world.spawn((456, false));
-/// let c = world.spawn((42, "def"));
-/// let entities = world.query::<(Entity, Satisfies<&bool>)>()
+/// let a = world.spawn((Idx(123), Flag(true)));
+/// let b = world.spawn((Idx(456), Flag(false)));
+/// let c = world.spawn((Idx(42),));
+/// let entities = world.query::<(Entity, Satisfies<&Flag>)>()
 ///     .iter()
 ///     .collect::<Vec<_>>();
 /// assert_eq!(entities.len(), 3);
@@ -719,18 +736,24 @@ impl<'w, Q: Query> QueryBorrow<'w, Q> {
     /// # Example
     /// ```
     /// # use hecs::*;
+    /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// struct Idx(i32);
+    /// impl Component for Idx {}
+    /// struct Flag(bool);
+    /// impl Component for Flag {}
+    ///
     /// let mut world = World::new();
-    /// let a = world.spawn((123, true, "abc"));
-    /// let b = world.spawn((456, false));
-    /// let c = world.spawn((42, "def"));
-    /// let entities = world.query::<(Entity, &i32)>()
-    ///     .with::<&bool>()
+    /// let a = world.spawn((Idx(123), Flag(true)));
+    /// let b = world.spawn((Idx(456), Flag(false)));
+    /// let c = world.spawn((Idx(42),));
+    /// let entities = world.query::<(Entity, &Idx)>()
+    ///     .with::<&Flag>()
     ///     .iter()
-    ///     .map(|(e, &i)| (e, i)) // Copy out of the world
+    ///     .map(|(e, i)| (e, *i)) // Copy out of the world
     ///     .collect::<Vec<_>>();
     /// assert_eq!(entities.len(), 2);
-    /// assert!(entities.contains(&(a, 123)));
-    /// assert!(entities.contains(&(b, 456)));
+    /// assert!(entities.contains(&(a, Idx(123))));
+    /// assert!(entities.contains(&(b, Idx(456))));
     /// ```
     pub fn with<R: Query>(self) -> QueryBorrow<'w, With<Q, R>> {
         self.transform()
@@ -743,16 +766,22 @@ impl<'w, Q: Query> QueryBorrow<'w, Q> {
     /// # Example
     /// ```
     /// # use hecs::*;
+    /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// struct Idx(i32);
+    /// impl Component for Idx {}
+    /// struct Flag(bool);
+    /// impl Component for Flag {}
+    ///
     /// let mut world = World::new();
-    /// let a = world.spawn((123, true, "abc"));
-    /// let b = world.spawn((456, false));
-    /// let c = world.spawn((42, "def"));
-    /// let entities = world.query::<(Entity, &i32)>()
-    ///     .without::<&bool>()
+    /// let a = world.spawn((Idx(123), Flag(true)));
+    /// let b = world.spawn((Idx(456), Flag(false)));
+    /// let c = world.spawn((Idx(42),));
+    /// let entities = world.query::<(Entity, &Idx)>()
+    ///     .without::<&Flag>()
     ///     .iter()
-    ///     .map(|(e, &i)| (e, i)) // Copy out of the world
+    ///     .map(|(e, i)| (e, *i)) // Copy out of the world
     ///     .collect::<Vec<_>>();
-    /// assert_eq!(entities, &[(c, 42)]);
+    /// assert_eq!(entities, &[(c, Idx(42))]);
     /// ```
     pub fn without<R: Query>(self) -> QueryBorrow<'w, Without<Q, R>> {
         self.transform()
@@ -1500,20 +1529,23 @@ impl<'q, Q: Query> View<'q, Q> {
     /// # Examples
     ///
     /// ```
-    /// # use hecs::World;
+    /// # use hecs::{Component, World};
+    /// struct Idx(i32);
+    /// impl Component for Idx {}
+    ///
     /// let mut world = World::new();
     ///
-    /// let a = world.spawn((1, 1.0));
-    /// let b = world.spawn((2, 4.0));
-    /// let c = world.spawn((3, 9.0));
+    /// let a = world.spawn((Idx(1),));
+    /// let b = world.spawn((Idx(2),));
+    /// let c = world.spawn((Idx(3),));
     ///
-    /// let mut query = world.query_mut::<&mut i32>();
+    /// let mut query = world.query_mut::<&mut Idx>();
     /// let mut view = query.view();
-    /// let [a,b,c] = view.get_disjoint_mut([a, b, c]);
+    /// let [a, b, c] = view.get_disjoint_mut([a, b, c]);
     ///
-    /// assert_eq!(*a.unwrap(), 1);
-    /// assert_eq!(*b.unwrap(), 2);
-    /// assert_eq!(*c.unwrap(), 3);
+    /// assert_eq!(a.unwrap().0, 1);
+    /// assert_eq!(b.unwrap().0, 2);
+    /// assert_eq!(c.unwrap().0, 3);
     /// ```
     pub fn get_disjoint_mut<const N: usize>(
         &mut self,
@@ -1809,19 +1841,22 @@ impl<'w, Q: Query> ViewBorrow<'w, Q> {
     /// # Examples
     ///
     /// ```
-    /// # use hecs::World;
+    /// # use hecs::{Component, World};
+    /// struct Idx(i32);
+    /// impl Component for Idx {}
+    ///
     /// let mut world = World::new();
     ///
-    /// let a = world.spawn((1, 1.0));
-    /// let b = world.spawn((2, 4.0));
-    /// let c = world.spawn((3, 9.0));
+    /// let a = world.spawn((Idx(1),));
+    /// let b = world.spawn((Idx(2),));
+    /// let c = world.spawn((Idx(3),));
     ///
-    /// let mut view = world.view_mut::<&mut i32>();
+    /// let mut view = world.view_mut::<&mut Idx>();
     /// let [a, b, c] = view.get_disjoint_mut([a, b, c]);
     ///
-    /// assert_eq!(*a.unwrap(), 1);
-    /// assert_eq!(*b.unwrap(), 2);
-    /// assert_eq!(*c.unwrap(), 3);
+    /// assert_eq!(a.unwrap().0, 1);
+    /// assert_eq!(b.unwrap().0, 2);
+    /// assert_eq!(c.unwrap().0, 3);
     /// ```
     pub fn get_disjoint_mut<const N: usize>(
         &mut self,

--- a/src/serialize/column.rs
+++ b/src/serialize/column.rs
@@ -40,8 +40,10 @@ use crate::{
 /// # use serde::{Serialize, Deserialize};
 /// # #[derive(Serialize)]
 /// # struct Position([f32; 3]);
+/// # impl Component for Position {}
 /// # #[derive(Serialize)]
 /// # struct Velocity([f32; 3]);
+/// # impl Component for Velocity {}
 /// use std::any::TypeId;
 /// use hecs::{*, serialize::column::*};
 ///
@@ -310,8 +312,10 @@ where
 /// # use serde::{Serialize, Deserialize};
 /// # #[derive(Deserialize)]
 /// # struct Position([f32; 3]);
+/// # impl Component for Position {}
 /// # #[derive(Deserialize)]
 /// # struct Velocity([f32; 3]);
+/// # impl Component for Velocity {}
 /// use hecs::{*, serialize::column::*};
 ///
 /// #[derive(Serialize, Deserialize)]
@@ -750,8 +754,10 @@ mod tests {
 
     #[derive(Serialize, Deserialize, PartialEq, Debug, Copy, Clone)]
     struct Position([f32; 3]);
+    impl Component for Position {}
     #[derive(Serialize, Deserialize, PartialEq, Debug, Copy, Clone)]
     struct Velocity([f32; 3]);
+    impl Component for Velocity {}
 
     #[derive(Default)]
     struct Context {

--- a/src/serialize/row.rs
+++ b/src/serialize/row.rs
@@ -30,8 +30,10 @@ use crate::{Component, EntityBuilder, EntityRef, Query, World};
 /// # use serde::{Serialize, Deserialize};
 /// # #[derive(Serialize)]
 /// # struct Position([f32; 3]);
+/// # impl Component for Position {}
 /// # #[derive(Serialize)]
 /// # struct Velocity([f32; 3]);
+/// # impl Component for Velocity {}
 /// use hecs::{*, serialize::row::*};
 ///
 /// #[derive(Serialize, Deserialize)]
@@ -163,8 +165,10 @@ where
 /// # use serde::{Serialize, Deserialize};
 /// # #[derive(Deserialize)]
 /// # struct Position([f32; 3]);
+/// # impl Component for Position {}
 /// # #[derive(Deserialize)]
 /// # struct Velocity([f32; 3]);
+/// # impl Component for Velocity {}
 /// use hecs::{*, serialize::row::*};
 ///
 /// #[derive(Serialize, Deserialize)]
@@ -281,8 +285,10 @@ mod tests {
 
     #[derive(Serialize, Deserialize, PartialEq, Debug, Copy, Clone)]
     struct Position([f32; 3]);
+    impl Component for Position {}
     #[derive(Serialize, Deserialize, PartialEq, Debug, Copy, Clone)]
     struct Velocity([f32; 3]);
+    impl Component for Velocity {}
 
     struct Context;
     #[derive(Serialize, Deserialize)]

--- a/src/world.rs
+++ b/src/world.rs
@@ -88,14 +88,19 @@ impl World {
     /// statically known. To spawn an entity with only one component, use a one-element tuple like
     /// `(x,)`.
     ///
-    /// Any type that satisfies `Send + Sync + 'static` can be used as a component.
+    /// All components must implement the [`Component`](crate::Component) trait.
     ///
     /// # Example
     /// ```
     /// # use hecs::*;
+    /// struct Idx(i32);
+    /// impl Component for Idx {}
+    /// struct Name(&'static str);
+    /// impl Component for Name {}
+    ///
     /// let mut world = World::new();
-    /// let a = world.spawn((123, "abc"));
-    /// let b = world.spawn((456, true));
+    /// let a = world.spawn((Idx(123), Name("abc")));
+    /// let b = world.spawn((Idx(456),));
     /// ```
     pub fn spawn(&mut self, components: impl DynamicBundle) -> Entity {
         // Ensure all entity allocations are accounted for so `self.entities` can realloc if
@@ -121,13 +126,18 @@ impl World {
     /// # Example
     /// ```
     /// # use hecs::*;
+    /// struct Idx(i32);
+    /// impl Component for Idx {}
+    /// struct Name(&'static str);
+    /// impl Component for Name {}
+    ///
     /// let mut world = World::new();
-    /// let a = world.spawn((123, "abc"));
-    /// let b = world.spawn((456, true));
+    /// let a = world.spawn((Idx(123), Name("abc")));
+    /// let b = world.spawn((Idx(456),));
     /// world.despawn(a);
     /// assert!(!world.contains(a));
     /// // all previous Entity values pointing to 'a' will be live again, instead pointing to the new entity.
-    /// world.spawn_at(a, (789, "ABC"));
+    /// world.spawn_at(a, (Idx(789), Name("ABC")));
     /// assert!(world.contains(a));
     /// ```
     pub fn spawn_at(&mut self, handle: Entity, components: impl DynamicBundle) {
@@ -179,10 +189,13 @@ impl World {
     /// # Example
     /// ```
     /// # use hecs::*;
+    /// struct Idx(i32);
+    /// impl Component for Idx {}
+    ///
     /// let mut world = World::new();
-    /// let entities = world.spawn_batch((0..1_000).map(|i| (i, "abc"))).collect::<Vec<_>>();
+    /// let entities = world.spawn_batch((0..1_000).map(|i| (Idx(i),))).collect::<Vec<_>>();
     /// for i in 0..1_000 {
-    ///     assert_eq!(*world.get::<&i32>(entities[i]).unwrap(), i as i32);
+    ///     assert_eq!(world.get::<&Idx>(entities[i]).unwrap().0, i as i32);
     /// }
     /// ```
     pub fn spawn_batch<I>(&mut self, iter: I) -> SpawnBatchIter<'_, I::IntoIter>
@@ -400,17 +413,24 @@ impl World {
     /// # Example
     /// ```
     /// # use hecs::*;
+    /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// struct Idx(i32);
+    /// impl Component for Idx {}
+    /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// struct Flag(bool);
+    /// impl Component for Flag {}
+    ///
     /// let mut world = World::new();
-    /// let a = world.spawn((123, true, "abc"));
-    /// let b = world.spawn((456, false));
-    /// let c = world.spawn((42, "def"));
-    /// let entities = world.query::<(Entity, &i32, &bool)>()
+    /// let a = world.spawn((Idx(123), Flag(true)));
+    /// let b = world.spawn((Idx(456), Flag(false)));
+    /// let c = world.spawn((Idx(42),));
+    /// let entities = world.query::<(Entity, &Idx, &Flag)>()
     ///     .iter()
-    ///     .map(|(e, &i, &b)| (e, i, b)) // Copy out of the world
+    ///     .map(|(e, i, b)| (e, *i, *b)) // Copy out of the world
     ///     .collect::<Vec<_>>();
     /// assert_eq!(entities.len(), 2);
-    /// assert!(entities.contains(&(a, 123, true)));
-    /// assert!(entities.contains(&(b, 456, false)));
+    /// assert!(entities.contains(&(a, Idx(123), Flag(true))));
+    /// assert!(entities.contains(&(b, Idx(456), Flag(false))));
     /// ```
     pub fn query<Q: Query>(&self) -> QueryBorrow<'_, Q> {
         QueryBorrow::new(self)
@@ -471,13 +491,18 @@ impl World {
     /// # Example
     /// ```
     /// # use hecs::*;
+    /// struct Idx(i32);
+    /// impl Component for Idx {}
+    /// struct Flag(bool);
+    /// impl Component for Flag {}
+    ///
     /// let mut world = World::new();
-    /// let a = world.spawn((123, true, "abc"));
+    /// let a = world.spawn((Idx(123), Flag(true)));
     /// // The returned query must outlive the borrow made by `get`
-    /// let mut query = world.query_one::<(&mut i32, &bool)>(a);
+    /// let mut query = world.query_one::<(&mut Idx, &Flag)>(a);
     /// let (number, flag) = query.get().unwrap();
-    /// if *flag { *number *= 2; }
-    /// assert_eq!(*number, 246);
+    /// if flag.0 { number.0 *= 2; }
+    /// assert_eq!(number.0, 246);
     /// ```
     pub fn query_one<Q: Query>(&self, entity: Entity) -> QueryOne<'_, Q> {
         let Ok(loc) = self.entities.get(entity) else {
@@ -612,11 +637,16 @@ impl World {
     /// # Example
     /// ```
     /// # use hecs::*;
+    /// struct Idx(i32);
+    /// impl Component for Idx {}
+    /// struct Flag(bool);
+    /// impl Component for Flag {}
+    ///
     /// let mut world = World::new();
-    /// let e = world.spawn((123, "abc"));
-    /// world.insert(e, (456, true));
-    /// assert_eq!(*world.get::<&i32>(e).unwrap(), 456);
-    /// assert_eq!(*world.get::<&bool>(e).unwrap(), true);
+    /// let e = world.spawn((Idx(123),));
+    /// world.insert(e, (Idx(456), Flag(true)));
+    /// assert_eq!(world.get::<&Idx>(e).unwrap().0, 456);
+    /// assert!(world.get::<&Flag>(e).unwrap().0);
     /// ```
     pub fn insert(
         &mut self,
@@ -731,12 +761,21 @@ impl World {
     /// # Example
     /// ```
     /// # use hecs::*;
+    /// #[derive(Debug, PartialEq)]
+    /// struct Idx(i32);
+    /// impl Component for Idx {}
+    /// #[derive(Debug, PartialEq)]
+    /// struct Name(&'static str);
+    /// impl Component for Name {}
+    /// struct Flag(bool);
+    /// impl Component for Flag {}
+    ///
     /// let mut world = World::new();
-    /// let e = world.spawn((123, "abc", true));
-    /// assert_eq!(world.remove::<(i32, &str)>(e), Ok((123, "abc")));
-    /// assert!(world.get::<&i32>(e).is_err());
-    /// assert!(world.get::<&&str>(e).is_err());
-    /// assert_eq!(*world.get::<&bool>(e).unwrap(), true);
+    /// let e = world.spawn((Idx(123), Name("abc"), Flag(true)));
+    /// assert_eq!(world.remove::<(Idx, Name)>(e), Ok((Idx(123), Name("abc"))));
+    /// assert!(world.get::<&Idx>(e).is_err());
+    /// assert!(world.get::<&Name>(e).is_err());
+    /// assert!(world.get::<&Flag>(e).unwrap().0);
     /// ```
     pub fn remove<T: Bundle + 'static>(&mut self, entity: Entity) -> Result<T, ComponentError> {
         self.flush();
@@ -929,9 +968,12 @@ impl World {
     /// # Example
     /// ```
     /// # use hecs::*;
+    /// struct Idx(i32);
+    /// impl Component for Idx {}
+    ///
     /// let mut world = World::new();
     /// let initial_gen = world.archetypes_generation();
-    /// world.spawn((123, "abc"));
+    /// world.spawn((Idx(123),));
     /// assert_ne!(initial_gen, world.archetypes_generation());
     /// ```
     pub fn archetypes_generation(&self) -> ArchetypesGeneration {
@@ -1062,12 +1104,14 @@ impl From<NoSuchEntity> for QueryOneError {
     }
 }
 
-/// Types that can be components, implemented automatically for all `Send + Sync + 'static` types
+/// Types that can be components
 ///
-/// This is just a convenient shorthand for `Send + Sync + 'static`, and never needs to be
-/// implemented manually.
+/// Implement this marker trait for your components to allow them to be inserted into a [`World`].
+/// This requirement guards against accidental insertion of unintended types, such as when
+/// refactoring a component constructor to return `Result`.
+///
+/// Enable the `macros` feature to use `#[derive(Component)]` as a short-hand.
 pub trait Component: Send + Sync + 'static {}
-impl<T: Send + Sync + 'static> Component for T {}
 
 /// Iterator over all of a world's entities
 pub struct Iter<'a> {
@@ -1391,6 +1435,12 @@ impl Hasher for IndexTypeIdHasher {
 mod tests {
     use super::*;
 
+    #[derive(Debug, PartialEq)]
+    struct I(i32);
+    impl Component for I {}
+    struct B(bool);
+    impl Component for B {}
+
     #[test]
     fn reuse_empty() {
         let mut world = World::new();
@@ -1429,27 +1479,27 @@ mod tests {
     #[test]
     fn reuse_populated() {
         let mut world = World::new();
-        let a = world.spawn((42,));
-        assert_eq!(*world.get::<&i32>(a).unwrap(), 42);
+        let a = world.spawn((I(42),));
+        assert_eq!(*world.get::<&I>(a).unwrap(), I(42));
         world.despawn(a).unwrap();
-        let b = world.spawn((true,));
+        let b = world.spawn((B(true),));
         assert_eq!(a.id, b.id);
         assert_ne!(a.generation, b.generation);
-        assert!(world.get::<&i32>(b).is_err());
-        assert!(*world.get::<&bool>(b).unwrap());
+        assert!(world.get::<&I>(b).is_err());
+        assert!(world.get::<&B>(b).unwrap().0);
     }
 
     #[test]
     fn remove_nothing() {
         let mut world = World::new();
-        let a = world.spawn(("abc", 123));
+        let a = world.spawn((B(true), I(123)));
         world.remove::<()>(a).unwrap();
     }
 
     #[test]
     fn bad_insert() {
         let mut world = World::new();
-        assert!(world.insert_one(Entity::DANGLING, ()).is_err());
+        assert!(world.insert_one(Entity::DANGLING, I(1)).is_err());
     }
 
     #[test]
@@ -1496,21 +1546,25 @@ mod tests {
     fn spawn_column_batch_at_redundant() {
         use alloc::string::String;
 
+        #[derive(Debug)]
+        struct Str(String);
+        impl Component for Str {}
+
         let mut world = World::new();
         // A column batch of two entities in the unit (no-component) archetype.
         let mut batch = crate::ColumnBatchType::new();
-        batch.add::<String>();
+        batch.add::<Str>();
         let batch = batch.into_batch(2);
         {
-            let mut writer = batch.writer::<String>().unwrap();
-            writer.push("a".into()).unwrap();
-            writer.push("b".into()).unwrap();
+            let mut writer = batch.writer::<Str>().unwrap();
+            writer.push(Str("a".into())).unwrap();
+            writer.push(Str("b".into())).unwrap();
         }
         let batch = batch.build().unwrap();
 
         let e = Entity::from_bits(1 << 32).unwrap(); // id 0, generation 1
         world.spawn_column_batch_at(&[e, e], batch); // the same handle twice
         assert_eq!(world.iter().count(), 1);
-        assert_eq!(&*world.get::<&String>(e).unwrap(), "b");
+        assert_eq!(world.get::<&Str>(e).unwrap().0, "b");
     }
 }

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -4,9 +4,15 @@
 fn derive() {
     const TEST_DIR: &str = "tests/derive";
     let t = trybuild::TestCases::new();
-    let failures = &["enum_unsupported.rs", "union.rs", "wrong_lifetime.rs"];
+    let failures = &[
+        "enum_unsupported.rs",
+        "union.rs",
+        "wrong_lifetime.rs",
+        "component_bounds.rs",
+    ];
     let successes = &[
         "enum_query.rs",
+        "component.rs",
         "unit_structs.rs",
         "tuple_structs.rs",
         "named_structs.rs",

--- a/tests/derive/component.rs
+++ b/tests/derive/component.rs
@@ -1,0 +1,40 @@
+use hecs::Component;
+
+#[derive(Component)]
+struct Unit;
+
+#[derive(Component, Debug, PartialEq)]
+struct Tuple(i32);
+
+#[derive(Component)]
+struct Named {
+    x: u64,
+}
+
+#[derive(Component)]
+enum Either {
+    A,
+    B(String),
+}
+
+#[derive(Component)]
+struct Bounded<T>(T);
+
+#[derive(Component)]
+struct WhereClause<T>(T)
+where
+    T: Send + Sync + 'static;
+
+fn main() {
+    let mut world = hecs::World::new();
+    let e = world.spawn((
+        Unit,
+        Tuple(1),
+        Named { x: 2 },
+        Either::B(String::from("hi")),
+        Bounded(3u8),
+        WhereClause(4.0f64),
+    ));
+    assert_eq!(*world.get::<&Tuple>(e).unwrap(), Tuple(1));
+    assert_eq!(world.query_one_mut::<&Named>(e).unwrap().x, 2);
+}

--- a/tests/derive/component_bounds.rs
+++ b/tests/derive/component_bounds.rs
@@ -1,0 +1,9 @@
+use hecs::Component;
+
+#[derive(Component)]
+struct NotSend(std::rc::Rc<()>);
+
+#[derive(Component)]
+struct NotStatic<'a>(&'a i32);
+
+fn main() {}

--- a/tests/derive/component_bounds.stderr
+++ b/tests/derive/component_bounds.stderr
@@ -1,0 +1,74 @@
+error[E0277]: `Rc<()>` cannot be shared between threads safely
+ --> tests/derive/component_bounds.rs:4:8
+  |
+4 | struct NotSend(std::rc::Rc<()>);
+  |        ^^^^^^^ `Rc<()>` cannot be shared between threads safely
+  |
+  = help: within `NotSend`, the trait `Sync` is not implemented for `Rc<()>`
+note: required because it appears within the type `NotSend`
+ --> tests/derive/component_bounds.rs:4:8
+  |
+4 | struct NotSend(std::rc::Rc<()>);
+  |        ^^^^^^^
+note: required by a bound in `hecs::Component`
+ --> src/world.rs
+  |
+  | pub trait Component: Send + Sync + 'static {}
+  |                             ^^^^ required by this bound in `Component`
+
+error[E0277]: `Rc<()>` cannot be sent between threads safely
+ --> tests/derive/component_bounds.rs:4:8
+  |
+4 | struct NotSend(std::rc::Rc<()>);
+  |        ^^^^^^^ `Rc<()>` cannot be sent between threads safely
+  |
+  = help: within `NotSend`, the trait `Send` is not implemented for `Rc<()>`
+note: required because it appears within the type `NotSend`
+ --> tests/derive/component_bounds.rs:4:8
+  |
+4 | struct NotSend(std::rc::Rc<()>);
+  |        ^^^^^^^
+note: required by a bound in `hecs::Component`
+ --> src/world.rs
+  |
+  | pub trait Component: Send + Sync + 'static {}
+  |                      ^^^^ required by this bound in `Component`
+
+error[E0478]: lifetime bound not satisfied
+ --> tests/derive/component_bounds.rs:6:10
+  |
+6 | #[derive(Component)]
+  |          ^^^^^^^^^
+  |
+note: lifetime parameter instantiated with the lifetime `'a` as defined here
+ --> tests/derive/component_bounds.rs:7:18
+  |
+7 | struct NotStatic<'a>(&'a i32);
+  |                  ^^
+  = note: but lifetime parameter must outlive the static lifetime
+  = note: this error originates in the derive macro `Component` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0803]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
+ --> tests/derive/component_bounds.rs:7:8
+  |
+7 | struct NotStatic<'a>(&'a i32);
+  |        ^^^^^^^^^^^^^
+  |
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
+ --> tests/derive/component_bounds.rs:7:18
+  |
+7 | struct NotStatic<'a>(&'a i32);
+  |                  ^^
+note: ...so that the types are compatible
+ --> tests/derive/component_bounds.rs:7:8
+  |
+7 | struct NotStatic<'a>(&'a i32);
+  |        ^^^^^^^^^^^^^
+  = note: expected `<NotStatic<'a> as hecs::Component>`
+             found `<NotStatic<'_> as hecs::Component>`
+  = note: but, the lifetime must be valid for the static lifetime...
+note: ...so that the declared lifetime parameter bounds are satisfied
+ --> tests/derive/component_bounds.rs:7:8
+  |
+7 | struct NotStatic<'a>(&'a i32);
+  |        ^^^^^^^^^^^^^

--- a/tests/derive/enum_query.rs
+++ b/tests/derive/enum_query.rs
@@ -1,24 +1,26 @@
-use hecs::Query;
+use hecs::{Component, Query};
+
+struct A(i32);
+impl Component for A {}
+
+struct B(bool);
+impl Component for B {}
 
 #[derive(Query)]
 enum Foo<'a> {
-    Foo(&'a i32)
+    Foo(&'a A),
 }
 
 #[derive(Query)]
 enum Bar<'a> {
-    Bar {
-        bar: &'a bool
-    },
+    Bar { bar: &'a B },
 }
 
 #[derive(Query)]
 enum All<'a> {
-    Foo(&'a i32),
-    Bar {
-        bar: &'a bool
-    },
-    Baz
+    Foo(&'a A),
+    Bar { bar: &'a B },
+    Baz,
 }
 
 fn main() {}

--- a/tests/derive/export.rs
+++ b/tests/derive/export.rs
@@ -1,12 +1,15 @@
 mod inner {
-    use hecs::{Bundle, Query};
+    use hecs::{Bundle, Component, Query};
+
+    struct A(i32);
+    impl Component for A {}
 
     #[derive(Bundle)]
     pub struct Foo;
 
     #[derive(Query)]
     pub struct Bar<'a> {
-        foo: &'a i32,
+        foo: &'a A,
     }
 }
 

--- a/tests/derive/generics.rs
+++ b/tests/derive/generics.rs
@@ -1,4 +1,7 @@
-use hecs::Bundle;
+use hecs::{Bundle, Component};
+
+struct A(i32);
+impl Component for A {}
 
 #[derive(Bundle)]
 struct Foo<T> {
@@ -7,7 +10,7 @@ struct Foo<T> {
 
 #[derive(Bundle)]
 struct Bar<T> {
-    foo: i32,
+    foo: A,
     bar: T,
 }
 

--- a/tests/derive/named_structs.rs
+++ b/tests/derive/named_structs.rs
@@ -1,27 +1,39 @@
-use hecs::{Bundle, Query};
+use hecs::{Bundle, Component, Query};
+
+struct A(i32);
+impl Component for A {}
+
+struct B(bool);
+impl Component for B {}
+
+struct S(String);
+impl Component for S {}
+
+struct T(&'static str);
+impl Component for T {}
 
 #[derive(Bundle)]
 struct Foo {
-    foo: i32,
+    foo: A,
 }
 
 #[derive(Bundle)]
 struct Bar {
-    foo: i32,
-    bar: String,
+    foo: A,
+    bar: S,
 }
 
 #[derive(Bundle)]
 struct Baz {
-    foo: i32,
-    bar: String,
-    baz: &'static str,
+    foo: A,
+    bar: S,
+    baz: T,
 }
 
 #[derive(Query)]
 struct Quux<'a> {
-    foo: &'a i32,
-    bar: &'a mut bool,
+    foo: &'a A,
+    bar: &'a mut B,
 }
 
 fn main() {}

--- a/tests/derive/nested_query.rs
+++ b/tests/derive/nested_query.rs
@@ -1,14 +1,20 @@
-use hecs::Query;
+use hecs::{Component, Query};
+
+struct A(i32);
+impl Component for A {}
+
+struct B(bool);
+impl Component for B {}
 
 #[derive(Query)]
 struct Foo<'a> {
-    foo: &'a i32,
+    foo: &'a A,
     bar: Bar<'a>,
 }
 
 #[derive(Query)]
 struct Bar<'a> {
-    baz: &'a mut bool,
+    baz: &'a mut B,
 }
 
 #[derive(Query)]

--- a/tests/derive/no_prelude.rs
+++ b/tests/derive/no_prelude.rs
@@ -1,8 +1,14 @@
 #![no_implicit_prelude]
 
+struct A(i32);
+impl ::hecs::Component for A {}
+
+struct B(bool);
+impl ::hecs::Component for B {}
+
 #[derive(::hecs::Bundle)]
 struct Foo {
-    foo: (),
+    foo: A,
 }
 
 #[derive(::hecs::Bundle)]
@@ -15,16 +21,14 @@ struct Baz;
 
 #[derive(::hecs::Query)]
 struct Quux<'a> {
-    foo: &'a (),
+    foo: &'a A,
 }
 
 #[derive(::hecs::Query)]
 enum Corge<'a> {
-    Foo (&'a i32),
-    Bar {
-        bar: &'a bool
-    },
-    Baz
+    Foo(&'a A),
+    Bar { bar: &'a B },
+    Baz,
 }
 
 fn main() {}

--- a/tests/derive/tuple_structs.rs
+++ b/tests/derive/tuple_structs.rs
@@ -1,15 +1,24 @@
-use hecs::{Bundle, Query};
+use hecs::{Bundle, Component, Query};
+
+struct A(i32);
+impl Component for A {}
+
+struct S(String);
+impl Component for S {}
+
+struct T(&'static str);
+impl Component for T {}
 
 #[derive(Bundle)]
-struct Foo(i32);
+struct Foo(A);
 
 #[derive(Bundle)]
-struct Bar(i32, String);
+struct Bar(A, S);
 
 #[derive(Bundle)]
-struct Baz(i32, String, &'static str);
+struct Baz(A, S, T);
 
 #[derive(Query)]
-struct Quux<'a>(&'a i32);
+struct Quux<'a>(&'a A);
 
 fn main() {}

--- a/tests/derive/wrong_lifetime.rs
+++ b/tests/derive/wrong_lifetime.rs
@@ -1,15 +1,21 @@
-use hecs::Query;
+use hecs::{Component, Query};
+
+struct A(i32);
+impl Component for A {}
+
+struct B(bool);
+impl Component for B {}
 
 #[derive(Query)]
 struct Foo<'a> {
-    foo: &'a i32,
-    bar: &'static mut bool,
+    foo: &'a A,
+    bar: &'static mut B,
 }
 
 #[derive(Query)]
 enum Bar<'a> {
-    Foo(&'a i32),
-    Bar(&'static mut bool)
+    Foo(&'a A),
+    Bar(&'static mut B),
 }
 
 fn main() {}

--- a/tests/derive/wrong_lifetime.stderr
+++ b/tests/derive/wrong_lifetime.stderr
@@ -1,19 +1,19 @@
 error: lifetime may not live long enough
- --> $DIR/wrong_lifetime.rs:6:5
-  |
-3 | #[derive(Query)]
-  |          ----- lifetime `'q` defined here
+  --> tests/derive/wrong_lifetime.rs:12:5
+   |
+ 9 | #[derive(Query)]
+   |          ----- lifetime `'q` defined here
 ...
-6 |     bar: &'static mut bool,
-  |     ^^^ this usage requires that `'q` must outlive `'static`
+12 |     bar: &'static mut B,
+   |     ^^^ this usage requires that `'q` must outlive `'static`
 
 error: lifetime may not live long enough
- --> $DIR/wrong_lifetime.rs:9:10
-  |
-9 | #[derive(Query)]
-  |          ^^^^^
-  |          |
-  |          lifetime `'q` defined here
-  |          this usage requires that `'q` must outlive `'static`
-  |
-  = note: this error originates in the derive macro `Query` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> tests/derive/wrong_lifetime.rs:15:10
+   |
+15 | #[derive(Query)]
+   |          ^^^^^
+   |          |
+   |          lifetime `'q` defined here
+   |          this usage requires that `'q` must outlive `'static`
+   |
+   = note: this error originates in the derive macro `Query` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/no-std-test-crates/macros/src/lib.rs
+++ b/tests/no-std-test-crates/macros/src/lib.rs
@@ -3,14 +3,20 @@
 #![no_std]
 #![allow(clippy::disallowed_names)]
 
-use hecs::{Bundle, Query};
+use hecs::{Bundle, Component, Query};
+
+#[derive(Component)]
+pub struct Comp;
+
+#[derive(Component)]
+pub struct Generic<T>(T);
 
 #[derive(Bundle)]
 pub struct Foo {
-    pub foo: i32,
+    pub foo: Comp,
 }
 
 #[derive(Query)]
 pub struct Quux<'a> {
-    pub foo: &'a Foo,
+    pub foo: &'a Comp,
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,47 +4,88 @@ use std::borrow::Cow;
 
 use hecs::*;
 
+// Component types used throughout these tests
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Int(i32);
+impl Component for Int {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Count(usize);
+impl Component for Count {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Bool(bool);
+impl Component for Bool {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Char(char);
+impl Component for Char {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Str(&'static str);
+impl Component for Str {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Bytes([u8; 1024]);
+impl Component for Bytes {}
+
+#[derive(Clone, Debug, PartialEq)]
+struct Label(String);
+impl Component for Label {}
+
+#[derive(Clone, Debug, PartialEq)]
+struct Text(Cow<'static, str>);
+impl Component for Text {}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct Float(f64);
+impl Component for Float {}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct F32(f32);
+impl Component for F32 {}
+
 #[test]
 fn random_access() {
     let mut world = World::new();
-    let e = world.spawn(("abc", 123));
-    let f = world.spawn(("def", 456, true));
-    assert_eq!(*world.get::<&&str>(e).unwrap(), "abc");
-    assert_eq!(*world.get::<&i32>(e).unwrap(), 123);
-    assert_eq!(*world.get::<&&str>(f).unwrap(), "def");
-    assert_eq!(*world.get::<&i32>(f).unwrap(), 456);
-    *world.get::<&mut i32>(f).unwrap() = 42;
-    assert_eq!(*world.get::<&i32>(f).unwrap(), 42);
+    let e = world.spawn((Str("abc"), Int(123)));
+    let f = world.spawn((Str("def"), Int(456), Bool(true)));
+    assert_eq!(world.get::<&Str>(e).unwrap().0, "abc");
+    assert_eq!(world.get::<&Int>(e).unwrap().0, 123);
+    assert_eq!(world.get::<&Str>(f).unwrap().0, "def");
+    assert_eq!(world.get::<&Int>(f).unwrap().0, 456);
+    world.get::<&mut Int>(f).unwrap().0 = 42;
+    assert_eq!(world.get::<&Int>(f).unwrap().0, 42);
 }
 
 #[test]
 fn despawn() {
     let mut world = World::new();
-    let e = world.spawn(("abc", 123));
-    let f = world.spawn(("def", 456));
+    let e = world.spawn((Str("abc"), Int(123)));
+    let f = world.spawn((Str("def"), Int(456)));
     assert_eq!(world.query::<()>().iter().count(), 2);
     world.despawn(e).unwrap();
     assert_eq!(world.query::<()>().iter().count(), 1);
-    assert!(world.get::<&&str>(e).is_err());
-    assert!(world.get::<&i32>(e).is_err());
-    assert_eq!(*world.get::<&&str>(f).unwrap(), "def");
-    assert_eq!(*world.get::<&i32>(f).unwrap(), 456);
+    assert!(world.get::<&Str>(e).is_err());
+    assert!(world.get::<&Int>(e).is_err());
+    assert_eq!(world.get::<&Str>(f).unwrap().0, "def");
+    assert_eq!(world.get::<&Int>(f).unwrap().0, 456);
 }
 
 #[test]
 fn query_all() {
     let mut world = World::new();
-    let e = world.spawn(("abc", 123));
-    let f = world.spawn(("def", 456));
+    let e = world.spawn((Str("abc"), Int(123)));
+    let f = world.spawn((Str("def"), Int(456)));
 
     let ents = world
-        .query::<(Entity, &i32, &&str)>()
+        .query::<(Entity, &Int, &Str)>()
         .iter()
-        .map(|(e, &i, &s)| (e, i, s))
+        .map(|(e, i, s)| (e, *i, *s))
         .collect::<Vec<_>>();
     assert_eq!(ents.len(), 2);
-    assert!(ents.contains(&(e, 123, "abc")));
-    assert!(ents.contains(&(f, 456, "def")));
+    assert!(ents.contains(&(e, Int(123), Str("abc"))));
+    assert!(ents.contains(&(f, Int(456), Str("def"))));
 
     let ents = world.query::<Entity>().iter().collect::<Vec<_>>();
     assert_eq!(ents.len(), 2);
@@ -57,17 +98,17 @@ fn query_all() {
 fn derived_query() {
     #[derive(Query, Debug, PartialEq)]
     struct Foo<'a> {
-        x: &'a i32,
-        y: &'a mut bool,
+        x: &'a Int,
+        y: &'a mut Bool,
     }
 
     let mut world = World::new();
-    let e = world.spawn((42, false));
+    let e = world.spawn((Int(42), Bool(false)));
     assert_eq!(
         world.query_one_mut::<Foo>(e).unwrap(),
         Foo {
-            x: &42,
-            y: &mut false
+            x: &Int(42),
+            y: &mut Bool(false)
         }
     );
 }
@@ -77,31 +118,34 @@ fn derived_query() {
 fn derived_enum_query() {
     #[derive(Query, Debug, PartialEq)]
     enum Foo<'a> {
-        NumberAndString(&'a i32, &'a String),
-        Number(&'a i32),
-        Boolean(&'a mut bool),
+        NumberAndString(&'a Int, &'a Label),
+        Number(&'a Int),
+        Boolean(&'a mut Bool),
     }
 
     let mut world = World::new();
-    let e1 = world.spawn((42, false));
+    let e1 = world.spawn((Int(42), Bool(false)));
 
-    assert_eq!(world.query_one_mut::<Foo>(e1).unwrap(), Foo::Number(&42));
+    assert_eq!(
+        world.query_one_mut::<Foo>(e1).unwrap(),
+        Foo::Number(&Int(42))
+    );
 
-    let e2 = world.spawn((String::from("Hello"), false));
+    let e2 = world.spawn((Label(String::from("Hello")), Bool(false)));
 
     assert_eq!(
         world.query_one_mut::<Foo>(e2).unwrap(),
-        Foo::Boolean(&mut false)
+        Foo::Boolean(&mut Bool(false))
     );
 
-    let e3 = world.spawn((String::from("Hello"), 42));
+    let e3 = world.spawn((Label(String::from("Hello")), Int(42)));
 
     assert_eq!(
         world.query_one_mut::<Foo>(e3).unwrap(),
-        Foo::NumberAndString(&42, &String::from("Hello"))
+        Foo::NumberAndString(&Int(42), &Label(String::from("Hello")))
     );
 
-    let e4 = world.spawn((String::from("Hello"), 0_usize));
+    let e4 = world.spawn((Label(String::from("Hello")), Count(0)));
 
     assert_eq!(
         world.query_one_mut::<Foo>(e4),
@@ -114,21 +158,24 @@ fn derived_enum_query() {
 fn derived_enum_query_with_empty() {
     #[derive(Query, Debug, PartialEq)]
     enum Foo<'a> {
-        Number(&'a i32),
+        Number(&'a Int),
         Empty,
-        Impossible(&'a String),
+        Impossible(&'a Label),
     }
 
     let mut world = World::new();
-    let e1 = world.spawn((42, false));
+    let e1 = world.spawn((Int(42), Bool(false)));
 
-    assert_eq!(world.query_one_mut::<Foo>(e1).unwrap(), Foo::Number(&42));
+    assert_eq!(
+        world.query_one_mut::<Foo>(e1).unwrap(),
+        Foo::Number(&Int(42))
+    );
 
-    let e2 = world.spawn((false, 0_usize));
+    let e2 = world.spawn((Bool(false), Count(0)));
 
     assert_eq!(world.query_one_mut::<Foo>(e2).unwrap(), Foo::Empty);
 
-    let e3 = world.spawn((String::from("Hello"), false));
+    let e3 = world.spawn((Label(String::from("Hello")), Bool(false)));
 
     assert_eq!(world.query_one_mut::<Foo>(e3).unwrap(), Foo::Empty);
 }
@@ -138,24 +185,24 @@ fn derived_enum_query_with_empty() {
 fn derived_bundle_clone() {
     #[derive(Bundle, DynamicBundleClone)]
     struct Foo<T: Clone + Component> {
-        x: i32,
-        y: bool,
+        x: Int,
+        y: Bool,
         z: T,
     }
 
     #[derive(PartialEq, Debug, Query)]
     struct FooQuery<'a> {
-        x: &'a i32,
-        y: &'a bool,
-        z: &'a String,
+        x: &'a Int,
+        y: &'a Bool,
+        z: &'a Label,
     }
 
     let mut world = World::new();
     let mut builder = EntityBuilderClone::new();
     builder.add_bundle(Foo {
-        x: 42,
-        y: false,
-        z: String::from("Foo"),
+        x: Int(42),
+        y: Bool(false),
+        z: Label(String::from("Foo")),
     });
 
     let entity = builder.build();
@@ -163,9 +210,9 @@ fn derived_bundle_clone() {
     assert_eq!(
         world.query_one_mut::<FooQuery>(e).unwrap(),
         FooQuery {
-            x: &42,
-            y: &false,
-            z: &String::from("Foo"),
+            x: &Int(42),
+            y: &Bool(false),
+            z: &Label(String::from("Foo")),
         }
     );
 }
@@ -173,123 +220,123 @@ fn derived_bundle_clone() {
 #[test]
 fn query_single_component() {
     let mut world = World::new();
-    let e = world.spawn(("abc", 123));
-    let f = world.spawn(("def", 456, true));
+    let e = world.spawn((Str("abc"), Int(123)));
+    let f = world.spawn((Str("def"), Int(456), Bool(true)));
     let ents = world
-        .query::<(Entity, &i32)>()
+        .query::<(Entity, &Int)>()
         .iter()
-        .map(|(e, &i)| (e, i))
+        .map(|(e, i)| (e, *i))
         .collect::<Vec<_>>();
     assert_eq!(ents.len(), 2);
-    assert!(ents.contains(&(e, 123)));
-    assert!(ents.contains(&(f, 456)));
+    assert!(ents.contains(&(e, Int(123))));
+    assert!(ents.contains(&(f, Int(456))));
 }
 
 #[test]
 fn query_missing_component() {
     let mut world = World::new();
-    world.spawn(("abc", 123));
-    world.spawn(("def", 456));
-    assert!(world.query::<(&bool, &i32)>().iter().next().is_none());
+    world.spawn((Str("abc"), Int(123)));
+    world.spawn((Str("def"), Int(456)));
+    assert!(world.query::<(&Bool, &Int)>().iter().next().is_none());
 }
 
 #[test]
 fn query_sparse_component() {
     let mut world = World::new();
-    world.spawn(("abc", 123));
-    let f = world.spawn(("def", 456, true));
+    world.spawn((Str("abc"), Int(123)));
+    let f = world.spawn((Str("def"), Int(456), Bool(true)));
     let ents = world
-        .query::<(Entity, &bool)>()
+        .query::<(Entity, &Bool)>()
         .iter()
-        .map(|(e, &b)| (e, b))
+        .map(|(e, b)| (e, *b))
         .collect::<Vec<_>>();
-    assert_eq!(ents, &[(f, true)]);
+    assert_eq!(ents, &[(f, Bool(true))]);
 }
 
 #[test]
 fn query_optional_component() {
     let mut world = World::new();
-    let e = world.spawn(("abc", 123));
-    let f = world.spawn(("def", 456, true));
+    let e = world.spawn((Str("abc"), Int(123)));
+    let f = world.spawn((Str("def"), Int(456), Bool(true)));
     let ents = world
-        .query::<(Entity, Option<&bool>, &i32)>()
+        .query::<(Entity, Option<&Bool>, &Int)>()
         .iter()
-        .map(|(e, b, &i)| (e, b.copied(), i))
+        .map(|(e, b, i)| (e, b.copied(), *i))
         .collect::<Vec<_>>();
     assert_eq!(ents.len(), 2);
-    assert!(ents.contains(&(e, None, 123)));
-    assert!(ents.contains(&(f, Some(true), 456)));
+    assert!(ents.contains(&(e, None, Int(123))));
+    assert!(ents.contains(&(f, Some(Bool(true)), Int(456))));
 }
 
 #[test]
 fn prepare_query() {
     let mut world = World::new();
-    let e = world.spawn(("abc", 123));
-    let f = world.spawn(("def", 456));
+    let e = world.spawn((Str("abc"), Int(123)));
+    let f = world.spawn((Str("def"), Int(456)));
 
-    let mut query = PreparedQuery::<(Entity, &i32, &&str)>::default();
+    let mut query = PreparedQuery::<(Entity, &Int, &Str)>::default();
 
     let ents = query
         .query(&world)
         .iter()
-        .map(|(e, &i, &s)| (e, i, s))
+        .map(|(e, i, s)| (e, *i, *s))
         .collect::<Vec<_>>();
     assert_eq!(ents.len(), 2);
-    assert!(ents.contains(&(e, 123, "abc")));
-    assert!(ents.contains(&(f, 456, "def")));
+    assert!(ents.contains(&(e, Int(123), Str("abc"))));
+    assert!(ents.contains(&(f, Int(456), Str("def"))));
 
     let ents = query
         .query_mut(&mut world)
-        .map(|(e, &i, &s)| (e, i, s))
+        .map(|(e, i, s)| (e, *i, *s))
         .collect::<Vec<_>>();
     assert_eq!(ents.len(), 2);
-    assert!(ents.contains(&(e, 123, "abc")));
-    assert!(ents.contains(&(f, 456, "def")));
+    assert!(ents.contains(&(e, Int(123), Str("abc"))));
+    assert!(ents.contains(&(f, Int(456), Str("def"))));
 }
 
 #[test]
 fn invalidate_prepared_query() {
     let mut world = World::new();
-    let e = world.spawn(("abc", 123));
-    let f = world.spawn(("def", 456));
+    let e = world.spawn((Str("abc"), Int(123)));
+    let f = world.spawn((Str("def"), Int(456)));
 
-    let mut query = PreparedQuery::<(Entity, &i32, &&str)>::default();
+    let mut query = PreparedQuery::<(Entity, &Int, &Str)>::default();
 
     let ents = query
         .query(&world)
         .iter()
-        .map(|(e, &i, &s)| (e, i, s))
+        .map(|(e, i, s)| (e, *i, *s))
         .collect::<Vec<_>>();
     assert_eq!(ents.len(), 2);
-    assert!(ents.contains(&(e, 123, "abc")));
-    assert!(ents.contains(&(f, 456, "def")));
+    assert!(ents.contains(&(e, Int(123), Str("abc"))));
+    assert!(ents.contains(&(f, Int(456), Str("def"))));
 
-    world.spawn((true,));
-    let g = world.spawn(("ghi", 789));
+    world.spawn((Bool(true),));
+    let g = world.spawn((Str("ghi"), Int(789)));
 
     let ents = query
         .query_mut(&mut world)
-        .map(|(e, &i, &s)| (e, i, s))
+        .map(|(e, i, s)| (e, *i, *s))
         .collect::<Vec<_>>();
     assert_eq!(ents.len(), 3);
-    assert!(ents.contains(&(e, 123, "abc")));
-    assert!(ents.contains(&(f, 456, "def")));
-    assert!(ents.contains(&(g, 789, "ghi")));
+    assert!(ents.contains(&(e, Int(123), Str("abc"))));
+    assert!(ents.contains(&(f, Int(456), Str("def"))));
+    assert!(ents.contains(&(g, Int(789), Str("ghi"))));
 }
 
 #[test]
 fn random_access_via_view() {
     let mut world = World::new();
-    let e = world.spawn(("abc", 123));
-    let f = world.spawn(("def",));
+    let e = world.spawn((Str("abc"), Int(123)));
+    let f = world.spawn((Str("def"),));
 
-    let mut query = PreparedQuery::<(&i32, &&str)>::default();
+    let mut query = PreparedQuery::<(&Int, &Str)>::default();
     let mut query = query.query(&world);
     let mut view = query.view();
 
     let (i, s) = view.get(e).unwrap();
-    assert_eq!(*i, 123);
-    assert_eq!(*s, "abc");
+    assert_eq!(*i, Int(123));
+    assert_eq!(*s, Str("abc"));
 
     assert!(view.get_mut(f).is_none());
 }
@@ -297,15 +344,15 @@ fn random_access_via_view() {
 #[test]
 fn random_access_via_view_mut() {
     let mut world = World::new();
-    let e = world.spawn(("abc", 123));
-    let f = world.spawn(("def",));
+    let e = world.spawn((Str("abc"), Int(123)));
+    let f = world.spawn((Str("def"),));
 
-    let mut query = PreparedQuery::<(&i32, &&str)>::default();
+    let mut query = PreparedQuery::<(&Int, &Str)>::default();
     let mut view = query.view_mut(&mut world);
 
     let (i, s) = view.get(e).unwrap();
-    assert_eq!(*i, 123);
-    assert_eq!(*s, "abc");
+    assert_eq!(*i, Int(123));
+    assert_eq!(*s, Str("abc"));
 
     assert!(view.get_mut(f).is_none());
 
@@ -316,33 +363,33 @@ fn random_access_via_view_mut() {
 #[test]
 fn view_borrow_on_world() {
     let mut world = World::new();
-    let e0 = world.spawn((3, "hello"));
-    let e1 = world.spawn((6.0, "world"));
-    let e2 = world.spawn((12,));
+    let e0 = world.spawn((Int(3), Str("hello")));
+    let e1 = world.spawn((Float(6.0), Str("world")));
+    let e2 = world.spawn((Int(12),));
 
     {
-        let str_view = world.view::<&&str>();
+        let str_view = world.view::<&Str>();
 
-        assert_eq!(*str_view.get(e0).unwrap(), "hello");
-        assert_eq!(*str_view.get(e1).unwrap(), "world");
+        assert_eq!(str_view.get(e0).unwrap().0, "hello");
+        assert_eq!(str_view.get(e1).unwrap().0, "world");
         assert_eq!(str_view.get(e2), None);
     }
 
     {
-        let mut int_view = world.view::<&mut i32>();
-        assert_eq!(*int_view.get_mut(e0).unwrap(), 3);
+        let mut int_view = world.view::<&mut Int>();
+        assert_eq!(int_view.get_mut(e0).unwrap().0, 3);
         assert_eq!(int_view.get_mut(e1), None);
-        assert_eq!(*int_view.get_mut(e2).unwrap(), 12);
+        assert_eq!(int_view.get_mut(e2).unwrap().0, 12);
 
         // edit some value
-        *int_view.get_mut(e0).unwrap() = 100;
+        int_view.get_mut(e0).unwrap().0 = 100;
     }
 
     {
-        let mut int_str_view = world.view::<(&&str, &mut i32)>();
+        let mut int_str_view = world.view::<(&Str, &mut Int)>();
         let (s, i) = int_str_view.get_mut(e0).unwrap();
-        assert_eq!(*s, "hello");
-        assert_eq!(*i, 100);
+        assert_eq!(s.0, "hello");
+        assert_eq!(i.0, 100);
         assert_eq!(int_str_view.get_mut(e1), None);
         assert_eq!(int_str_view.get_mut(e2), None);
     }
@@ -351,27 +398,27 @@ fn view_borrow_on_world() {
 #[test]
 fn view_mut_on_world() {
     let mut world = World::new();
-    let e0 = world.spawn((3, "hello"));
-    let e1 = world.spawn((6.0, "world"));
-    let e2 = world.spawn((12,));
+    let e0 = world.spawn((Int(3), Str("hello")));
+    let e1 = world.spawn((Float(6.0), Str("world")));
+    let e2 = world.spawn((Int(12),));
 
-    let str_view = world.view_mut::<&&str>();
-    assert_eq!(*str_view.get(e0).unwrap(), "hello");
-    assert_eq!(*str_view.get(e1).unwrap(), "world");
+    let str_view = world.view_mut::<&Str>();
+    assert_eq!(str_view.get(e0).unwrap().0, "hello");
+    assert_eq!(str_view.get(e1).unwrap().0, "world");
     assert_eq!(str_view.get(e2), None);
 
-    let mut int_view = world.view_mut::<&mut i32>();
-    assert_eq!(*int_view.get_mut(e0).unwrap(), 3);
+    let mut int_view = world.view_mut::<&mut Int>();
+    assert_eq!(int_view.get_mut(e0).unwrap().0, 3);
     assert_eq!(int_view.get_mut(e1), None);
-    assert_eq!(*int_view.get_mut(e2).unwrap(), 12);
+    assert_eq!(int_view.get_mut(e2).unwrap().0, 12);
 
     // edit some value
-    *int_view.get_mut(e0).unwrap() = 100;
+    int_view.get_mut(e0).unwrap().0 = 100;
 
-    let mut int_str_view = world.view_mut::<(&&str, &mut i32)>();
+    let mut int_str_view = world.view_mut::<(&Str, &mut Int)>();
     let (s, i) = int_str_view.get_mut(e0).unwrap();
-    assert_eq!(*s, "hello");
-    assert_eq!(*i, 100);
+    assert_eq!(s.0, "hello");
+    assert_eq!(i.0, 100);
     assert_eq!(int_str_view.get_mut(e1), None);
     assert_eq!(int_str_view.get_mut(e2), None);
 }
@@ -380,11 +427,11 @@ fn view_mut_on_world() {
 #[test]
 fn view_mut_panic() {
     let mut world = World::new();
-    let e = world.spawn(('a',));
+    let e = world.spawn((Char('a'),));
 
     // we should panic since we have two overlapping views:
-    let mut first_view = world.view::<&mut char>();
-    let mut second_view = world.view::<&mut char>();
+    let mut first_view = world.view::<&mut Char>();
+    let mut second_view = world.view::<&mut Char>();
 
     first_view.get_mut(e).unwrap();
     second_view.get_mut(e).unwrap();
@@ -394,12 +441,12 @@ fn view_mut_panic() {
 #[should_panic]
 fn simultaneous_access_must_be_non_overlapping() {
     let mut world = World::new();
-    let a = world.spawn((1,));
-    let b = world.spawn((2,));
-    let c = world.spawn((3,));
-    let d = world.spawn((4,));
+    let a = world.spawn((Int(1),));
+    let b = world.spawn((Int(2),));
+    let c = world.spawn((Int(3),));
+    let d = world.spawn((Int(4),));
 
-    let mut query = world.query_mut::<&mut i32>();
+    let mut query = world.query_mut::<&mut Int>();
     let mut view = query.view();
 
     view.get_disjoint_mut([a, d, c, b, a]);
@@ -409,72 +456,72 @@ fn simultaneous_access_must_be_non_overlapping() {
 fn build_entity() {
     let mut world = World::new();
     let mut entity = EntityBuilder::new();
-    entity.add("abc");
-    entity.add(123);
+    entity.add(Str("abc"));
+    entity.add(Int(123));
     let e = world.spawn(entity.build());
-    entity.add("def");
-    entity.add([0u8; 1024]);
-    entity.add(456);
-    entity.add(789);
+    entity.add(Str("def"));
+    entity.add(Bytes([0u8; 1024]));
+    entity.add(Int(456));
+    entity.add(Int(789));
     let f = world.spawn(entity.build());
-    assert_eq!(*world.get::<&&str>(e).unwrap(), "abc");
-    assert_eq!(*world.get::<&i32>(e).unwrap(), 123);
-    assert_eq!(*world.get::<&&str>(f).unwrap(), "def");
-    assert_eq!(*world.get::<&i32>(f).unwrap(), 789);
+    assert_eq!(world.get::<&Str>(e).unwrap().0, "abc");
+    assert_eq!(world.get::<&Int>(e).unwrap().0, 123);
+    assert_eq!(world.get::<&Str>(f).unwrap().0, "def");
+    assert_eq!(world.get::<&Int>(f).unwrap().0, 789);
 }
 
 #[test]
 fn build_entity_clone() {
     let mut world = World::new();
     let mut entity = EntityBuilderClone::new();
-    entity.add("def");
-    entity.add([0u8; 1024]);
-    entity.add(456);
-    entity.add(789);
-    entity.add_bundle(("yup", 67_usize));
-    entity.add_bundle((5.0_f32, String::from("Foo")));
-    entity.add_bundle((7.0_f32, String::from("Bar"), 42_usize));
+    entity.add(Str("def"));
+    entity.add(Bytes([0u8; 1024]));
+    entity.add(Int(456));
+    entity.add(Int(789));
+    entity.add_bundle((Str("yup"), Count(67)));
+    entity.add_bundle((F32(5.0), Label(String::from("Foo"))));
+    entity.add_bundle((F32(7.0), Label(String::from("Bar")), Count(42)));
     let entity = entity.build();
     let e = world.spawn(&entity);
     let f = world.spawn(&entity);
     let g = world.spawn(&entity);
     world
-        .insert_one(g, Cow::<'static, str>::from("after"))
+        .insert_one(g, Text(Cow::<'static, str>::from("after")))
         .unwrap();
 
     for e in [e, f, g] {
-        assert_eq!(*world.get::<&&str>(e).unwrap(), "yup");
-        assert_eq!(*world.get::<&i32>(e).unwrap(), 789);
-        assert_eq!(*world.get::<&usize>(e).unwrap(), 42);
-        assert_eq!(*world.get::<&f32>(e).unwrap(), 7.0);
-        assert_eq!(*world.get::<&String>(e).unwrap(), "Bar");
+        assert_eq!(world.get::<&Str>(e).unwrap().0, "yup");
+        assert_eq!(world.get::<&Int>(e).unwrap().0, 789);
+        assert_eq!(world.get::<&Count>(e).unwrap().0, 42);
+        assert_eq!(world.get::<&F32>(e).unwrap().0, 7.0);
+        assert_eq!(world.get::<&Label>(e).unwrap().0, "Bar");
     }
 
-    assert_eq!(*world.get::<&Cow<'static, str>>(g).unwrap(), "after");
+    assert_eq!(world.get::<&Text>(g).unwrap().0, "after");
 }
 
 #[test]
 fn build_builder_clone() {
     let mut a = EntityBuilderClone::new();
-    a.add(String::from("abc"));
-    a.add(123);
+    a.add(Label(String::from("abc")));
+    a.add(Int(123));
     let mut b = EntityBuilderClone::new();
-    b.add(String::from("def"));
+    b.add(Label(String::from("def")));
     b.add_bundle(&a.build());
-    assert_eq!(b.get::<&String>(), Some(&String::from("abc")));
-    assert_eq!(b.get::<&i32>(), Some(&123));
+    assert_eq!(b.get::<&Label>(), Some(&Label(String::from("abc"))));
+    assert_eq!(b.get::<&Int>(), Some(&Int(123)));
 }
 
 #[test]
 #[allow(clippy::redundant_clone)]
 fn cloned_builder() {
     let mut builder = EntityBuilderClone::new();
-    builder.add(String::from("abc")).add(123);
+    builder.add(Label(String::from("abc"))).add(Int(123));
 
     let mut world = World::new();
     let e = world.spawn(&builder.build().clone());
-    assert_eq!(*world.get::<&String>(e).unwrap(), "abc");
-    assert_eq!(*world.get::<&i32>(e).unwrap(), 123);
+    assert_eq!(world.get::<&Label>(e).unwrap().0, "abc");
+    assert_eq!(world.get::<&Int>(e).unwrap().0, 123);
 }
 
 #[test]
@@ -482,32 +529,35 @@ fn cloned_builder() {
 fn build_dynamic_bundle() {
     #[derive(Bundle, DynamicBundleClone)]
     struct Foo {
-        x: i32,
-        y: char,
+        x: Int,
+        y: Char,
     }
 
     let mut world = World::new();
     let mut entity = EntityBuilderClone::new();
-    entity.add_bundle(Foo { x: 5, y: 'c' });
-    entity.add_bundle((String::from("Bar"), 6.0_f32));
-    entity.add('a');
+    entity.add_bundle(Foo {
+        x: Int(5),
+        y: Char('c'),
+    });
+    entity.add_bundle((Label(String::from("Bar")), F32(6.0)));
+    entity.add(Char('a'));
     let entity = entity.build();
     let e = world.spawn(&entity);
     let f = world.spawn(&entity);
     let g = world.spawn(&entity);
 
     world
-        .insert_one(g, Cow::<'static, str>::from("after"))
+        .insert_one(g, Text(Cow::<'static, str>::from("after")))
         .unwrap();
 
     for e in [e, f, g] {
-        assert_eq!(*world.get::<&i32>(e).unwrap(), 5);
-        assert_eq!(*world.get::<&char>(e).unwrap(), 'a');
-        assert_eq!(*world.get::<&String>(e).unwrap(), "Bar");
-        assert_eq!(*world.get::<&f32>(e).unwrap(), 6.0);
+        assert_eq!(world.get::<&Int>(e).unwrap().0, 5);
+        assert_eq!(world.get::<&Char>(e).unwrap().0, 'a');
+        assert_eq!(world.get::<&Label>(e).unwrap().0, "Bar");
+        assert_eq!(world.get::<&F32>(e).unwrap().0, 6.0);
     }
 
-    assert_eq!(*world.get::<&Cow<'static, str>>(g).unwrap(), "after");
+    assert_eq!(world.get::<&Text>(g).unwrap().0, "after");
 }
 
 #[test]
@@ -515,70 +565,70 @@ fn access_builder_components() {
     let mut world = World::new();
     let mut entity = EntityBuilder::new();
 
-    entity.add("abc");
-    entity.add(123);
+    entity.add(Str("abc"));
+    entity.add(Int(123));
 
-    assert!(entity.has::<&str>());
-    assert!(entity.has::<i32>());
-    assert!(!entity.has::<usize>());
+    assert!(entity.has::<Str>());
+    assert!(entity.has::<Int>());
+    assert!(!entity.has::<Count>());
 
-    assert_eq!(*entity.get::<&&str>().unwrap(), "abc");
-    assert_eq!(*entity.get::<&i32>().unwrap(), 123);
-    assert_eq!(entity.get::<&usize>(), None);
+    assert_eq!(entity.get::<&Str>().unwrap().0, "abc");
+    assert_eq!(entity.get::<&Int>().unwrap().0, 123);
+    assert_eq!(entity.get::<&Count>(), None);
 
-    *entity.get_mut::<&mut i32>().unwrap() = 456;
-    assert_eq!(*entity.get::<&i32>().unwrap(), 456);
+    entity.get_mut::<&mut Int>().unwrap().0 = 456;
+    assert_eq!(entity.get::<&Int>().unwrap().0, 456);
 
     let g = world.spawn(entity.build());
 
-    assert_eq!(*world.get::<&&str>(g).unwrap(), "abc");
-    assert_eq!(*world.get::<&i32>(g).unwrap(), 456);
+    assert_eq!(world.get::<&Str>(g).unwrap().0, "abc");
+    assert_eq!(world.get::<&Int>(g).unwrap().0, 456);
 }
 
 #[test]
 fn build_entity_bundle() {
     let mut world = World::new();
     let mut entity = EntityBuilder::new();
-    entity.add_bundle(("abc", 123));
+    entity.add_bundle((Str("abc"), Int(123)));
     let e = world.spawn(entity.build());
-    entity.add(456);
-    entity.add_bundle(("def", [0u8; 1024], 789));
+    entity.add(Int(456));
+    entity.add_bundle((Str("def"), Bytes([0u8; 1024]), Int(789)));
     let f = world.spawn(entity.build());
-    assert_eq!(*world.get::<&&str>(e).unwrap(), "abc");
-    assert_eq!(*world.get::<&i32>(e).unwrap(), 123);
-    assert_eq!(*world.get::<&&str>(f).unwrap(), "def");
-    assert_eq!(*world.get::<&i32>(f).unwrap(), 789);
+    assert_eq!(world.get::<&Str>(e).unwrap().0, "abc");
+    assert_eq!(world.get::<&Int>(e).unwrap().0, 123);
+    assert_eq!(world.get::<&Str>(f).unwrap().0, "def");
+    assert_eq!(world.get::<&Int>(f).unwrap().0, 789);
 }
 
 #[test]
 fn dynamic_components() {
     let mut world = World::new();
-    let e = world.spawn((42,));
-    world.insert(e, (true, "abc")).unwrap();
+    let e = world.spawn((Int(42),));
+    world.insert(e, (Bool(true), Str("abc"))).unwrap();
     assert_eq!(
         world
-            .query::<(Entity, &i32, &bool)>()
+            .query::<(Entity, &Int, &Bool)>()
             .iter()
-            .map(|(e, &i, &b)| (e, i, b))
+            .map(|(e, i, b)| (e, *i, *b))
             .collect::<Vec<_>>(),
-        &[(e, 42, true)]
+        &[(e, Int(42), Bool(true))]
     );
-    assert_eq!(world.remove_one::<i32>(e), Ok(42));
+    assert_eq!(world.remove_one::<Int>(e), Ok(Int(42)));
     assert_eq!(
         world
-            .query::<(Entity, &i32, &bool)>()
+            .query::<(Entity, &Int, &Bool)>()
             .iter()
-            .map(|(e, &i, &b)| (e, i, b))
+            .map(|(e, i, b)| (e, *i, *b))
             .collect::<Vec<_>>(),
         &[]
     );
     assert_eq!(
         world
-            .query::<(Entity, &bool, &&str)>()
+            .query::<(Entity, &Bool, &Str)>()
             .iter()
-            .map(|(e, &b, &s)| (e, b, s))
+            .map(|(e, b, s)| (e, *b, *s))
             .collect::<Vec<_>>(),
-        &[(e, true, "abc")]
+        &[(e, Bool(true), Str("abc"))]
     );
 }
 
@@ -591,26 +641,26 @@ fn spawn_buffered_entity() {
     let ent2 = world.reserve_entity();
     let ent3 = world.reserve_entity();
 
-    buffer.insert(ent, (1, true));
-    buffer.insert(ent1, (13, 7.11, "hecs"));
-    buffer.insert(ent2, (17i8, false, 'o'));
-    buffer.insert(ent3, (2u8, "qwe", 101.103, false));
+    buffer.insert(ent, (Int(1), Bool(true)));
+    buffer.insert(ent1, (Int(13), Float(7.11), Str("hecs")));
+    buffer.insert(ent2, (Int(17), Bool(false), Char('o')));
+    buffer.insert(ent3, (Int(2), Str("qwe"), Float(101.103), Bool(false)));
 
     buffer.run_on(&mut world);
 
-    assert!(*world.get::<&bool>(ent).unwrap());
-    assert!(!*world.get::<&bool>(ent2).unwrap());
+    assert!(world.get::<&Bool>(ent).unwrap().0);
+    assert!(!world.get::<&Bool>(ent2).unwrap().0);
 
-    assert_eq!(*world.get::<&&str>(ent1).unwrap(), "hecs");
-    assert_eq!(*world.get::<&i32>(ent1).unwrap(), 13);
-    assert_eq!(*world.get::<&u8>(ent3).unwrap(), 2);
+    assert_eq!(world.get::<&Str>(ent1).unwrap().0, "hecs");
+    assert_eq!(world.get::<&Int>(ent1).unwrap().0, 13);
+    assert_eq!(world.get::<&Int>(ent3).unwrap().0, 2);
 }
 
 #[test]
 fn despawn_buffered_entity() {
     let mut world = World::new();
     let mut buffer = CommandBuffer::new();
-    let ent = world.spawn((1, true));
+    let ent = world.spawn((Int(1), Bool(true)));
     buffer.despawn(ent);
 
     buffer.run_on(&mut world);
@@ -621,62 +671,62 @@ fn despawn_buffered_entity() {
 fn remove_buffered_component() {
     let mut world = World::new();
     let mut buffer = CommandBuffer::new();
-    let ent = world.spawn((7, true, "hecs"));
+    let ent = world.spawn((Int(7), Bool(true), Str("hecs")));
 
-    buffer.remove::<(i32, &str)>(ent);
+    buffer.remove::<(Int, Str)>(ent);
     buffer.run_on(&mut world);
 
-    assert!(world.get::<&&str>(ent).is_err());
-    assert!(world.get::<&i32>(ent).is_err());
+    assert!(world.get::<&Str>(ent).is_err());
+    assert!(world.get::<&Int>(ent).is_err());
 }
 
 #[test]
 #[should_panic(expected = "already borrowed")]
 fn illegal_borrow() {
     let mut world = World::new();
-    world.spawn(("abc", 123));
-    world.spawn(("def", 456));
+    world.spawn((Str("abc"), Int(123)));
+    world.spawn((Str("def"), Int(456)));
 
-    world.query::<(&mut i32, &i32)>().iter();
+    world.query::<(&mut Int, &Int)>().iter();
 }
 
 #[test]
 #[should_panic(expected = "already borrowed")]
 fn illegal_borrow_2() {
     let mut world = World::new();
-    world.spawn(("abc", 123));
-    world.spawn(("def", 456));
+    world.spawn((Str("abc"), Int(123)));
+    world.spawn((Str("def"), Int(456)));
 
-    world.query::<(&mut i32, &mut i32)>().iter();
+    world.query::<(&mut Int, &mut Int)>().iter();
 }
 
 #[test]
 #[should_panic(expected = "query violates a unique borrow")]
 fn illegal_query_mut_borrow() {
     let mut world = World::new();
-    world.spawn(("abc", 123));
-    world.spawn(("def", 456));
+    world.spawn((Str("abc"), Int(123)));
+    world.spawn((Str("def"), Int(456)));
 
-    world.query_mut::<(&i32, &mut i32)>();
+    world.query_mut::<(&Int, &mut Int)>();
 }
 
 #[test]
 #[should_panic(expected = "query violates a unique borrow")]
 fn illegal_query_one_borrow() {
     let mut world = World::new();
-    let entity = world.spawn(("abc", 123));
+    let entity = world.spawn((Str("abc"), Int(123)));
 
-    world.query_one::<(&mut i32, &i32)>(entity).get().unwrap();
+    world.query_one::<(&mut Int, &Int)>(entity).get().unwrap();
 }
 
 #[test]
 #[should_panic(expected = "query violates a unique borrow")]
 fn illegal_query_one_borrow_2() {
     let mut world = World::new();
-    let entity = world.spawn(("abc", 123));
+    let entity = world.spawn((Str("abc"), Int(123)));
 
     world
-        .query_one::<(&mut i32, &mut i32)>(entity)
+        .query_one::<(&mut Int, &mut Int)>(entity)
         .get()
         .unwrap();
 }
@@ -685,46 +735,46 @@ fn illegal_query_one_borrow_2() {
 #[should_panic(expected = "query violates a unique borrow")]
 fn illegal_query_one_mut_borrow() {
     let mut world = World::new();
-    let entity = world.spawn(("abc", 123));
+    let entity = world.spawn((Str("abc"), Int(123)));
 
-    world.query_one_mut::<(&mut i32, &i32)>(entity).unwrap();
+    world.query_one_mut::<(&mut Int, &Int)>(entity).unwrap();
 }
 
 #[test]
 #[should_panic(expected = "query violates a unique borrow")]
 fn illegal_query_one_mut_borrow_2() {
     let mut world = World::new();
-    let entity = world.spawn(("abc", 123));
+    let entity = world.spawn((Str("abc"), Int(123)));
 
-    world.query_one_mut::<(&mut i32, &mut i32)>(entity).unwrap();
+    world.query_one_mut::<(&mut Int, &mut Int)>(entity).unwrap();
 }
 
 #[test]
 fn disjoint_queries() {
     let mut world = World::new();
-    world.spawn(("abc", true));
-    world.spawn(("def", 456));
+    world.spawn((Str("abc"), Bool(true)));
+    world.spawn((Str("def"), Int(456)));
 
-    let _a = world.query::<(&mut &str, &bool)>();
-    let _b = world.query::<(&mut &str, &i32)>();
+    let _a = world.query::<(&mut Str, &Bool)>();
+    let _b = world.query::<(&mut Str, &Int)>();
 }
 
 #[test]
 fn shared_borrow() {
     let mut world = World::new();
-    world.spawn(("abc", 123));
-    world.spawn(("def", 456));
+    world.spawn((Str("abc"), Int(123)));
+    world.spawn((Str("def"), Int(456)));
 
-    world.query::<(&i32, &i32)>();
+    world.query::<(&Int, &Int)>();
 }
 
 #[test]
 #[should_panic(expected = "already borrowed")]
 fn illegal_random_access() {
     let mut world = World::new();
-    let e = world.spawn(("abc", 123));
-    let _borrow = world.get::<&mut i32>(e).unwrap();
-    world.get::<&i32>(e).unwrap();
+    let e = world.spawn((Str("abc"), Int(123)));
+    let _borrow = world.get::<&mut Int>(e).unwrap();
+    world.get::<&Int>(e).unwrap();
 }
 
 #[test]
@@ -732,14 +782,17 @@ fn illegal_random_access() {
 fn derived_bundle() {
     #[derive(Bundle)]
     struct Foo {
-        x: i32,
-        y: char,
+        x: Int,
+        y: Char,
     }
 
     let mut world = World::new();
-    let e = world.spawn(Foo { x: 42, y: 'a' });
-    assert_eq!(*world.get::<&i32>(e).unwrap(), 42);
-    assert_eq!(*world.get::<&char>(e).unwrap(), 'a');
+    let e = world.spawn(Foo {
+        x: Int(42),
+        y: Char('a'),
+    });
+    assert_eq!(world.get::<&Int>(e).unwrap().0, 42);
+    assert_eq!(world.get::<&Char>(e).unwrap().0, 'a');
 }
 
 #[test]
@@ -747,24 +800,27 @@ fn derived_bundle() {
 #[cfg_attr(
     debug_assertions,
     should_panic(
-        expected = "attempted to allocate entity with duplicate i32 components; each type must occur at most once!"
+        expected = "attempted to allocate entity with duplicate tests::Int components; \
+                    each type must occur at most once!"
     )
 )]
 #[cfg_attr(
     not(debug_assertions),
-    should_panic(
-        expected = "attempted to allocate entity with duplicate components; each type must occur at most once!"
-    )
+    should_panic(expected = "attempted to allocate entity with duplicate components; \
+                    each type must occur at most once!")
 )]
 fn bad_bundle_derive() {
     #[derive(Bundle)]
     struct Foo {
-        x: i32,
-        y: i32,
+        x: Int,
+        y: Int,
     }
 
     let mut world = World::new();
-    world.spawn(Foo { x: 42, y: 42 });
+    world.spawn(Foo {
+        x: Int(42),
+        y: Int(42),
+    });
 }
 
 #[test]
@@ -773,7 +829,7 @@ fn spawn_many() {
     let mut world = World::new();
     const N: usize = 100_000;
     for _ in 0..N {
-        world.spawn((42u128,));
+        world.spawn((Int(42),));
     }
     assert_eq!(world.iter().count(), N);
 }
@@ -781,8 +837,8 @@ fn spawn_many() {
 #[test]
 fn clear() {
     let mut world = World::new();
-    world.spawn(("abc", 123));
-    world.spawn(("def", 456, true));
+    world.spawn((Str("abc"), Int(123)));
+    world.spawn((Str("def"), Int(456), Bool(true)));
     world.clear();
     assert_eq!(world.iter().count(), 0);
 }
@@ -790,23 +846,23 @@ fn clear() {
 #[test]
 fn remove_missing() {
     let mut world = World::new();
-    let e = world.spawn(("abc", 123));
-    assert!(world.remove_one::<bool>(e).is_err());
+    let e = world.spawn((Str("abc"), Int(123)));
+    assert!(world.remove_one::<Bool>(e).is_err());
 }
 
 #[test]
 fn exchange_components() {
     let mut world = World::new();
 
-    let entity = world.spawn(("abc".to_owned(), 123));
-    assert!(world.get::<&String>(entity).is_ok());
-    assert!(world.get::<&i32>(entity).is_ok());
-    assert!(world.get::<&bool>(entity).is_err());
+    let entity = world.spawn((Label("abc".to_owned()), Int(123)));
+    assert!(world.get::<&Label>(entity).is_ok());
+    assert!(world.get::<&Int>(entity).is_ok());
+    assert!(world.get::<&Bool>(entity).is_err());
 
-    world.exchange_one::<String, _>(entity, true).unwrap();
-    assert!(world.get::<&String>(entity).is_err());
-    assert!(world.get::<&i32>(entity).is_ok());
-    assert!(world.get::<&bool>(entity).is_ok());
+    world.exchange_one::<Label, _>(entity, Bool(true)).unwrap();
+    assert!(world.get::<&Label>(entity).is_err());
+    assert!(world.get::<&Int>(entity).is_ok());
+    assert!(world.get::<&Bool>(entity).is_ok());
 }
 
 #[test]
@@ -831,7 +887,7 @@ fn query_batched() {
     let mut world = World::new();
     let a = world.spawn(());
     let b = world.spawn(());
-    let c = world.spawn((42,));
+    let c = world.spawn((Int(42),));
     assert_eq!(world.query::<()>().iter_batched(1).count(), 3);
     assert_eq!(world.query::<()>().iter_batched(2).count(), 2);
     assert_eq!(world.query::<()>().iter_batched(2).flatten().count(), 3);
@@ -844,7 +900,6 @@ fn query_batched() {
         .iter_batched(1)
         .flatten()
         .collect::<Vec<_>>();
-    dbg!(&entities);
     assert_eq!(entities.len(), 3);
     assert!(entities.contains(&a));
     assert!(entities.contains(&b));
@@ -853,11 +908,11 @@ fn query_batched() {
     // Batched queries filter like usual
     assert_eq!(
         world
-            .query::<(Entity, &i32)>()
+            .query::<(Entity, &Int)>()
             .iter_batched(1)
             .flatten()
             .collect::<Vec<_>>(),
-        &[(c, &42)]
+        &[(c, &Int(42))]
     );
 }
 
@@ -866,7 +921,7 @@ fn query_mut_batched() {
     let mut world = World::new();
     let a = world.spawn(());
     let b = world.spawn(());
-    let c = world.spawn((42,));
+    let c = world.spawn((Int(42),));
     assert_eq!(world.query_mut::<()>().into_iter_batched(1).count(), 3);
     assert_eq!(world.query_mut::<()>().into_iter_batched(2).count(), 2);
     assert_eq!(
@@ -893,7 +948,6 @@ fn query_mut_batched() {
         .into_iter_batched(1)
         .flatten()
         .collect::<Vec<_>>();
-    dbg!(&entities);
     assert_eq!(entities.len(), 3);
     assert!(entities.contains(&a));
     assert!(entities.contains(&b));
@@ -903,27 +957,30 @@ fn query_mut_batched() {
 #[test]
 fn spawn_batch() {
     let mut world = World::new();
-    world.spawn_batch((0..10).map(|x| (x, "abc")));
-    let entity_count = world.query::<&i32>().iter().count();
+    world.spawn_batch((0..10).map(|x| (Int(x), Str("abc"))));
+    let entity_count = world.query::<&Int>().iter().count();
     assert_eq!(entity_count, 10);
 }
 
 #[test]
 fn query_one() {
     let mut world = World::new();
-    let a = world.spawn(("abc", 123));
-    let b = world.spawn(("def", 456));
-    let c = world.spawn(("ghi", 789, true));
-    assert_eq!(world.query_one::<&i32>(a).get(), Ok(&123));
-    assert_eq!(world.query_one::<&i32>(b).get(), Ok(&456));
+    let a = world.spawn((Str("abc"), Int(123)));
+    let b = world.spawn((Str("def"), Int(456)));
+    let c = world.spawn((Str("ghi"), Int(789), Bool(true)));
+    assert_eq!(world.query_one::<&Int>(a).get(), Ok(&Int(123)));
+    assert_eq!(world.query_one::<&Int>(b).get(), Ok(&Int(456)));
     assert_eq!(
-        world.query_one::<(&i32, &bool)>(a).get(),
+        world.query_one::<(&Int, &Bool)>(a).get(),
         Err(QueryOneError::Unsatisfied)
     );
-    assert_eq!(world.query_one::<(&i32, &bool)>(c).get(), Ok((&789, &true)));
+    assert_eq!(
+        world.query_one::<(&Int, &Bool)>(c).get(),
+        Ok((&Int(789), &Bool(true)))
+    );
     world.despawn(a).unwrap();
     assert_eq!(
-        world.query_one::<&i32>(a).get(),
+        world.query_one::<&Int>(a).get(),
         Err(QueryOneError::NoSuchEntity)
     );
 }
@@ -932,49 +989,49 @@ fn query_one() {
 #[cfg_attr(
     debug_assertions,
     should_panic(
-        expected = "attempted to allocate entity with duplicate f32 components; each type must occur at most once!"
+        expected = "attempted to allocate entity with duplicate tests::F32 components; \
+                    each type must occur at most once!"
     )
 )]
 #[cfg_attr(
     not(debug_assertions),
-    should_panic(
-        expected = "attempted to allocate entity with duplicate components; each type must occur at most once!"
-    )
+    should_panic(expected = "attempted to allocate entity with duplicate components; \
+                    each type must occur at most once!")
 )]
 fn duplicate_components_panic() {
     let mut world = World::new();
-    world.reserve::<(f32, i64, f32)>(1);
+    world.reserve::<(F32, Int, F32)>(1);
 }
 
 #[test]
 fn spawn_column_batch() {
     let mut world = World::new();
     let mut batch_ty = ColumnBatchType::new();
-    batch_ty.add::<i32>().add::<bool>();
+    batch_ty.add::<Int>().add::<Bool>();
 
     // Unique archetype
     let b;
     {
         let batch = batch_ty.clone().into_batch(2);
         {
-            let mut bs = batch.writer::<bool>().unwrap();
-            bs.push(true).unwrap();
-            bs.push(false).unwrap();
-            let mut is = batch.writer::<i32>().unwrap();
-            is.push(42).unwrap();
-            is.push(43).unwrap();
+            let mut bs = batch.writer::<Bool>().unwrap();
+            bs.push(Bool(true)).unwrap();
+            bs.push(Bool(false)).unwrap();
+            let mut is = batch.writer::<Int>().unwrap();
+            is.push(Int(42)).unwrap();
+            is.push(Int(43)).unwrap();
         }
         let entities = world
             .spawn_column_batch(batch.build().unwrap())
             .collect::<Vec<_>>();
         assert_eq!(entities.len(), 2);
         assert_eq!(
-            world.query_one_mut::<(&i32, &bool)>(entities[0]).unwrap(),
-            (&42, &true)
+            world.query_one_mut::<(&Int, &Bool)>(entities[0]).unwrap(),
+            (&Int(42), &Bool(true))
         );
         assert_eq!(
-            world.query_one_mut::<(&i32, &bool)>(entities[1]).unwrap(),
-            (&43, &false)
+            world.query_one_mut::<(&Int, &Bool)>(entities[1]).unwrap(),
+            (&Int(43), &Bool(false))
         );
         world.despawn(entities[0]).unwrap();
         b = entities[1];
@@ -984,38 +1041,38 @@ fn spawn_column_batch() {
     {
         let batch = batch_ty.clone().into_batch(2);
         {
-            let mut bs = batch.writer::<bool>().unwrap();
-            bs.push(true).unwrap();
-            bs.push(false).unwrap();
-            let mut is = batch.writer::<i32>().unwrap();
-            is.push(44).unwrap();
-            is.push(45).unwrap();
+            let mut bs = batch.writer::<Bool>().unwrap();
+            bs.push(Bool(true)).unwrap();
+            bs.push(Bool(false)).unwrap();
+            let mut is = batch.writer::<Int>().unwrap();
+            is.push(Int(44)).unwrap();
+            is.push(Int(45)).unwrap();
         }
         let entities = world
             .spawn_column_batch(batch.build().unwrap())
             .collect::<Vec<_>>();
         assert_eq!(entities.len(), 2);
-        assert_eq!(*world.get::<&i32>(b).unwrap(), 43);
-        assert_eq!(*world.get::<&i32>(entities[0]).unwrap(), 44);
-        assert_eq!(*world.get::<&i32>(entities[1]).unwrap(), 45);
+        assert_eq!(world.get::<&Int>(b).unwrap().0, 43);
+        assert_eq!(world.get::<&Int>(entities[0]).unwrap().0, 44);
+        assert_eq!(world.get::<&Int>(entities[1]).unwrap().0, 45);
     }
 }
 
 #[test]
 fn columnar_access() {
     let mut world = World::new();
-    let e = world.spawn(("abc", 123));
-    let f = world.spawn(("def", 456, true));
-    let g = world.spawn(("ghi", 789, false));
+    let e = world.spawn((Str("abc"), Int(123)));
+    let f = world.spawn((Str("def"), Int(456), Bool(true)));
+    let g = world.spawn((Str("ghi"), Int(789), Bool(false)));
     let mut archetypes = world.archetypes();
     let _empty = archetypes.next().unwrap();
     let a = archetypes.next().unwrap();
     assert_eq!(a.ids(), &[e.id()]);
-    assert_eq!(*a.get::<&i32>().unwrap(), [123]);
-    assert!(a.get::<&bool>().is_none());
+    assert_eq!(*a.get::<&Int>().unwrap(), [Int(123)]);
+    assert!(a.get::<&Bool>().is_none());
     let b = archetypes.next().unwrap();
     assert_eq!(b.ids(), &[f.id(), g.id()]);
-    assert_eq!(*b.get::<&i32>().unwrap(), [456, 789]);
+    assert_eq!(*b.get::<&Int>().unwrap(), [Int(456), Int(789)]);
 }
 
 #[test]
@@ -1029,19 +1086,19 @@ fn empty_entity_ref() {
 #[test]
 fn query_or() {
     let mut world = World::new();
-    let e = world.spawn(("abc", 123));
-    let _ = world.spawn(("def",));
-    let f = world.spawn(("ghi", true));
-    let g = world.spawn(("jkl", 456, false));
+    let e = world.spawn((Str("abc"), Int(123)));
+    let _ = world.spawn((Str("def"),));
+    let f = world.spawn((Str("ghi"), Bool(true)));
+    let g = world.spawn((Str("jkl"), Int(456), Bool(false)));
     let results = world
-        .query::<(Entity, &&str, Or<&i32, &bool>)>()
+        .query::<(Entity, &Str, Or<&Int, &Bool>)>()
         .iter()
-        .map(|(handle, &s, value)| (handle, s, value.cloned()))
+        .map(|(handle, s, value)| (handle, *s, value.cloned()))
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 3);
-    assert!(results.contains(&(e, "abc", Or::Left(123))));
-    assert!(results.contains(&(f, "ghi", Or::Right(true))));
-    assert!(results.contains(&(g, "jkl", Or::Both(456, false))));
+    assert!(results.contains(&(e, Str("abc"), Or::Left(Int(123)))));
+    assert!(results.contains(&(f, Str("ghi"), Or::Right(Bool(true)))));
+    assert!(results.contains(&(g, Str("jkl"), Or::Both(Int(456), Bool(false)))));
 }
 
 #[test]
@@ -1060,15 +1117,15 @@ fn len() {
 #[test]
 fn take() {
     let mut world_a = World::new();
-    let e = world_a.spawn(("abc".to_string(), 42));
-    let f = world_a.spawn(("def".to_string(), 17));
+    let e = world_a.spawn((Label("abc".to_string()), Int(42)));
+    let f = world_a.spawn((Label("def".to_string()), Int(17)));
     let mut world_b = World::new();
     let e2 = world_b.spawn(world_a.take(e).unwrap());
     assert!(!world_a.contains(e));
-    assert_eq!(*world_b.get::<&String>(e2).unwrap(), "abc");
-    assert_eq!(*world_b.get::<&i32>(e2).unwrap(), 42);
-    assert_eq!(*world_a.get::<&String>(f).unwrap(), "def");
-    assert_eq!(*world_a.get::<&i32>(f).unwrap(), 17);
+    assert_eq!(world_b.get::<&Label>(e2).unwrap().0, "abc");
+    assert_eq!(world_b.get::<&Int>(e2).unwrap().0, 42);
+    assert_eq!(world_a.get::<&Label>(f).unwrap().0, "def");
+    assert_eq!(world_a.get::<&Int>(f).unwrap().0, 17);
     world_b.take(e2).unwrap();
     assert!(!world_b.contains(e2));
 }
@@ -1076,12 +1133,12 @@ fn take() {
 #[test]
 fn empty_archetype_conflict() {
     let mut world = World::new();
-    let _ = world.spawn((42, true));
-    let _ = world.spawn((17, "abc"));
-    let e = world.spawn((12, false, "def"));
+    let _ = world.spawn((Int(42), Bool(true)));
+    let _ = world.spawn((Int(17), Str("abc")));
+    let e = world.spawn((Int(12), Bool(false), Str("def")));
     world.despawn(e).unwrap();
-    for _ in world.query::<(&mut i32, &&str)>().iter() {
-        for _ in world.query::<(&mut i32, &bool)>().iter() {}
+    for _ in world.query::<(&mut Int, &Str)>().iter() {
+        for _ in world.query::<(&mut Int, &Bool)>().iter() {}
     }
 }
 
@@ -1090,6 +1147,7 @@ fn component_ref_map() {
     struct TestComponent {
         id: i32,
     }
+    impl Component for TestComponent {}
 
     let mut world = World::new();
     let e = world.spawn((TestComponent { id: 21 },));
@@ -1119,9 +1177,12 @@ fn component_ref_map() {
 #[test]
 fn query_many() {
     let mut world = World::new();
-    let a = world.spawn((42, true));
-    let b = world.spawn((17,));
-    assert_eq!(world.query_many_mut::<&i32, 2>([a, b]), [Ok(&42), Ok(&17)]);
+    let a = world.spawn((Int(42), Bool(true)));
+    let b = world.spawn((Int(17),));
+    assert_eq!(
+        world.query_many_mut::<&Int, 2>([a, b]),
+        [Ok(&Int(42)), Ok(&Int(17))]
+    );
 }
 
 #[test]
@@ -1136,14 +1197,14 @@ fn query_many_duplicate() {
 fn cache_invalidation() {
     let mut world = World::new();
     assert_eq!(
-        world.query::<(Entity, &i32)>().iter().collect::<Vec<_>>(),
+        world.query::<(Entity, &Int)>().iter().collect::<Vec<_>>(),
         []
     );
-    let a = world.spawn((42, true));
-    let b = world.spawn((17,));
+    let a = world.spawn((Int(42), Bool(true)));
+    let b = world.spawn((Int(17),));
     assert_eq!(
-        world.query::<(Entity, &i32)>().iter().collect::<Vec<_>>(),
-        &[(a, &42), (b, &17)]
+        world.query::<(Entity, &Int)>().iter().collect::<Vec<_>>(),
+        &[(a, &Int(42)), (b, &Int(17))]
     );
 }
 
@@ -1151,6 +1212,7 @@ fn cache_invalidation() {
 #[test]
 fn entity_generation_regression() {
     struct C;
+    impl Component for C {}
 
     let mut world = World::new();
 


### PR DESCRIPTION
Alternative to https://github.com/Ralith/hecs/pull/454. This is a major breaking change for which I am seeking feedback. It is motivated by several user reports of difficult-to-diagnose errors, and general agreement that inserting foreign types as components is rare and not especially important.