### PR TITLE
Add hegel property tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+/.hegel

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ serde_test = "1.0.117"
 bincode = "1.3.3"
 hegeltest = "0.35.0"
 
+[[test]]
+name = "serialize"
+required-features = ["row-serialize", "column-serialize"]
+
 [[bench]]
 name = "bench"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ trybuild = "1.0.23"
 serde = { version = "1.0.117", features = ["derive"] }
 serde_test = "1.0.117"
 bincode = "1.3.3"
-hegeltest = "0.35.0"
+hegel = { package = "hegeltest", version = "0.35.0" }
 
 [[test]]
 name = "serialize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ serde = { version = "1.0.117", features = ["derive"] }
 serde_test = "1.0.117"
 bincode = "1.3.3"
 hegel = { package = "hegeltest", version = "0.35.0" }
+fixtures = { path = "tests/fixtures" }
 
 [[test]]
 name = "serialize"
@@ -57,7 +58,7 @@ required-features = ["macros"]
 debug = true
 
 [workspace]
-members = ["macros", "tests/no-std-test-crates/macros"]
+members = ["macros", "tests/fixtures", "tests/no-std-test-crates/macros"]
 
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ trybuild = "1.0.23"
 serde = { version = "1.0.117", features = ["derive"] }
 serde_test = "1.0.117"
 bincode = "1.3.3"
+hegeltest = "0.35.0"
 
 [[bench]]
 name = "bench"

--- a/tests/builders.rs
+++ b/tests/builders.rs
@@ -21,11 +21,11 @@ use hecs::{
 /// spawned from that very bundle.
 #[hegel::test(settings())]
 fn bundle_satisfaction_agrees_with_world_satisfies(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let cs = tc.draw(components());
     let mut world = World::new();
 
-    let mut builder = cs.builder();
+    let mut builder = cs.builder(&ds);
     let built = builder.build();
     assert_eq!(built.has::<A>(), cs.a.is_some(), "BuiltEntity::has::<A>");
     assert_eq!(built.has::<B>(), cs.b.is_some(), "BuiltEntity::has::<B>");
@@ -79,15 +79,15 @@ fn bundle_satisfaction_agrees_with_world_satisfies(tc: hegel::TestCase) {
 /// leaks when the bundle goes unused.
 #[hegel::test(settings())]
 fn an_unspawned_bundle_drops_its_components(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let cs = tc.draw(components());
     {
-        let mut builder = cs.builder();
+        let mut builder = cs.builder(&ds);
         let built = builder.build();
         assert_eq!(built.has::<D>(), cs.d.is_some(), "BuiltEntity::has::<D>");
     }
     assert_eq!(
-        d_live(),
+        ds.live(),
         0,
         "an unspawned bundle leaked or double-dropped its components"
     );
@@ -97,10 +97,10 @@ fn an_unspawned_bundle_drops_its_components(tc: hegel::TestCase) {
 /// build spawns nothing.
 #[hegel::test(settings())]
 fn clearing_a_builder_drops_its_components(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let cs = tc.draw(components());
     let mut world = World::new();
-    let mut builder = cs.builder();
+    let mut builder = cs.builder(&ds);
     builder.clear();
     assert_eq!(
         builder.component_types().count(),
@@ -112,7 +112,7 @@ fn clearing_a_builder_drops_its_components(tc: hegel::TestCase) {
         "clear left components"
     );
     assert_eq!(
-        d_live(),
+        ds.live(),
         0,
         "clear leaked or double-dropped the builder's components"
     );
@@ -129,11 +129,11 @@ fn clearing_a_builder_drops_its_components(tc: hegel::TestCase) {
 /// spawned.
 #[hegel::test(settings())]
 fn builder_edits_through_get_mut_are_spawned(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let cs = tc.draw(components());
     let v = tc.draw(val());
     let mut world = World::new();
-    let mut builder = cs.builder();
+    let mut builder = cs.builder(&ds);
 
     let mut expected = cs;
     if let Some(a) = builder.get_mut::<&mut A>() {
@@ -141,7 +141,7 @@ fn builder_edits_through_get_mut_are_spawned(tc: hegel::TestCase) {
         expected.a = Some(v);
     }
     if let Some(d) = builder.get_mut::<&mut D>() {
-        d.0 = v;
+        d.value = v;
         expected.d = Some(v);
     }
     let e = world.spawn(builder.build());
@@ -266,11 +266,11 @@ fn a_cloned_builder_spawns_the_same_entity(tc: hegel::TestCase) {
 /// in the world.
 #[hegel::test(settings())]
 fn ref_projections_read_and_write_the_component(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let v = tc.draw(val());
     let w = tc.draw(val());
     let mut world = World::new();
-    let e = world.spawn((A(v), D::new(v)));
+    let e = world.spawn((A(v), D::new(v, &ds)));
 
     {
         let shared: Ref<'_, A> = world.get::<&A>(e).expect("A was just spawned");
@@ -299,7 +299,7 @@ fn ref_projections_read_and_write_the_component(tc: hegel::TestCase) {
     );
 
     world.despawn(e).unwrap();
-    assert_eq!(d_live(), 0, "drop imbalance in the ref-projection test");
+    assert_eq!(ds.live(), 0, "drop imbalance in the ref-projection test");
 }
 
 /// Whole-column archetype access presents the same values as per-entity reads,
@@ -308,9 +308,9 @@ fn ref_projections_read_and_write_the_component(tc: hegel::TestCase) {
 /// views of the same storage must not drift.
 #[hegel::test(settings())]
 fn archetype_columns_agree_with_per_entity_reads(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let world = build_world(&history);
+    let world = build_world(&history, &ds);
     let before = fingerprint(&world);
 
     let mut by_id: BTreeMap<u32, i32> = BTreeMap::new();

--- a/tests/builders.rs
+++ b/tests/builders.rs
@@ -310,9 +310,8 @@ fn ref_projections_read_and_write_the_component(tc: hegel::TestCase) {
 fn archetype_columns_agree_with_per_entity_reads(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let (mut worlds, _pool) = build_twins(&history, 1);
-    let world = &mut worlds[0];
-    let before = fingerprint(world);
+    let world = build_world(&history);
+    let before = fingerprint(&world);
 
     let mut by_id: BTreeMap<u32, i32> = BTreeMap::new();
     for arch in world.archetypes() {
@@ -344,7 +343,7 @@ fn archetype_columns_agree_with_per_entity_reads(tc: hegel::TestCase) {
             }
         }
     }
-    for (e, o) in fingerprint(world) {
+    for (e, o) in fingerprint(&world) {
         assert_eq!(
             o.b,
             before[&e].b.map(|_| v),

--- a/tests/builders.rs
+++ b/tests/builders.rs
@@ -238,20 +238,12 @@ fn add_bundle_matches_individual_adds(tc: hegel::TestCase) {
 
 /// A cloned `EntityBuilderClone` spawns the same entity as the original, and
 /// the original still spawns correctly afterwards.
-///
-/// The spec is forced to contain a sized component: cloning a builder whose
-/// storage layout is zero-sized calls `alloc` with a zero-size layout, which
-/// is undefined behaviour and would make this test fail under Miri. See the
-/// ignored `cloning_an_empty_clone_builder_is_sound` below.
 #[hegel::test(settings())]
 fn a_cloned_builder_spawns_the_same_entity(tc: hegel::TestCase) {
-    let mut s = Spec {
+    let s = Spec {
         d: None,
         ..tc.draw(specs())
     };
-    if s.a.is_none() && s.b.is_none() {
-        s.a = Some(tc.draw(val()));
-    }
     let mut world = World::new();
 
     let mut original = EntityBuilderClone::new();
@@ -376,14 +368,11 @@ fn archetype_columns_agree_with_per_entity_reads(tc: hegel::TestCase) {
     }
 }
 
-/// `build()` sorts the builder's component info by descending alignment but
-/// does not rebuild the `TypeId -> slot` map, so after the documented
-/// `BuiltEntityClone -> EntityBuilderClone` round trip, `get`/`get_mut`/`add`
-/// resolve to the wrong slot. Here `get::<&Small>()` returns the first byte of
-/// `Big`; `add` on such a builder reads out of bounds (Miri confirms).
-/// Reproduces on hecs 0.11.1 (issue #460).
+/// `build()` used to sort the component info by alignment without rebuilding
+/// the `TypeId -> slot` map, so after the documented `BuiltEntityClone ->
+/// EntityBuilderClone` round trip `get` read the wrong slot. Reproduces on
+/// hecs 0.11.1 (issue #460).
 #[test]
-#[ignore = "hecs#460: BuiltEntityClone -> EntityBuilderClone leaves a stale component index"]
 fn builder_clone_roundtrip_preserves_component_lookup() {
     #[derive(Clone)]
     struct Small(u8);
@@ -420,16 +409,10 @@ fn builder_clone_roundtrip_preserves_component_lookup() {
     );
 }
 
-/// `Clone for EntityBuilderClone` calls `alloc` with the builder's layout
-/// unconditionally, and a builder holding nothing (or only zero-sized
-/// components) has a zero-size layout — undefined behaviour per
-/// `GlobalAlloc::alloc`, and `NonNull::new_unchecked` on the result is
-/// unsound in its own right. `Common::drop` and `Common::grow` both guard
-/// against a zero-size layout; `clone` does not. Only Miri observes this, so
-/// the test passes under a normal `cargo test`. Reproduces on hecs 0.11.1
-/// (issue #461).
+/// `Clone for EntityBuilderClone` used to call `alloc` with a zero-size layout
+/// for a builder holding nothing, or only zero-sized components. Only Miri
+/// observes it. Reproduces on hecs 0.11.1 (issue #461).
 #[test]
-#[ignore = "hecs#461: cloning an empty EntityBuilderClone allocates a zero-size layout"]
 fn cloning_an_empty_clone_builder_is_sound() {
     #[derive(Clone)]
     struct Marker;

--- a/tests/builders.rs
+++ b/tests/builders.rs
@@ -383,7 +383,7 @@ fn archetype_columns_agree_with_per_entity_reads(tc: hegel::TestCase) {
 /// `Big`; `add` on such a builder reads out of bounds (Miri confirms).
 /// Reproduces on hecs 0.11.1 (issue #460).
 #[test]
-#[ignore = "hecs bug: BuiltEntityClone -> EntityBuilderClone leaves a stale component index"]
+#[ignore = "hecs#460: BuiltEntityClone -> EntityBuilderClone leaves a stale component index"]
 fn builder_clone_roundtrip_preserves_component_lookup() {
     #[derive(Clone)]
     struct Small(u8);
@@ -429,7 +429,7 @@ fn builder_clone_roundtrip_preserves_component_lookup() {
 /// the test passes under a normal `cargo test`. Reproduces on hecs 0.11.1
 /// (issue #461).
 #[test]
-#[ignore = "hecs bug: cloning an empty EntityBuilderClone allocates a zero-size layout"]
+#[ignore = "hecs#461: cloning an empty EntityBuilderClone allocates a zero-size layout"]
 fn cloning_an_empty_clone_builder_is_sound() {
     #[derive(Clone)]
     struct Marker;

--- a/tests/builders.rs
+++ b/tests/builders.rs
@@ -8,11 +8,9 @@
 //! drop-tracked, so a builder that leaks or double-drops what it holds fails
 //! even when the components it spawns look right.
 
-mod common;
-
 use std::collections::BTreeMap;
 
-use common::*;
+use fixtures::*;
 use hecs::{
     bundle_satisfies_query, dynamic_bundle_satisfies_query, DynamicBundle, Entity,
     EntityBuilderClone, Ref, RefMut, World,

--- a/tests/builders.rs
+++ b/tests/builders.rs
@@ -49,8 +49,12 @@ fn bundle_satisfaction_agrees_with_world_satisfies(tc: hegel::TestCase) {
         predicted, actual,
         "dynamic_bundle_satisfies_query disagreed with satisfies"
     );
+}
 
-    // The static form answers the same question from the bundle's type alone.
+/// The static form answers the same question from the bundle's type alone.
+#[test]
+fn static_bundle_satisfaction_agrees_with_world_satisfies() {
+    let mut world = World::new();
     let tuple = world.spawn((A(1), B(2)));
     assert_eq!(
         (

--- a/tests/builders.rs
+++ b/tests/builders.rs
@@ -194,10 +194,7 @@ fn observe(world: &World, e: Entity) -> Spec {
 /// them all across.
 #[hegel::test(settings())]
 fn add_bundle_matches_individual_adds(tc: hegel::TestCase) {
-    let s = Spec {
-        d: None,
-        ..tc.draw(specs())
-    };
+    let s = tc.draw(specs_without_d());
     let expected = s;
     let mut world = World::new();
 
@@ -240,10 +237,7 @@ fn add_bundle_matches_individual_adds(tc: hegel::TestCase) {
 /// the original still spawns correctly afterwards.
 #[hegel::test(settings())]
 fn a_cloned_builder_spawns_the_same_entity(tc: hegel::TestCase) {
-    let s = Spec {
-        d: None,
-        ..tc.draw(specs())
-    };
+    let s = tc.draw(specs_without_d());
     let mut world = World::new();
 
     let mut original = EntityBuilderClone::new();
@@ -317,7 +311,8 @@ fn ref_projections_read_and_write_the_component(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn archetype_columns_agree_with_per_entity_reads(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let (mut worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let history = tc.draw(histories(0, MAX_ENTITIES));
+    let (mut worlds, _pool) = build_twins(&history, 1);
     let world = &mut worlds[0];
     let before = fingerprint(world);
 

--- a/tests/builders.rs
+++ b/tests/builders.rs
@@ -1,0 +1,443 @@
+//! Properties of the bundle-construction surface: `EntityBuilder`,
+//! `EntityBuilderClone`, the bundle query-satisfaction predicates, the `Ref`
+//! wrappers, and whole-column archetype access.
+//!
+//! The oracles are the drawn spec, the world's own `satisfies` (which must
+//! agree with the predicates that answer the same question without a world),
+//! and per-entity reads (which must agree with whole-column reads). `D` is
+//! drop-tracked, so a builder that leaks or double-drops what it holds fails
+//! even when the components it spawns look right.
+
+mod common;
+
+use std::collections::BTreeMap;
+
+use common::*;
+use hecs::{
+    bundle_satisfies_query, dynamic_bundle_satisfies_query, DynamicBundle, Entity,
+    EntityBuilderClone, Ref, RefMut, World,
+};
+
+/// The bundle predicates answer "would an entity with these components match
+/// `Q`?" without a world. They must agree with `World::satisfies` on an entity
+/// spawned from that very bundle.
+#[hegel::test(settings())]
+fn bundle_satisfaction_agrees_with_world_satisfies(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let s = tc.draw(specs());
+    let mut world = World::new();
+
+    let mut builder = make_builder(s);
+    let built = builder.build();
+    assert_eq!(built.has::<A>(), s.a.is_some(), "BuiltEntity::has::<A>");
+    assert_eq!(built.has::<B>(), s.b.is_some(), "BuiltEntity::has::<B>");
+    assert_eq!(built.has::<C>(), s.c, "BuiltEntity::has::<C>");
+    assert_eq!(built.has::<D>(), s.d.is_some(), "BuiltEntity::has::<D>");
+
+    let predicted = (
+        dynamic_bundle_satisfies_query::<_, &A>(&built),
+        dynamic_bundle_satisfies_query::<_, &D>(&built),
+        dynamic_bundle_satisfies_query::<_, (&A, &B)>(&built),
+        dynamic_bundle_satisfies_query::<_, (&A, &C)>(&built),
+    );
+    let e = world.spawn(built);
+    let actual = (
+        world.satisfies::<&A>(e),
+        world.satisfies::<&D>(e),
+        world.satisfies::<(&A, &B)>(e),
+        world.satisfies::<(&A, &C)>(e),
+    );
+    assert_eq!(
+        predicted, actual,
+        "dynamic_bundle_satisfies_query disagreed with satisfies"
+    );
+
+    // The static form answers the same question from the bundle's type alone.
+    let tuple = world.spawn((A(1), B(2)));
+    assert_eq!(
+        (
+            bundle_satisfies_query::<(A, B), &A>(),
+            bundle_satisfies_query::<(A, B), (&A, &B)>(),
+            bundle_satisfies_query::<(A, B), &C>(),
+            bundle_satisfies_query::<(A, B), (&A, &C)>(),
+        ),
+        (
+            world.satisfies::<&A>(tuple),
+            world.satisfies::<(&A, &B)>(tuple),
+            world.satisfies::<&C>(tuple),
+            world.satisfies::<(&A, &C)>(tuple),
+        ),
+        "bundle_satisfies_query disagreed with satisfies"
+    );
+    let pair = (A(1), B(2));
+    assert!(
+        pair.has::<A>() && pair.has::<B>() && !pair.has::<C>(),
+        "tuple DynamicBundle::has"
+    );
+}
+
+/// A bundle that is built but never spawned still drops its components exactly
+/// once — `BuiltEntity::drop` documents that it clears the builder so nothing
+/// leaks when the bundle goes unused.
+#[hegel::test(settings())]
+fn an_unspawned_bundle_drops_its_components(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let s = tc.draw(specs());
+    {
+        let mut builder = make_builder(s);
+        let built = builder.build();
+        assert_eq!(built.has::<D>(), s.d.is_some(), "BuiltEntity::has::<D>");
+    }
+    assert_eq!(
+        d_live(),
+        0,
+        "an unspawned bundle leaked or double-dropped its components"
+    );
+}
+
+/// `clear` drops what the builder holds and leaves it empty, so a subsequent
+/// build spawns nothing.
+#[hegel::test(settings())]
+fn clearing_a_builder_drops_its_components(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let s = tc.draw(specs());
+    let mut world = World::new();
+    let mut builder = make_builder(s);
+    builder.clear();
+    assert_eq!(
+        builder.component_types().count(),
+        0,
+        "clear left component types"
+    );
+    assert!(
+        !builder.has::<A>() && !builder.has::<D>(),
+        "clear left components"
+    );
+    assert_eq!(
+        d_live(),
+        0,
+        "clear leaked or double-dropped the builder's components"
+    );
+
+    let e = world.spawn(builder.build());
+    assert_eq!(
+        fingerprint(&world).get(&e),
+        Some(&Spec::default()),
+        "a cleared builder spawned components"
+    );
+}
+
+/// An edit made through `get_mut` before building is the value that gets
+/// spawned.
+#[hegel::test(settings())]
+fn builder_edits_through_get_mut_are_spawned(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let s = tc.draw(specs());
+    let v = tc.draw(val());
+    let mut world = World::new();
+    let mut builder = make_builder(s);
+
+    let mut expected = s;
+    if let Some(a) = builder.get_mut::<&mut A>() {
+        a.0 = v;
+        expected.a = Some(v);
+    }
+    if let Some(d) = builder.get_mut::<&mut D>() {
+        d.0 = v;
+        expected.d = Some(v);
+    }
+    let e = world.spawn(builder.build());
+    assert_eq!(
+        fingerprint(&world).get(&e),
+        Some(&expected),
+        "get_mut edits were not spawned"
+    );
+}
+
+/// Add the `{A, B, C}` part of `s` one component at a time. `D` is not
+/// `Clone`, so it cannot go into an `EntityBuilderClone`.
+fn add_individually(builder: &mut EntityBuilderClone, s: Spec) {
+    if let Some(v) = s.a {
+        builder.add(A(v));
+    }
+    if let Some(v) = s.b {
+        builder.add(B(v));
+    }
+    if s.c {
+        builder.add(C);
+    }
+}
+
+/// Add the same components with one `add_bundle` of a concrete tuple, which
+/// goes through the tuple `DynamicBundleClone` impls instead.
+fn add_as_tuple(builder: &mut EntityBuilderClone, s: Spec) {
+    match (s.a, s.b, s.c) {
+        (None, None, false) => builder.add_bundle(()),
+        (Some(a), None, false) => builder.add_bundle((A(a),)),
+        (None, Some(b), false) => builder.add_bundle((B(b),)),
+        (None, None, true) => builder.add_bundle((C,)),
+        (Some(a), Some(b), false) => builder.add_bundle((A(a), B(b))),
+        (Some(a), None, true) => builder.add_bundle((A(a), C)),
+        (None, Some(b), true) => builder.add_bundle((B(b), C)),
+        (Some(a), Some(b), true) => builder.add_bundle((A(a), B(b), C)),
+    };
+}
+
+fn observe(world: &World, e: Entity) -> Spec {
+    *fingerprint(world)
+        .get(&e)
+        .unwrap_or_else(|| panic!("{e:?} is missing from the world"))
+}
+
+/// `add_bundle` of a tuple is equivalent to adding the same components one at
+/// a time, and a `BuiltEntityClone` fed back in through `add_bundle` carries
+/// them all across.
+#[hegel::test(settings())]
+fn add_bundle_matches_individual_adds(tc: hegel::TestCase) {
+    let s = Spec {
+        d: None,
+        ..tc.draw(specs())
+    };
+    let expected = s;
+    let mut world = World::new();
+
+    let mut individually = EntityBuilderClone::new();
+    add_individually(&mut individually, s);
+    assert_eq!(
+        individually.get::<&A>().map(|r| r.0),
+        s.a,
+        "EntityBuilderClone::get::<&A>"
+    );
+    assert_eq!(
+        individually.component_types().count(),
+        s.component_count(),
+        "EntityBuilderClone::component_types"
+    );
+    let built = individually.build();
+    let e = world.spawn(&built);
+    assert_eq!(observe(&world, e), expected, "individual adds");
+
+    let mut as_tuple = EntityBuilderClone::new();
+    add_as_tuple(&mut as_tuple, s);
+    let e = world.spawn(&as_tuple.build());
+    assert_eq!(
+        observe(&world, e),
+        expected,
+        "add_bundle of a tuple lost components"
+    );
+
+    let mut renested = EntityBuilderClone::new();
+    renested.add_bundle(&built);
+    let e = world.spawn(&renested.build());
+    assert_eq!(
+        observe(&world, e),
+        expected,
+        "add_bundle of a built bundle lost components"
+    );
+}
+
+/// A cloned `EntityBuilderClone` spawns the same entity as the original, and
+/// the original still spawns correctly afterwards.
+///
+/// The spec is forced to contain a sized component: cloning a builder whose
+/// storage layout is zero-sized calls `alloc` with a zero-size layout, which
+/// is undefined behaviour and would make this test fail under Miri. See the
+/// ignored `cloning_an_empty_clone_builder_is_sound` below.
+#[hegel::test(settings())]
+fn a_cloned_builder_spawns_the_same_entity(tc: hegel::TestCase) {
+    let mut s = Spec {
+        d: None,
+        ..tc.draw(specs())
+    };
+    if s.a.is_none() && s.b.is_none() {
+        s.a = Some(tc.draw(val()));
+    }
+    let mut world = World::new();
+
+    let mut original = EntityBuilderClone::new();
+    add_individually(&mut original, s);
+    let copy = original.clone();
+    assert_eq!(
+        copy.has::<A>(),
+        s.a.is_some(),
+        "a clone lost a component type"
+    );
+
+    let from_original = world.spawn(&original.build());
+    let from_copy = world.spawn(&copy.build());
+    assert_eq!(
+        observe(&world, from_original),
+        s,
+        "the original builder spawned the wrong entity"
+    );
+    assert_eq!(
+        observe(&world, from_copy),
+        s,
+        "a cloned builder spawned a different entity"
+    );
+}
+
+/// `Ref` and `RefMut` are transparent handles on a component: projecting with
+/// `map` reads the same value, and a write through a projected `RefMut` lands
+/// in the world.
+#[hegel::test(settings())]
+fn ref_projections_read_and_write_the_component(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let v = tc.draw(val());
+    let w = tc.draw(val());
+    let mut world = World::new();
+    let e = world.spawn((A(v), D::new(v)));
+
+    {
+        let shared: Ref<'_, A> = world.get::<&A>(e).expect("A was just spawned");
+        assert_eq!(
+            format!("{shared:?}"),
+            format!("{:?}", A(v)),
+            "Ref forwards Debug"
+        );
+        let copy = shared.clone();
+        let projected: Ref<'_, i32> = Ref::map(shared, |a| &a.0);
+        assert_eq!(*projected, v, "Ref::map read a different value");
+        assert_eq!(
+            copy.0, v,
+            "a cloned Ref was disturbed by mapping the original"
+        );
+    }
+    {
+        let unique: RefMut<'_, A> = world.get::<&mut A>(e).expect("A was just spawned");
+        let mut projected: RefMut<'_, i32> = RefMut::map(unique, |a| &mut a.0);
+        *projected = w;
+    }
+    assert_eq!(
+        world.get::<&A>(e).unwrap().0,
+        w,
+        "a write through RefMut::map was lost"
+    );
+
+    world.despawn(e).unwrap();
+    assert_eq!(d_live(), 0, "drop imbalance in the ref-projection test");
+}
+
+/// Whole-column archetype access presents the same values as per-entity reads,
+/// and a write through a unique column is visible to ordinary reads. This is
+/// the API serialization and the cloning example are built on, so the two
+/// views of the same storage must not drift.
+#[hegel::test(settings())]
+fn archetype_columns_agree_with_per_entity_reads(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let (mut worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let world = &mut worlds[0];
+    let before = fingerprint(world);
+
+    let mut by_id: BTreeMap<u32, i32> = BTreeMap::new();
+    for arch in world.archetypes() {
+        if let Some(column) = arch.get::<&A>() {
+            assert_eq!(
+                column.len(),
+                arch.len() as usize,
+                "column length != archetype length"
+            );
+            for (&id, a) in arch.ids().iter().zip(column.iter()) {
+                assert!(
+                    by_id.insert(id, a.0).is_none(),
+                    "entity id {id} in two A columns"
+                );
+            }
+        }
+    }
+    let want: BTreeMap<u32, i32> = before
+        .iter()
+        .filter_map(|(e, o)| o.a.map(|v| (e.id(), v)))
+        .collect();
+    assert_eq!(by_id, want, "A columns disagree with per-entity reads");
+
+    let v = tc.draw(val());
+    for arch in world.archetypes() {
+        if let Some(mut column) = arch.get::<&mut B>() {
+            for b in column.iter_mut() {
+                b.0 = v;
+            }
+        }
+    }
+    for (e, o) in fingerprint(world) {
+        assert_eq!(
+            o.b,
+            before[&e].b.map(|_| v),
+            "the column write to B missed {e:?}"
+        );
+        assert_eq!(
+            o.a, before[&e].a,
+            "the column write to B disturbed A on {e:?}"
+        );
+        assert_eq!(
+            o.d, before[&e].d,
+            "the column write to B disturbed D on {e:?}"
+        );
+    }
+}
+
+/// `build()` sorts the builder's component info by descending alignment but
+/// does not rebuild the `TypeId -> slot` map, so after the documented
+/// `BuiltEntityClone -> EntityBuilderClone` round trip, `get`/`get_mut`/`add`
+/// resolve to the wrong slot. Here `get::<&Small>()` returns the first byte of
+/// `Big`; `add` on such a builder reads out of bounds (Miri confirms).
+/// Reproduces on hecs 0.11.1 (issue #460).
+#[test]
+#[ignore = "hecs bug: BuiltEntityClone -> EntityBuilderClone leaves a stale component index"]
+fn builder_clone_roundtrip_preserves_component_lookup() {
+    #[derive(Clone)]
+    struct Small(u8);
+    #[derive(Clone)]
+    struct Big(u64);
+
+    let mut builder = EntityBuilderClone::new();
+    // Added lowest-alignment first, so the sort in build() is guaranteed to
+    // permute the info vector.
+    builder.add(Small(7));
+    builder.add(Big(0x4242_4242_4242_4242));
+    let built = builder.build();
+
+    // Spawning is unaffected: it iterates the info vector directly.
+    let mut world = World::new();
+    let e = world.spawn(&built);
+    assert_eq!(world.get::<&Small>(e).unwrap().0, 7, "spawned Small");
+    assert_eq!(
+        world.get::<&Big>(e).unwrap().0,
+        0x4242_4242_4242_4242,
+        "spawned Big"
+    );
+
+    let roundtripped: EntityBuilderClone = built.into();
+    assert_eq!(
+        roundtripped.get::<&Small>().map(|s| s.0),
+        Some(7),
+        "Small after a round trip"
+    );
+    assert_eq!(
+        roundtripped.get::<&Big>().map(|b| b.0),
+        Some(0x4242_4242_4242_4242),
+        "Big after a round trip"
+    );
+}
+
+/// `Clone for EntityBuilderClone` calls `alloc` with the builder's layout
+/// unconditionally, and a builder holding nothing (or only zero-sized
+/// components) has a zero-size layout — undefined behaviour per
+/// `GlobalAlloc::alloc`, and `NonNull::new_unchecked` on the result is
+/// unsound in its own right. `Common::drop` and `Common::grow` both guard
+/// against a zero-size layout; `clone` does not. Only Miri observes this, so
+/// the test passes under a normal `cargo test`. Reproduces on hecs 0.11.1
+/// (issue #461).
+#[test]
+#[ignore = "hecs bug: cloning an empty EntityBuilderClone allocates a zero-size layout"]
+fn cloning_an_empty_clone_builder_is_sound() {
+    #[derive(Clone)]
+    struct Marker;
+
+    let empty = EntityBuilderClone::new();
+    drop(empty.clone());
+
+    let mut zero_sized = EntityBuilderClone::new();
+    zero_sized.add(Marker);
+    drop(zero_sized.clone());
+}

--- a/tests/builders.rs
+++ b/tests/builders.rs
@@ -2,7 +2,7 @@
 //! `EntityBuilderClone`, the bundle query-satisfaction predicates, the `Ref`
 //! wrappers, and whole-column archetype access.
 //!
-//! The oracles are the drawn spec, the world's own `satisfies` (which must
+//! The oracles are the drawn components, the world's own `satisfies` (which must
 //! agree with the predicates that answer the same question without a world),
 //! and per-entity reads (which must agree with whole-column reads). `D` is
 //! drop-tracked, so a builder that leaks or double-drops what it holds fails
@@ -22,15 +22,15 @@ use hecs::{
 #[hegel::test(settings())]
 fn bundle_satisfaction_agrees_with_world_satisfies(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let s = tc.draw(specs());
+    let cs = tc.draw(components());
     let mut world = World::new();
 
-    let mut builder = make_builder(s);
+    let mut builder = cs.builder();
     let built = builder.build();
-    assert_eq!(built.has::<A>(), s.a.is_some(), "BuiltEntity::has::<A>");
-    assert_eq!(built.has::<B>(), s.b.is_some(), "BuiltEntity::has::<B>");
-    assert_eq!(built.has::<C>(), s.c, "BuiltEntity::has::<C>");
-    assert_eq!(built.has::<D>(), s.d.is_some(), "BuiltEntity::has::<D>");
+    assert_eq!(built.has::<A>(), cs.a.is_some(), "BuiltEntity::has::<A>");
+    assert_eq!(built.has::<B>(), cs.b.is_some(), "BuiltEntity::has::<B>");
+    assert_eq!(built.has::<C>(), cs.c, "BuiltEntity::has::<C>");
+    assert_eq!(built.has::<D>(), cs.d.is_some(), "BuiltEntity::has::<D>");
 
     let predicted = (
         dynamic_bundle_satisfies_query::<_, &A>(&built),
@@ -80,11 +80,11 @@ fn bundle_satisfaction_agrees_with_world_satisfies(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn an_unspawned_bundle_drops_its_components(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let s = tc.draw(specs());
+    let cs = tc.draw(components());
     {
-        let mut builder = make_builder(s);
+        let mut builder = cs.builder();
         let built = builder.build();
-        assert_eq!(built.has::<D>(), s.d.is_some(), "BuiltEntity::has::<D>");
+        assert_eq!(built.has::<D>(), cs.d.is_some(), "BuiltEntity::has::<D>");
     }
     assert_eq!(
         d_live(),
@@ -98,9 +98,9 @@ fn an_unspawned_bundle_drops_its_components(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn clearing_a_builder_drops_its_components(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let s = tc.draw(specs());
+    let cs = tc.draw(components());
     let mut world = World::new();
-    let mut builder = make_builder(s);
+    let mut builder = cs.builder();
     builder.clear();
     assert_eq!(
         builder.component_types().count(),
@@ -120,7 +120,7 @@ fn clearing_a_builder_drops_its_components(tc: hegel::TestCase) {
     let e = world.spawn(builder.build());
     assert_eq!(
         fingerprint(&world).get(&e),
-        Some(&Spec::default()),
+        Some(&Components::default()),
         "a cleared builder spawned components"
     );
 }
@@ -130,12 +130,12 @@ fn clearing_a_builder_drops_its_components(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn builder_edits_through_get_mut_are_spawned(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let s = tc.draw(specs());
+    let cs = tc.draw(components());
     let v = tc.draw(val());
     let mut world = World::new();
-    let mut builder = make_builder(s);
+    let mut builder = cs.builder();
 
-    let mut expected = s;
+    let mut expected = cs;
     if let Some(a) = builder.get_mut::<&mut A>() {
         a.0 = v;
         expected.a = Some(v);
@@ -152,24 +152,24 @@ fn builder_edits_through_get_mut_are_spawned(tc: hegel::TestCase) {
     );
 }
 
-/// Add the `{A, B, C}` part of `s` one component at a time. `D` is not
+/// Add the `{A, B, C}` part of `cs` one component at a time. `D` is not
 /// `Clone`, so it cannot go into an `EntityBuilderClone`.
-fn add_individually(builder: &mut EntityBuilderClone, s: Spec) {
-    if let Some(v) = s.a {
+fn add_individually(builder: &mut EntityBuilderClone, cs: Components) {
+    if let Some(v) = cs.a {
         builder.add(A(v));
     }
-    if let Some(v) = s.b {
+    if let Some(v) = cs.b {
         builder.add(B(v));
     }
-    if s.c {
+    if cs.c {
         builder.add(C);
     }
 }
 
 /// Add the same components with one `add_bundle` of a concrete tuple, which
 /// goes through the tuple `DynamicBundleClone` impls instead.
-fn add_as_tuple(builder: &mut EntityBuilderClone, s: Spec) {
-    match (s.a, s.b, s.c) {
+fn add_as_tuple(builder: &mut EntityBuilderClone, cs: Components) {
+    match (cs.a, cs.b, cs.c) {
         (None, None, false) => builder.add_bundle(()),
         (Some(a), None, false) => builder.add_bundle((A(a),)),
         (None, Some(b), false) => builder.add_bundle((B(b),)),
@@ -181,7 +181,7 @@ fn add_as_tuple(builder: &mut EntityBuilderClone, s: Spec) {
     };
 }
 
-fn observe(world: &World, e: Entity) -> Spec {
+fn observe(world: &World, e: Entity) -> Components {
     *fingerprint(world)
         .get(&e)
         .unwrap_or_else(|| panic!("{e:?} is missing from the world"))
@@ -192,20 +192,20 @@ fn observe(world: &World, e: Entity) -> Spec {
 /// them all across.
 #[hegel::test(settings())]
 fn add_bundle_matches_individual_adds(tc: hegel::TestCase) {
-    let s = tc.draw(specs_without_d());
-    let expected = s;
+    let cs = tc.draw(components_without_d());
+    let expected = cs;
     let mut world = World::new();
 
     let mut individually = EntityBuilderClone::new();
-    add_individually(&mut individually, s);
+    add_individually(&mut individually, cs);
     assert_eq!(
         individually.get::<&A>().map(|r| r.0),
-        s.a,
+        cs.a,
         "EntityBuilderClone::get::<&A>"
     );
     assert_eq!(
         individually.component_types().count(),
-        s.component_count(),
+        cs.component_count(),
         "EntityBuilderClone::component_types"
     );
     let built = individually.build();
@@ -213,7 +213,7 @@ fn add_bundle_matches_individual_adds(tc: hegel::TestCase) {
     assert_eq!(observe(&world, e), expected, "individual adds");
 
     let mut as_tuple = EntityBuilderClone::new();
-    add_as_tuple(&mut as_tuple, s);
+    add_as_tuple(&mut as_tuple, cs);
     let e = world.spawn(&as_tuple.build());
     assert_eq!(
         observe(&world, e),
@@ -235,15 +235,15 @@ fn add_bundle_matches_individual_adds(tc: hegel::TestCase) {
 /// the original still spawns correctly afterwards.
 #[hegel::test(settings())]
 fn a_cloned_builder_spawns_the_same_entity(tc: hegel::TestCase) {
-    let s = tc.draw(specs_without_d());
+    let cs = tc.draw(components_without_d());
     let mut world = World::new();
 
     let mut original = EntityBuilderClone::new();
-    add_individually(&mut original, s);
+    add_individually(&mut original, cs);
     let copy = original.clone();
     assert_eq!(
         copy.has::<A>(),
-        s.a.is_some(),
+        cs.a.is_some(),
         "a clone lost a component type"
     );
 
@@ -251,12 +251,12 @@ fn a_cloned_builder_spawns_the_same_entity(tc: hegel::TestCase) {
     let from_copy = world.spawn(&copy.build());
     assert_eq!(
         observe(&world, from_original),
-        s,
+        cs,
         "the original builder spawned the wrong entity"
     );
     assert_eq!(
         observe(&world, from_copy),
-        s,
+        cs,
         "a cloned builder spawned a different entity"
     );
 }

--- a/tests/change_tracker.rs
+++ b/tests/change_tracker.rs
@@ -1,0 +1,441 @@
+//! Model-based property test for `ChangeTracker`.
+//!
+//! `ChangeTracker<T>` keeps a private `Previous<T>` component holding the value
+//! as of the last `track` call, and `Changes` reports, relative to that:
+//! `added` for entities that have `T` but no snapshot, `changed` for entities
+//! whose current value differs from the snapshot *by `PartialEq`*, and
+//! `removed` for live entities with a snapshot but no `T`. Iterators the caller
+//! does not drain are drained when `Changes` drops, so the snapshot always
+//! advances to the current state.
+//!
+//! The model carries the current payload and the snapshot payload per entity,
+//! which pins the consequences exactly: removing and re-inserting a different
+//! value between polls is a change, not a removal followed by an addition;
+//! re-inserting an equal value is nothing; writing an equal value through
+//! `&mut` is nothing; and an entity that is despawned is never reported as
+//! removed.
+//!
+//! The tracked component counts its own live instances, so between polls the
+//! only live values must be the world's components plus the tracker's
+//! snapshots. That catches a snapshot leaked or dropped twice inside the
+//! tracker.
+
+mod common;
+
+use std::cell::Cell;
+use std::collections::HashMap;
+
+use common::{settings, val};
+use hecs::{ChangeTracker, Changes, Entity, EntityBuilder, World};
+use hegel::generators::{self as gs, Generator};
+use hegel::stateful::{pool, Pool};
+use hegel::TestCase;
+
+const STEPS: i64 = 150;
+
+thread_local! { static LIVE: Cell<i64> = const { Cell::new(0) }; }
+
+/// The tracked component. `Clone` counts too, because that is how the tracker
+/// takes its snapshots.
+#[derive(Debug)]
+struct Tracked(i32);
+
+impl Tracked {
+    fn new(v: i32) -> Tracked {
+        LIVE.with(|c| c.set(c.get() + 1));
+        Tracked(v)
+    }
+}
+
+impl Clone for Tracked {
+    fn clone(&self) -> Tracked {
+        Tracked::new(self.0)
+    }
+}
+
+impl PartialEq for Tracked {
+    fn eq(&self, other: &Tracked) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Drop for Tracked {
+    fn drop(&mut self) {
+        LIVE.with(|c| c.set(c.get() - 1));
+    }
+}
+
+fn live() -> i64 {
+    LIVE.with(|c| c.get())
+}
+
+/// An untracked component, used to force archetype migrations under the
+/// tracker: the private snapshot has to migrate with the entity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Other(i32);
+
+#[derive(Clone, Copy, Debug, Default)]
+struct Model {
+    /// The entity's current `Tracked` payload.
+    current: Option<i32>,
+    /// The payload the tracker snapshotted at the last poll.
+    snapshot: Option<i32>,
+    other: Option<i32>,
+}
+
+struct TrackerModel {
+    world: World,
+    tracker: ChangeTracker<Tracked>,
+    model: HashMap<Entity, Model>,
+    handles: Pool<Entity>,
+}
+
+/// What the next poll must report, derived from the model alone.
+type Expected = (
+    HashMap<Entity, i32>,
+    HashMap<Entity, (i32, i32)>,
+    HashMap<Entity, i32>,
+);
+
+impl TrackerModel {
+    fn expected(&self) -> Expected {
+        let mut added = HashMap::new();
+        let mut changed = HashMap::new();
+        let mut removed = HashMap::new();
+        for (&e, m) in &self.model {
+            match (m.current, m.snapshot) {
+                (Some(v), None) => {
+                    added.insert(e, v);
+                }
+                (Some(new), Some(old)) if new != old => {
+                    changed.insert(e, (old, new));
+                }
+                (None, Some(old)) => {
+                    removed.insert(e, old);
+                }
+                _ => {}
+            }
+        }
+        (added, changed, removed)
+    }
+
+    fn draw_handle(&self, tc: &TestCase) -> Entity {
+        *tc.draw(self.handles.values_reusable().print_as_debug())
+    }
+}
+
+fn check_added(changes: &mut Changes<'_, Tracked>, want: &HashMap<Entity, i32>) {
+    let it = changes.added();
+    assert_eq!(it.len(), want.len(), "added().len()");
+    let mut got = HashMap::new();
+    for (e, t) in it {
+        assert!(got.insert(e, t.0).is_none(), "added() yielded {e:?} twice");
+    }
+    assert_eq!(got, *want, "added()");
+}
+
+fn check_changed(changes: &mut Changes<'_, Tracked>, want: &HashMap<Entity, (i32, i32)>) {
+    let mut got = HashMap::new();
+    for (e, old, new) in changes.changed() {
+        assert!(
+            got.insert(e, (old.0, new.0)).is_none(),
+            "changed() yielded {e:?} twice"
+        );
+    }
+    assert_eq!(got, *want, "changed()");
+}
+
+fn check_removed(changes: &mut Changes<'_, Tracked>, want: &HashMap<Entity, i32>) {
+    let it = changes.removed();
+    assert_eq!(it.len(), want.len(), "removed().len()");
+    let mut got = HashMap::new();
+    for (e, old) in it {
+        assert!(
+            got.insert(e, old.0).is_none(),
+            "removed() yielded {e:?} twice"
+        );
+    }
+    assert_eq!(got, *want, "removed()");
+}
+
+#[hegel::state_machine]
+impl TrackerModel {
+    #[rule]
+    fn spawn(&mut self, tc: TestCase) {
+        let tracked = tc.draw(gs::optional(val()));
+        let other = tc.draw(gs::optional(val()));
+        let mut builder = EntityBuilder::new();
+        if let Some(v) = tracked {
+            builder.add(Tracked::new(v));
+        }
+        if let Some(v) = other {
+            builder.add(Other(v));
+        }
+        let e = self.world.spawn(builder.build());
+        self.model.insert(
+            e,
+            Model {
+                current: tracked,
+                snapshot: None,
+                other,
+            },
+        );
+        self.handles.add(e);
+    }
+
+    /// A homogeneous batch, so `spawn_batch` also feeds the tracker.
+    #[rule]
+    fn spawn_batch(&mut self, tc: TestCase) {
+        let n = tc.draw(gs::integers::<u32>().min_value(0).max_value(4));
+        let v = tc.draw(val());
+        let handles: Vec<Entity> = self
+            .world
+            .spawn_batch((0..n).map(|_| (Tracked::new(v), Other(v))))
+            .collect();
+        for e in handles {
+            self.model.insert(
+                e,
+                Model {
+                    current: Some(v),
+                    snapshot: None,
+                    other: Some(v),
+                },
+            );
+            self.handles.add(e);
+        }
+    }
+
+    /// Despawning drops both the component and its snapshot, and the entity
+    /// must never be reported as removed.
+    #[rule]
+    fn despawn(&mut self, tc: TestCase) {
+        let e = self.draw_handle(&tc);
+        let ok = self.world.despawn(e).is_ok();
+        assert_eq!(
+            ok,
+            self.model.remove(&e).is_some(),
+            "despawn disagreed for {e:?}"
+        );
+    }
+
+    #[rule]
+    fn insert_tracked(&mut self, tc: TestCase) {
+        let e = self.draw_handle(&tc);
+        let v = tc.draw(val());
+        let live_entity = self.model.contains_key(&e);
+        let ok = self.world.insert_one(e, Tracked::new(v)).is_ok();
+        assert_eq!(ok, live_entity, "insert of Tracked disagreed for {e:?}");
+        if let Some(m) = self.model.get_mut(&e) {
+            m.current = Some(v);
+        }
+    }
+
+    #[rule]
+    fn remove_tracked(&mut self, tc: TestCase) {
+        let e = self.draw_handle(&tc);
+        let had = self.model.get(&e).is_some_and(|m| m.current.is_some());
+        assert_eq!(
+            self.world.remove_one::<Tracked>(e).is_ok(),
+            had,
+            "remove of Tracked {e:?}"
+        );
+        if let Some(m) = self.model.get_mut(&e) {
+            m.current = None;
+        }
+    }
+
+    #[rule]
+    fn write_through_unique_reference(&mut self, tc: TestCase) {
+        let e = self.draw_handle(&tc);
+        let v = tc.draw(val());
+        let had = self.model.get(&e).is_some_and(|m| m.current.is_some());
+        match self.world.get::<&mut Tracked>(e) {
+            Ok(mut t) => {
+                assert!(
+                    had,
+                    "&mut Tracked succeeded for {e:?} but the model has none"
+                );
+                t.0 = v;
+            }
+            Err(_) => assert!(!had, "&mut Tracked failed for {e:?} but the model has one"),
+        }
+        if had {
+            self.model.get_mut(&e).unwrap().current = Some(v);
+        }
+    }
+
+    /// Writing the value it already holds must not count as a change: the
+    /// tracker compares by `PartialEq`, not by whether `&mut` was taken.
+    #[rule]
+    fn write_the_same_value(&mut self, tc: TestCase) {
+        let e = self.draw_handle(&tc);
+        if let Some(v) = self.model.get(&e).and_then(|m| m.current) {
+            self.world
+                .get::<&mut Tracked>(e)
+                .expect("the model says Tracked is present")
+                .0 = v;
+        }
+    }
+
+    #[rule]
+    fn insert_other(&mut self, tc: TestCase) {
+        let e = self.draw_handle(&tc);
+        let v = tc.draw(val());
+        let live_entity = self.model.contains_key(&e);
+        assert_eq!(
+            self.world.insert_one(e, Other(v)).is_ok(),
+            live_entity,
+            "insert Other {e:?}"
+        );
+        if let Some(m) = self.model.get_mut(&e) {
+            m.other = Some(v);
+        }
+    }
+
+    #[rule]
+    fn remove_other(&mut self, tc: TestCase) {
+        let e = self.draw_handle(&tc);
+        let had = self.model.get(&e).is_some_and(|m| m.other.is_some());
+        assert_eq!(
+            self.world.remove_one::<Other>(e).is_ok(),
+            had,
+            "remove Other {e:?}"
+        );
+        if let Some(m) = self.model.get_mut(&e) {
+            m.other = None;
+        }
+    }
+
+    /// `clear` drops the snapshots along with everything else, so whatever is
+    /// spawned next is reported as added.
+    #[rule]
+    fn clear(&mut self, _: TestCase) {
+        self.world.clear();
+        self.model.clear();
+    }
+
+    /// Poll the tracker and check its three reports against the model, then
+    /// advance the model's snapshots.
+    ///
+    /// The drawn mode picks one of the six orders the iterators can be called
+    /// in, or leaves `added` half-consumed, or drops `Changes` without touching
+    /// anything — the snapshot must advance regardless, which the next poll and
+    /// the live-count invariant check.
+    #[rule]
+    fn poll(&mut self, tc: TestCase) {
+        let (added, changed, removed) = self.expected();
+        let mode = tc.draw(gs::integers::<u8>().min_value(0).max_value(7));
+        {
+            let mut changes = self.tracker.track(&mut self.world);
+            match mode {
+                0 => {
+                    check_added(&mut changes, &added);
+                    check_changed(&mut changes, &changed);
+                    check_removed(&mut changes, &removed);
+                }
+                1 => {
+                    check_added(&mut changes, &added);
+                    check_removed(&mut changes, &removed);
+                    check_changed(&mut changes, &changed);
+                }
+                2 => {
+                    check_changed(&mut changes, &changed);
+                    check_added(&mut changes, &added);
+                    check_removed(&mut changes, &removed);
+                }
+                3 => {
+                    check_changed(&mut changes, &changed);
+                    check_removed(&mut changes, &removed);
+                    check_added(&mut changes, &added);
+                }
+                4 => {
+                    check_removed(&mut changes, &removed);
+                    check_added(&mut changes, &added);
+                    check_changed(&mut changes, &changed);
+                }
+                5 => {
+                    check_removed(&mut changes, &removed);
+                    check_changed(&mut changes, &changed);
+                    check_added(&mut changes, &added);
+                }
+                6 => {
+                    {
+                        let mut it = changes.added();
+                        assert_eq!(it.len(), added.len(), "added().len()");
+                        if let Some((e, t)) = it.next() {
+                            assert_eq!(added.get(&e), Some(&t.0), "first element of added()");
+                        }
+                    }
+                    check_changed(&mut changes, &changed);
+                    check_removed(&mut changes, &removed);
+                }
+                _ => {}
+            }
+        }
+        for m in self.model.values_mut() {
+            m.snapshot = m.current;
+        }
+    }
+
+    #[invariant]
+    fn world_matches_model(&self, _: TestCase) {
+        assert_eq!(
+            self.world.len() as usize,
+            self.model.len(),
+            "world.len() != model.len()"
+        );
+        for (&e, m) in &self.model {
+            assert!(self.world.contains(e), "world is missing modelled {e:?}");
+            assert_eq!(
+                self.world.get::<&Tracked>(e).ok().map(|t| t.0),
+                m.current,
+                "Tracked on {e:?}"
+            );
+            assert_eq!(
+                self.world.get::<&Other>(e).ok().map(|o| o.0),
+                m.other,
+                "Other on {e:?}"
+            );
+        }
+        for eref in self.world.iter() {
+            assert!(
+                self.model.contains_key(&eref.entity()),
+                "world has unmodelled {:?}",
+                eref.entity()
+            );
+        }
+    }
+
+    /// Live tracked values are exactly the world's components plus the
+    /// tracker's snapshots.
+    #[invariant]
+    fn tracked_values_are_accounted_for(&self, _: TestCase) {
+        let current = self.model.values().filter(|m| m.current.is_some()).count();
+        let snapshots = self.model.values().filter(|m| m.snapshot.is_some()).count();
+        assert_eq!(
+            live(),
+            (current + snapshots) as i64,
+            "live Tracked count != current components + snapshots"
+        );
+    }
+}
+
+// Not run under Miri: `ChangeTracker` contains no unsafe code — it is built
+// on `PreparedQuery`, `insert_one` and `remove_one` — so the interpreter has
+// nothing here that the `World` and query properties do not already cover, and
+// polling the tracker is by far the slowest thing in the suite under it.
+#[cfg_attr(
+    miri,
+    ignore = "no unsafe code to check, and slow under the interpreter"
+)]
+#[hegel::test(settings().stateful_step_count(STEPS))]
+fn change_tracker_matches_model(tc: TestCase) {
+    assert_eq!(live(), 0, "live Tracked count nonzero at case start");
+    let machine = TrackerModel {
+        world: World::new(),
+        tracker: ChangeTracker::new(),
+        model: HashMap::new(),
+        handles: pool(&tc),
+    };
+    hegel::stateful::run(machine, tc);
+}

--- a/tests/change_tracker.rs
+++ b/tests/change_tracker.rs
@@ -345,10 +345,10 @@ impl TrackerModel {
     /// Poll the tracker, check the reports the caller pulls against the
     /// model, and advance the model's snapshots.
     ///
-    /// `pulled` is which reports the caller asks for and in what order; the
-    /// rest are left to `Changes::drop`, which must drain them so that the
-    /// snapshot advances regardless. The next poll and the live-count
-    /// invariant check that it did.
+    /// `pulled` is which reports the caller asks for, in what order. The rest
+    /// are left to `Changes::drop`, which must drain them so that the snapshot
+    /// advances regardless. The next poll and the live-count invariant check
+    /// that it did.
     #[rule]
     fn poll(&mut self, tc: TestCase) {
         let expected = self.expected();

--- a/tests/change_tracker.rs
+++ b/tests/change_tracker.rs
@@ -20,12 +20,10 @@
 //! snapshots. That catches a snapshot leaked or dropped twice inside the
 //! tracker.
 
-mod common;
-
 use std::cell::Cell;
 use std::collections::HashMap;
 
-use common::{settings, val};
+use fixtures::{settings, val};
 use hecs::{ChangeTracker, Changes, Entity, EntityBuilder, World};
 use hegel::generators::{self as gs, Generator};
 use hegel::stateful::{pool, Pool};

--- a/tests/change_tracker.rs
+++ b/tests/change_tracker.rs
@@ -159,10 +159,7 @@ fn check_removed(changes: &mut Changes<'_, Tracked>, want: &HashMap<Entity, i32>
     assert_eq!(got, *want, "removed()");
 }
 
-// Each case applies up to `STEPS` rules, chosen at random, to the machine
-// built in `change_tracker_matches_model` below. Invariants run in full on the
-// initial and final state and, after each step, each with probability
-// `1 / STEPS`.
+// Driven by `change_tracker_matches_model` below.
 #[hegel::state_machine]
 impl TrackerModel {
     #[rule]

--- a/tests/change_tracker.rs
+++ b/tests/change_tracker.rs
@@ -77,32 +77,44 @@ struct TrackerModel {
 }
 
 /// What the next poll must report, derived from the model alone.
-type Expected = (
-    HashMap<Entity, i32>,
-    HashMap<Entity, (i32, i32)>,
-    HashMap<Entity, i32>,
-);
+struct Expected {
+    added: HashMap<Entity, i32>,
+    changed: HashMap<Entity, (i32, i32)>,
+    removed: HashMap<Entity, i32>,
+}
+
+/// One of the three reports `Changes` offers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, hegel::PrettyPrintable)]
+enum Report {
+    Added,
+    Changed,
+    Removed,
+}
+
+const REPORTS: [Report; 3] = [Report::Added, Report::Changed, Report::Removed];
 
 impl TrackerModel {
     fn expected(&self) -> Expected {
-        let mut added = HashMap::new();
-        let mut changed = HashMap::new();
-        let mut removed = HashMap::new();
+        let mut expected = Expected {
+            added: HashMap::new(),
+            changed: HashMap::new(),
+            removed: HashMap::new(),
+        };
         for (&e, m) in &self.model {
             match (m.current, m.snapshot) {
                 (Some(v), None) => {
-                    added.insert(e, v);
+                    expected.added.insert(e, v);
                 }
                 (Some(new), Some(old)) if new != old => {
-                    changed.insert(e, (old, new));
+                    expected.changed.insert(e, (old, new));
                 }
                 (None, Some(old)) => {
-                    removed.insert(e, old);
+                    expected.removed.insert(e, old);
                 }
                 _ => {}
             }
         }
-        (added, changed, removed)
+        expected
     }
 
     fn draw_handle(&self, tc: &TestCase) -> Entity {
@@ -133,6 +145,15 @@ fn check_added(changes: &mut Changes<'_, Tracked>, want: &HashMap<Entity, i32>) 
         );
     }
     assert_eq!(got, *want, "added()");
+}
+
+/// Pull one element of `added()` and leave the rest to `Changes::drop`.
+fn peek_added(changes: &mut Changes<'_, Tracked>, want: &HashMap<Entity, i32>) {
+    let mut it = changes.added();
+    assert_eq!(it.len(), want.len(), "added().len()");
+    if let Some((e, t)) = it.next() {
+        assert_eq!(want.get(&e), Some(&t.value), "first element of added()");
+    }
 }
 
 fn check_changed(changes: &mut Changes<'_, Tracked>, want: &HashMap<Entity, (i32, i32)>) {
@@ -321,64 +342,31 @@ impl TrackerModel {
         self.model.clear();
     }
 
-    /// Poll the tracker and check its three reports against the model, then
-    /// advance the model's snapshots.
+    /// Poll the tracker, check the reports the caller pulls against the
+    /// model, and advance the model's snapshots.
     ///
-    /// The drawn mode picks one of the six orders the iterators can be called
-    /// in, or leaves `added` half-consumed, or drops `Changes` without touching
-    /// anything — the snapshot must advance regardless, which the next poll and
-    /// the live-count invariant check.
+    /// `pulled` is which reports the caller asks for and in what order; the
+    /// rest are left to `Changes::drop`, which must drain them so that the
+    /// snapshot advances regardless. The next poll and the live-count
+    /// invariant check that it did.
     #[rule]
     fn poll(&mut self, tc: TestCase) {
-        let (added, changed, removed) = self.expected();
-        let mode = tc.draw(gs::integers::<u8>().min_value(0).max_value(7));
-        {
-            let mut changes = self.tracker.track(&mut self.world);
-            match mode {
-                0 => {
-                    check_added(&mut changes, &added);
-                    check_changed(&mut changes, &changed);
-                    check_removed(&mut changes, &removed);
-                }
-                1 => {
-                    check_added(&mut changes, &added);
-                    check_removed(&mut changes, &removed);
-                    check_changed(&mut changes, &changed);
-                }
-                2 => {
-                    check_changed(&mut changes, &changed);
-                    check_added(&mut changes, &added);
-                    check_removed(&mut changes, &removed);
-                }
-                3 => {
-                    check_changed(&mut changes, &changed);
-                    check_removed(&mut changes, &removed);
-                    check_added(&mut changes, &added);
-                }
-                4 => {
-                    check_removed(&mut changes, &removed);
-                    check_added(&mut changes, &added);
-                    check_changed(&mut changes, &changed);
-                }
-                5 => {
-                    check_removed(&mut changes, &removed);
-                    check_changed(&mut changes, &changed);
-                    check_added(&mut changes, &added);
-                }
-                6 => {
-                    {
-                        let mut it = changes.added();
-                        assert_eq!(it.len(), added.len(), "added().len()");
-                        if let Some((e, t)) = it.next() {
-                            assert_eq!(added.get(&e), Some(&t.value), "first element of added()");
-                        }
-                    }
-                    check_changed(&mut changes, &changed);
-                    check_removed(&mut changes, &removed);
-                }
-                _ => {}
+        let expected = self.expected();
+        let pulled = tc.draw(gs::samples(&REPORTS[..]).without_replacement());
+        let peek_added_only = tc.draw(gs::booleans());
+        tc.note(&format!(
+            "poll: pulled {pulled:?}, peek_added_only = {peek_added_only}"
+        ));
+        let mut changes = self.tracker.track(&mut self.world);
+        for report in pulled {
+            match report {
+                Report::Added if peek_added_only => peek_added(&mut changes, &expected.added),
+                Report::Added => check_added(&mut changes, &expected.added),
+                Report::Changed => check_changed(&mut changes, &expected.changed),
+                Report::Removed => check_removed(&mut changes, &expected.removed),
             }
         }
+        drop(changes);
         for m in self.model.values_mut() {
             m.snapshot = m.current;
         }

--- a/tests/change_tracker.rs
+++ b/tests/change_tracker.rs
@@ -20,8 +20,9 @@
 //! snapshots. That catches a snapshot leaked or dropped twice inside the
 //! tracker.
 
-use std::cell::Cell;
 use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
 
 use fixtures::{settings, val};
 use hecs::{ChangeTracker, Changes, Entity, EntityBuilder, World};
@@ -31,40 +32,25 @@ use hegel::TestCase;
 
 const STEPS: i64 = 150;
 
-thread_local! { static LIVE: Cell<i64> = const { Cell::new(0) }; }
-
-/// The tracked component. `Clone` counts too, because that is how the tracker
-/// takes its snapshots.
-#[derive(Debug)]
-struct Tracked(i32);
-
-impl Tracked {
-    fn new(v: i32) -> Tracked {
-        LIVE.with(|c| c.set(c.get() + 1));
-        Tracked(v)
-    }
+/// The tracked component. Every `Tracked` holds a clone of one `Arc`, so the
+/// strong count minus the test's own handle is how many are alive. `Clone`
+/// counts too, because that is how the tracker takes its snapshots.
+#[derive(Clone)]
+struct Tracked {
+    value: i32,
+    _live: Arc<()>,
 }
 
-impl Clone for Tracked {
-    fn clone(&self) -> Tracked {
-        Tracked::new(self.0)
+impl fmt::Debug for Tracked {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Tracked").field(&self.value).finish()
     }
 }
 
 impl PartialEq for Tracked {
     fn eq(&self, other: &Tracked) -> bool {
-        self.0 == other.0
+        self.value == other.value
     }
-}
-
-impl Drop for Tracked {
-    fn drop(&mut self) {
-        LIVE.with(|c| c.set(c.get() - 1));
-    }
-}
-
-fn live() -> i64 {
-    LIVE.with(|c| c.get())
 }
 
 /// An untracked component, used to force archetype migrations under the
@@ -86,6 +72,8 @@ struct TrackerModel {
     tracker: ChangeTracker<Tracked>,
     model: HashMap<Entity, Model>,
     handles: Pool<Entity>,
+    /// The handle every `Tracked` is cloned from.
+    live: Arc<()>,
 }
 
 /// What the next poll must report, derived from the model alone.
@@ -120,6 +108,18 @@ impl TrackerModel {
     fn draw_handle(&self, tc: &TestCase) -> Entity {
         *tc.draw(self.handles.values_reusable().print_as_debug())
     }
+
+    fn tracked(&self, value: i32) -> Tracked {
+        Tracked {
+            value,
+            _live: self.live.clone(),
+        }
+    }
+
+    /// How many `Tracked` values are alive, snapshots included.
+    fn live(&self) -> usize {
+        Arc::strong_count(&self.live) - 1
+    }
 }
 
 fn check_added(changes: &mut Changes<'_, Tracked>, want: &HashMap<Entity, i32>) {
@@ -127,7 +127,10 @@ fn check_added(changes: &mut Changes<'_, Tracked>, want: &HashMap<Entity, i32>) 
     assert_eq!(it.len(), want.len(), "added().len()");
     let mut got = HashMap::new();
     for (e, t) in it {
-        assert!(got.insert(e, t.0).is_none(), "added() yielded {e:?} twice");
+        assert!(
+            got.insert(e, t.value).is_none(),
+            "added() yielded {e:?} twice"
+        );
     }
     assert_eq!(got, *want, "added()");
 }
@@ -136,7 +139,7 @@ fn check_changed(changes: &mut Changes<'_, Tracked>, want: &HashMap<Entity, (i32
     let mut got = HashMap::new();
     for (e, old, new) in changes.changed() {
         assert!(
-            got.insert(e, (old.0, new.0)).is_none(),
+            got.insert(e, (old.value, new.value)).is_none(),
             "changed() yielded {e:?} twice"
         );
     }
@@ -149,7 +152,7 @@ fn check_removed(changes: &mut Changes<'_, Tracked>, want: &HashMap<Entity, i32>
     let mut got = HashMap::new();
     for (e, old) in it {
         assert!(
-            got.insert(e, old.0).is_none(),
+            got.insert(e, old.value).is_none(),
             "removed() yielded {e:?} twice"
         );
     }
@@ -168,7 +171,7 @@ impl TrackerModel {
         let other = tc.draw(gs::optional(val()));
         let mut builder = EntityBuilder::new();
         if let Some(v) = tracked {
-            builder.add(Tracked::new(v));
+            builder.add(self.tracked(v));
         }
         if let Some(v) = other {
             builder.add(Other(v));
@@ -190,9 +193,14 @@ impl TrackerModel {
     fn spawn_batch(&mut self, tc: TestCase) {
         let n = tc.draw(gs::integers::<u32>().min_value(0).max_value(4));
         let v = tc.draw(val());
+        let live = &self.live;
+        let tracked = || Tracked {
+            value: v,
+            _live: live.clone(),
+        };
         let handles: Vec<Entity> = self
             .world
-            .spawn_batch((0..n).map(|_| (Tracked::new(v), Other(v))))
+            .spawn_batch((0..n).map(|_| (tracked(), Other(v))))
             .collect();
         for e in handles {
             self.model.insert(
@@ -225,7 +233,7 @@ impl TrackerModel {
         let e = self.draw_handle(&tc);
         let v = tc.draw(val());
         let live_entity = self.model.contains_key(&e);
-        let ok = self.world.insert_one(e, Tracked::new(v)).is_ok();
+        let ok = self.world.insert_one(e, self.tracked(v)).is_ok();
         assert_eq!(ok, live_entity, "insert of Tracked disagreed for {e:?}");
         if let Some(m) = self.model.get_mut(&e) {
             m.current = Some(v);
@@ -257,7 +265,7 @@ impl TrackerModel {
                     had,
                     "&mut Tracked succeeded for {e:?} but the model has none"
                 );
-                t.0 = v;
+                t.value = v;
             }
             Err(_) => assert!(!had, "&mut Tracked failed for {e:?} but the model has one"),
         }
@@ -275,7 +283,7 @@ impl TrackerModel {
             self.world
                 .get::<&mut Tracked>(e)
                 .expect("the model says Tracked is present")
-                .0 = v;
+                .value = v;
         }
     }
 
@@ -365,7 +373,7 @@ impl TrackerModel {
                         let mut it = changes.added();
                         assert_eq!(it.len(), added.len(), "added().len()");
                         if let Some((e, t)) = it.next() {
-                            assert_eq!(added.get(&e), Some(&t.0), "first element of added()");
+                            assert_eq!(added.get(&e), Some(&t.value), "first element of added()");
                         }
                     }
                     check_changed(&mut changes, &changed);
@@ -389,7 +397,7 @@ impl TrackerModel {
         for (&e, m) in &self.model {
             assert!(self.world.contains(e), "world is missing modelled {e:?}");
             assert_eq!(
-                self.world.get::<&Tracked>(e).ok().map(|t| t.0),
+                self.world.get::<&Tracked>(e).ok().map(|t| t.value),
                 m.current,
                 "Tracked on {e:?}"
             );
@@ -415,8 +423,8 @@ impl TrackerModel {
         let current = self.model.values().filter(|m| m.current.is_some()).count();
         let snapshots = self.model.values().filter(|m| m.snapshot.is_some()).count();
         assert_eq!(
-            live(),
-            (current + snapshots) as i64,
+            self.live(),
+            current + snapshots,
             "live Tracked count != current components + snapshots"
         );
     }
@@ -432,12 +440,12 @@ impl TrackerModel {
 )]
 #[hegel::test(settings().stateful_step_count(STEPS))]
 fn change_tracker_matches_model(tc: TestCase) {
-    assert_eq!(live(), 0, "live Tracked count nonzero at case start");
     let machine = TrackerModel {
         world: World::new(),
         tracker: ChangeTracker::new(),
         model: HashMap::new(),
         handles: pool(&tc),
+        live: Arc::new(()),
     };
     hegel::stateful::run(machine, tc);
 }

--- a/tests/change_tracker.rs
+++ b/tests/change_tracker.rs
@@ -158,6 +158,10 @@ fn check_removed(changes: &mut Changes<'_, Tracked>, want: &HashMap<Entity, i32>
     assert_eq!(got, *want, "removed()");
 }
 
+// Each case applies up to `STEPS` rules, chosen at random, to the machine
+// built in `change_tracker_matches_model` below. Invariants run in full on the
+// initial and final state and, after each step, each with probability
+// `1 / STEPS`.
 #[hegel::state_machine]
 impl TrackerModel {
     #[rule]

--- a/tests/column_batch.rs
+++ b/tests/column_batch.rs
@@ -123,11 +123,6 @@ fn column_batch_matches_individual_spawns(tc: hegel::TestCase) {
     }
 }
 
-/// How many `D` components a world holds.
-fn d_in(world: &World) -> i64 {
-    world.query::<&D>().iter().count() as i64
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq, hegel::PrettyPrintable)]
 enum Kind {
     /// Live, with components the batch does not supply; they must not survive.

--- a/tests/column_batch.rs
+++ b/tests/column_batch.rs
@@ -83,13 +83,12 @@ fn column_batch_matches_individual_spawns(tc: hegel::TestCase) {
 
     // Two successive batches, so the second one merges into the archetype the
     // first one created.
-    let batches = tc.draw(gs::integers::<u8>().min_value(1).max_value(2));
-    for _ in 0..batches {
-        let rows = tc.draw(rows_up_to(12));
+    let batches: Vec<Vec<Row>> = tc.draw(gs::vecs(rows_up_to(12)).min_size(1).max_size(2));
+    for rows in &batches {
         let len_before = batched.len();
         let mut seen: HashSet<Entity> = batched.iter().map(|eref| eref.entity()).collect();
 
-        let iter = batched.spawn_column_batch(build_batch(&rows, &ds));
+        let iter = batched.spawn_column_batch(build_batch(rows, &ds));
         assert_eq!(iter.len(), rows.len(), "SpawnColumnBatchIter::len");
         let handles: Vec<Entity> = iter.collect();
         assert_eq!(
@@ -103,14 +102,14 @@ fn column_batch_matches_individual_spawns(tc: hegel::TestCase) {
             "world.len() after spawn_column_batch"
         );
 
-        for (i, (&e, &(a, d))) in handles.iter().zip(&rows).enumerate() {
+        for (i, (&e, &(a, d))) in handles.iter().zip(rows).enumerate() {
             assert!(seen.insert(e), "row {i} reused handle {e:?}");
             assert!(batched.contains(e), "row {i} handle {e:?} is not contained");
             assert_eq!(batched.get::<&A>(e).unwrap().0, a, "A of row {i}");
             assert_eq!(batched.get::<&D>(e).unwrap().value, d, "D of row {i}");
         }
 
-        for &(a, d) in &rows {
+        for &(a, d) in rows {
             individually.spawn((A(a), D::new(d, &ds)));
         }
         assert_eq!(

--- a/tests/column_batch.rs
+++ b/tests/column_batch.rs
@@ -24,6 +24,19 @@ fn rows_up_to(max: usize) -> impl gs::PrintableGenerator<Vec<Row>> {
     gs::vecs(row()).max_size(max)
 }
 
+/// Push `rows` into a builder whose type declares `A` and `D`.
+fn fill_batch(builder: &ColumnBatchBuilder, rows: &[Row], ds: &DropTracker) {
+    let mut writer = builder.writer::<A>().expect("A is in the batch type");
+    for &(a, _) in rows {
+        writer.push(A(a)).expect("push within capacity");
+    }
+    drop(writer);
+    let mut writer = builder.writer::<D>().expect("D is in the batch type");
+    for &(_, d) in rows {
+        writer.push(D::new(d, ds)).expect("push within capacity");
+    }
+}
+
 /// Build a complete `{A, D}` batch from `rows`, exercising the writer surface
 /// on the way: `writer` for a type outside the batch, `fill`, and a push past
 /// capacity.
@@ -37,11 +50,9 @@ fn build_batch(rows: &[Row], ds: &DropTracker) -> ColumnBatch {
         builder.writer::<B>().is_none(),
         "writer::<B> exists but B is not in the batch type"
     );
+    fill_batch(&builder, rows, ds);
     {
         let mut writer = builder.writer::<A>().expect("A is in the batch type");
-        for &(a, _) in rows {
-            writer.push(A(a)).expect("push within capacity");
-        }
         assert_eq!(writer.fill(), rows.len() as u32, "A column fill");
         assert_eq!(
             writer.push(A(0)),
@@ -49,13 +60,14 @@ fn build_batch(rows: &[Row], ds: &DropTracker) -> ColumnBatch {
             "a push past capacity must return the value"
         );
     }
-    {
-        let mut writer = builder.writer::<D>().expect("D is in the batch type");
-        for &(_, d) in rows {
-            writer.push(D::new(d, ds)).expect("push within capacity");
-        }
-        assert_eq!(writer.fill(), rows.len() as u32, "D column fill");
-    }
+    assert_eq!(
+        builder
+            .writer::<D>()
+            .expect("D is in the batch type")
+            .fill(),
+        rows.len() as u32,
+        "D column fill"
+    );
     builder.build().expect("a fully filled batch must build")
 }
 
@@ -248,32 +260,26 @@ fn the_ways_of_declaring_a_batch_type_agree(tc: hegel::TestCase) {
     as_bundle.add_bundle::<(A, D)>();
 
     let mut worlds = Vec::new();
-    for types in [individually, dynamically, as_bundle] {
+    for (name, types) in [
+        ("add", individually),
+        ("add_dynamic", dynamically),
+        ("add_bundle", as_bundle),
+    ] {
         let mut world = World::new();
         // `ColumnBatchBuilder::new` is the non-consuming spelling of
         // `into_batch`.
         let builder = ColumnBatchBuilder::new(types, rows.len() as u32);
-        {
-            let mut writer = builder.writer::<A>().expect("A was declared");
-            for &(a, _) in &rows {
-                writer.push(A(a)).expect("push within capacity");
-            }
-        }
-        {
-            let mut writer = builder.writer::<D>().expect("D was declared");
-            for &(_, d) in &rows {
-                writer.push(D::new(d, &ds)).expect("push within capacity");
-            }
-        }
+        fill_batch(&builder, &rows, &ds);
         world.spawn_column_batch(builder.build().expect("a filled batch must build"));
-        worlds.push(world);
+        worlds.push((name, world));
     }
-    let expected = fingerprint(&worlds[0]);
-    for (i, world) in worlds.iter().enumerate().skip(1) {
+    let (_, first) = &worlds[0];
+    let expected = fingerprint(first);
+    for (name, world) in &worlds[1..] {
         assert_eq!(
             expected,
             fingerprint(world),
-            "batch type {i} produced different entities"
+            "the batch type declared with {name} produced different entities"
         );
     }
 }

--- a/tests/column_batch.rs
+++ b/tests/column_batch.rs
@@ -317,17 +317,17 @@ fn the_ways_of_declaring_a_batch_type_agree(tc: hegel::TestCase) {
     }
 }
 
-/// A builder with an underfilled column refuses to build. All the components
-/// here are `Copy`, so this checks only the `Err` half of the contract; the
-/// drop half is `a_refused_build_drops_the_written_components` below.
+/// A builder with an underfilled column refuses to build, and the values
+/// already written into it are dropped.
 #[hegel::test(settings())]
 fn an_underfilled_batch_is_refused(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
     let capacity = tc.draw(gs::integers::<u32>().min_value(1).max_value(8));
     let written = tc.draw(gs::integers::<u32>().min_value(0).max_value(capacity - 1));
 
     let mut types = ColumnBatchType::new();
     types.add::<A>();
-    types.add::<B>();
+    types.add::<D>();
     let builder = types.into_batch(capacity);
     {
         let mut writer = builder.writer::<A>().expect("A is in the batch type");
@@ -336,11 +336,16 @@ fn an_underfilled_batch_is_refused(tc: hegel::TestCase) {
         }
     }
     {
-        let mut writer = builder.writer::<B>().expect("B is in the batch type");
+        let mut writer = builder.writer::<D>().expect("D is in the batch type");
         for _ in 0..written {
-            writer.push(B(0)).expect("push within capacity");
+            writer.push(D::new(0)).expect("push within capacity");
         }
     }
+    assert_eq!(
+        d_live(),
+        written as i64,
+        "the builder is not holding what was written"
+    );
     let Err(error) = builder.build() else {
         panic!("build accepted an underfilled column");
     };
@@ -348,6 +353,7 @@ fn an_underfilled_batch_is_refused(tc: hegel::TestCase) {
         !error.to_string().is_empty(),
         "BatchIncomplete has no message"
     );
+    assert_eq!(d_live(), 0, "a refused build leaked the written components");
 }
 
 /// Dropping a `ColumnBatchBuilder` without building drops whatever was written
@@ -385,16 +391,10 @@ fn dropping_an_unbuilt_batch_drops_its_components(tc: hegel::TestCase) {
     );
 }
 
-/// A builder with an underfilled column must refuse to build, and the values
-/// already written into it must still be dropped.
-///
-/// `build` moves the archetype out with its length still zero and only then
-/// checks completeness, so the components written so far are leaked. The `Err`
-/// half of the contract holds; the drop half does not. Reproduces on hecs
-/// 0.11.1 — the same defect as issue #450, on the path its fix did not cover
-/// (issue #459).
+/// `build` used to move the archetype out before checking completeness, so a
+/// refused build leaked the components written so far. Reproduces on hecs
+/// 0.11.1 (issue #459).
 #[test]
-#[ignore = "hecs#459: ColumnBatchBuilder::build() -> Err leaks the written components"]
 fn a_refused_build_drops_the_written_components() {
     assert_d_balanced_at_start();
     let mut types = ColumnBatchType::new();

--- a/tests/column_batch.rs
+++ b/tests/column_batch.rs
@@ -18,9 +18,8 @@ use hegel::generators as gs;
 /// One entity's worth of batch data: payloads for its `A` and `D` columns.
 type Row = (i32, i32);
 
-fn draw_rows(tc: &hegel::TestCase, max: usize) -> Vec<Row> {
-    let n = tc.draw(gs::integers::<usize>().min_value(0).max_value(max));
-    (0..n).map(|_| (tc.draw(val()), tc.draw(val()))).collect()
+fn rows_up_to(max: usize) -> impl gs::PrintableGenerator<Vec<Row>> {
+    gs::vecs(hegel::tuples!(val(), val())).max_size(max)
 }
 
 /// Build a complete `{A, D}` batch from `rows`, exercising the writer surface
@@ -75,32 +74,16 @@ fn multiset(world: &World) -> Vec<Spec> {
 #[hegel::test(settings())]
 fn column_batch_matches_individual_spawns(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let mut batched = World::new();
-    let mut individually = World::new();
-
-    let seeded = tc.draw(gs::integers::<u32>().min_value(0).max_value(6));
-    let mut seed_handles = Vec::new();
-    for _ in 0..seeded {
-        let s = tc.draw(specs());
-        let e = batched.spawn(make_builder(s).build());
-        assert_eq!(
-            e,
-            individually.spawn(make_builder(s).build()),
-            "seeding diverged"
-        );
-        seed_handles.push(e);
-    }
-    for &e in &seed_handles {
-        if tc.draw(gs::booleans()) {
-            batched.despawn(e).expect("despawn of a live seed");
-            individually.despawn(e).expect("despawn of a live seed");
-        }
-    }
+    let history = tc.draw(histories(0, 6));
+    let (mut worlds, _pool) = build_twins(&history, 2);
+    let mut individually = worlds.pop().unwrap();
+    let mut batched = worlds.pop().unwrap();
 
     // Two successive batches, so the second one merges into the archetype the
     // first one created.
-    for _ in 0..tc.draw(gs::integers::<u8>().min_value(1).max_value(2)) {
-        let rows = draw_rows(&tc, 12);
+    let batches = tc.draw(gs::integers::<u8>().min_value(1).max_value(2));
+    for _ in 0..batches {
+        let rows = tc.draw(rows_up_to(12));
         let len_before = batched.len();
         let mut seen: HashSet<Entity> = batched.iter().map(|eref| eref.entity()).collect();
 
@@ -147,12 +130,32 @@ fn d_in(world: &World) -> i64 {
     world.query::<&D>().iter().count() as i64
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Target {
+#[derive(Clone, Copy, Debug, PartialEq, Eq, hegel::PrettyPrintable)]
+enum Kind {
     /// Live, with components the batch does not supply; they must not survive.
     Live,
     /// Spawned and then despawned; the batch resurrects the exact handle.
     Despawned,
+}
+
+/// A batch target. Every target starts with a full component set, so the
+/// batch has to remove B and C as well as overwrite A and D.
+#[derive(Clone, Copy, Debug, hegel::PrettyPrintable)]
+struct Target {
+    kind: Kind,
+    a: i32,
+    b: i32,
+    d: i32,
+}
+
+#[hegel::composite]
+fn batch_targets(tc: &hegel::TestCase) -> Target {
+    Target {
+        kind: tc.draw(gs::sampled_from(vec![Kind::Despawned, Kind::Live])),
+        a: tc.draw(val()),
+        b: tc.draw(val()),
+        d: tc.draw(val()),
+    }
 }
 
 /// `spawn_column_batch_at` places row `i` on handle `i`, replacing whatever
@@ -172,47 +175,46 @@ fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
     // Bystanders first, then targets, then despawns: every id stays distinct,
     // so a repeated handle in the batch list is the only way two rows can
     // collide.
-    let mut bystanders: Vec<(Entity, Spec)> = Vec::new();
-    for _ in 0..tc.draw(gs::integers::<u32>().min_value(0).max_value(4)) {
-        let s = Spec {
-            b: Some(tc.draw(val())),
-            ..Spec::default()
-        };
-        bystanders.push((world.spawn(make_builder(s).build()), s));
-    }
-
-    let kinds: Vec<Target> = (0..tc.draw(gs::integers::<usize>().min_value(0).max_value(6)))
-        .map(|_| {
-            if tc.draw(gs::booleans()) {
-                Target::Live
-            } else {
-                Target::Despawned
-            }
+    let bystander_bs: Vec<i32> = tc.draw(gs::vecs(val()).max_size(4));
+    let bystanders: Vec<(Entity, Spec)> = bystander_bs
+        .iter()
+        .map(|&b| {
+            let s = Spec {
+                b: Some(b),
+                ..Spec::default()
+            };
+            (world.spawn(make_builder(s).build()), s)
         })
         .collect();
-    let mut targets: Vec<Entity> = Vec::new();
-    for _ in &kinds {
-        // Every target starts with a full component set, so the batch has to
-        // remove B and C as well as overwrite A and D.
-        let s = Spec {
-            a: Some(tc.draw(val())),
-            b: Some(tc.draw(val())),
-            c: true,
-            d: Some(tc.draw(val())),
-        };
-        targets.push(world.spawn(make_builder(s).build()));
-    }
-    for (&kind, &e) in kinds.iter().zip(&targets) {
-        if kind == Target::Despawned {
+
+    let targets: Vec<Target> = tc.draw(gs::vecs(batch_targets()).max_size(6));
+    let target_handles: Vec<Entity> = targets
+        .iter()
+        .map(|t| {
+            let s = Spec {
+                a: Some(t.a),
+                b: Some(t.b),
+                c: true,
+                d: Some(t.d),
+            };
+            world.spawn(make_builder(s).build())
+        })
+        .collect();
+    for (t, &e) in targets.iter().zip(&target_handles) {
+        if t.kind == Kind::Despawned {
             world.despawn(e).expect("despawn of a live target");
         }
     }
 
-    if targets.is_empty() {
+    if target_handles.is_empty() {
         return;
     }
-    let rows = draw_rows(&tc, 8);
-    let handles: Vec<Entity> = rows.iter().map(|_| pick(&tc, &targets).unwrap()).collect();
+    let rows = tc.draw(rows_up_to(8));
+    let handles: Vec<Entity> = tc.draw(
+        gs::vecs(pick(&target_handles))
+            .min_size(rows.len())
+            .max_size(rows.len()),
+    );
 
     let before = fingerprint(&world);
     let d_before = d_live();
@@ -238,8 +240,8 @@ fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
         placed.push((e, spec));
     }
     let replaced: HashSet<u32> = handles.iter().map(|e| e.id()).collect();
-    for (&kind, &e) in kinds.iter().zip(&targets) {
-        if kind == Target::Live && !replaced.contains(&e.id()) {
+    for (t, &e) in targets.iter().zip(&target_handles) {
+        if t.kind == Kind::Live && !replaced.contains(&e.id()) {
             expected.push((e, before[&e]));
         }
     }
@@ -273,7 +275,7 @@ fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn the_ways_of_declaring_a_batch_type_agree(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let rows = draw_rows(&tc, 8);
+    let rows = tc.draw(rows_up_to(8));
 
     let mut individually = ColumnBatchType::new();
     individually.add::<A>();
@@ -363,8 +365,12 @@ fn an_underfilled_batch_is_refused(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn dropping_an_unbuilt_batch_drops_its_components(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let capacity = tc.draw(gs::integers::<u32>().min_value(0).max_value(8));
-    let written = tc.draw(gs::integers::<u32>().min_value(0).max_value(capacity));
+    let written: Vec<i32> = tc.draw(gs::vecs(val()).max_size(8));
+    let capacity = tc.draw(
+        gs::integers::<u32>()
+            .min_value(written.len() as u32)
+            .max_value(8),
+    );
 
     let mut types = ColumnBatchType::new();
     types.add::<A>();
@@ -372,22 +378,21 @@ fn dropping_an_unbuilt_batch_drops_its_components(tc: hegel::TestCase) {
     let builder = types.into_batch(capacity);
     {
         let mut writer = builder.writer::<D>().expect("D is in the batch type");
-        for _ in 0..written {
-            writer
-                .push(D::new(tc.draw(val())))
-                .expect("push within capacity");
+        for &d in &written {
+            writer.push(D::new(d)).expect("push within capacity");
         }
     }
     assert_eq!(
         d_live(),
-        written as i64,
+        written.len() as i64,
         "the builder is not holding what was written"
     );
     drop(builder);
     assert_eq!(
         d_live(),
         0,
-        "dropping an unbuilt batch leaked {written} components"
+        "dropping an unbuilt batch leaked {} components",
+        written.len()
     );
 }
 

--- a/tests/column_batch.rs
+++ b/tests/column_batch.rs
@@ -203,7 +203,7 @@ fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
         tc.draw(gs::vecs(hegel::tuples!(row(), handle_from(&target_handles))).max_size(8));
     let (rows, handles): (Vec<Row>, Vec<Entity>) = placements.iter().copied().unzip();
 
-    // Every entity the batch does not name keeps its components; a named
+    // Every entity the batch does not name keeps its components, and a named
     // handle takes its last row.
     let mut expected = fingerprint(&world);
     for &((a, d), e) in &placements {

--- a/tests/column_batch.rs
+++ b/tests/column_batch.rs
@@ -56,8 +56,8 @@ fn build_batch(rows: &[Row]) -> ColumnBatch {
 }
 
 /// A world's observable contents as an order-independent multiset.
-fn multiset(world: &World) -> Vec<Spec> {
-    let mut v: Vec<Spec> = fingerprint(world).into_values().collect();
+fn multiset(world: &World) -> Vec<Components> {
+    let mut v: Vec<Components> = fingerprint(world).into_values().collect();
     v.sort();
     v
 }
@@ -174,14 +174,14 @@ fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
     // so a repeated handle in the batch list is the only way two rows can
     // collide.
     let bystander_bs: Vec<i32> = tc.draw(gs::vecs(val()).max_size(4));
-    let bystanders: Vec<(Entity, Spec)> = bystander_bs
+    let bystanders: Vec<(Entity, Components)> = bystander_bs
         .iter()
         .map(|&b| {
-            let s = Spec {
+            let cs = Components {
                 b: Some(b),
-                ..Spec::default()
+                ..Components::default()
             };
-            (world.spawn(make_builder(s).build()), s)
+            (world.spawn(cs.builder().build()), cs)
         })
         .collect();
 
@@ -189,13 +189,13 @@ fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
     let target_handles: Vec<Entity> = targets
         .iter()
         .map(|t| {
-            let s = Spec {
+            let cs = Components {
                 a: Some(t.a),
                 b: Some(t.b),
                 c: true,
                 d: Some(t.d),
             };
-            world.spawn(make_builder(s).build())
+            world.spawn(cs.builder().build())
         })
         .collect();
     for (t, &e) in targets.iter().zip(&target_handles) {
@@ -209,7 +209,7 @@ fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
     }
     let rows = tc.draw(rows_up_to(8));
     let handles: Vec<Entity> = tc.draw(
-        gs::vecs(pick(&target_handles))
+        gs::vecs(handle_from(&target_handles))
             .min_size(rows.len())
             .max_size(rows.len()),
     );
@@ -225,17 +225,17 @@ fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
     world.spawn_column_batch_at(&handles, batch);
 
     // The last row for an id wins.
-    let mut expected: Vec<(Entity, Spec)> = bystanders.clone();
-    let mut placed: Vec<(Entity, Spec)> = Vec::new();
+    let mut expected: Vec<(Entity, Components)> = bystanders.clone();
+    let mut placed: Vec<(Entity, Components)> = Vec::new();
     for (&e, &(a, d)) in handles.iter().zip(&rows) {
-        let spec = Spec {
+        let cs = Components {
             a: Some(a),
             b: None,
             c: false,
             d: Some(d),
         };
         placed.retain(|(other, _)| other.id() != e.id());
-        placed.push((e, spec));
+        placed.push((e, cs));
     }
     let replaced: HashSet<u32> = handles.iter().map(|e| e.id()).collect();
     for (t, &e) in targets.iter().zip(&target_handles) {
@@ -251,12 +251,8 @@ fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
         expected.len(),
         "world holds the wrong number of entities"
     );
-    for (e, spec) in &expected {
-        assert_eq!(
-            after.get(e),
-            Some(spec),
-            "contents of {e:?} after the batch"
-        );
+    for (e, cs) in &expected {
+        assert_eq!(after.get(e), Some(cs), "contents of {e:?} after the batch");
     }
     check_archetypes(&world, "batch-at world");
     assert_eq!(

--- a/tests/column_batch.rs
+++ b/tests/column_batch.rs
@@ -16,8 +16,12 @@ use hegel::generators as gs;
 /// One entity's worth of batch data: payloads for its `A` and `D` columns.
 type Row = (i32, i32);
 
+fn row() -> impl gs::PrintableGenerator<Row> {
+    hegel::tuples!(val(), val())
+}
+
 fn rows_up_to(max: usize) -> impl gs::PrintableGenerator<Vec<Row>> {
-    gs::vecs(hegel::tuples!(val(), val())).max_size(max)
+    gs::vecs(row()).max_size(max)
 }
 
 /// Build a complete `{A, D}` batch from `rows`, exercising the writer surface
@@ -123,8 +127,9 @@ fn column_batch_matches_individual_spawns(tc: hegel::TestCase) {
     }
 }
 
+/// Whether a batch target is still live when the batch is spawned over it.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, hegel::PrettyPrintable)]
-enum Kind {
+enum Liveness {
     /// Live, with components the batch does not supply; they must not survive.
     Live,
     /// Spawned and then despawned; the batch resurrects the exact handle.
@@ -135,7 +140,7 @@ enum Kind {
 /// batch has to remove B and C as well as overwrite A and D.
 #[derive(Clone, Copy, Debug, hegel::PrettyPrintable)]
 struct Target {
-    kind: Kind,
+    liveness: Liveness,
     a: i32,
     b: i32,
     d: i32,
@@ -144,7 +149,7 @@ struct Target {
 #[hegel::composite]
 fn batch_targets(tc: &hegel::TestCase) -> Target {
     Target {
-        kind: tc.draw(gs::sampled_from(vec![Kind::Despawned, Kind::Live])),
+        liveness: tc.draw(gs::sampled_from(vec![Liveness::Despawned, Liveness::Live])),
         a: tc.draw(val()),
         b: tc.draw(val()),
         d: tc.draw(val()),
@@ -169,47 +174,38 @@ fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
     // so a repeated handle in the batch list is the only way two rows can
     // collide.
     let bystander_bs: Vec<i32> = tc.draw(gs::vecs(val()).max_size(4));
-    let bystanders: Vec<(Entity, Components)> = bystander_bs
-        .iter()
-        .map(|&b| {
-            let cs = Components {
-                b: Some(b),
-                ..Components::default()
-            };
-            (world.spawn(cs.builder(&ds).build()), cs)
-        })
-        .collect();
-
-    let targets: Vec<Target> = tc.draw(gs::vecs(batch_targets()).max_size(6));
+    for &b in &bystander_bs {
+        world.spawn((B(b),));
+    }
+    let targets: Vec<Target> = tc.draw(gs::vecs(batch_targets()).min_size(1).max_size(6));
     let target_handles: Vec<Entity> = targets
         .iter()
-        .map(|t| {
-            let cs = Components {
-                a: Some(t.a),
-                b: Some(t.b),
-                c: true,
-                d: Some(t.d),
-            };
-            world.spawn(cs.builder(&ds).build())
-        })
+        .map(|t| world.spawn((A(t.a), B(t.b), C, D::new(t.d, &ds))))
         .collect();
     for (t, &e) in targets.iter().zip(&target_handles) {
-        if t.kind == Kind::Despawned {
+        if t.liveness == Liveness::Despawned {
             world.despawn(e).expect("despawn of a live target");
         }
     }
 
-    if target_handles.is_empty() {
-        return;
-    }
-    let rows = tc.draw(rows_up_to(8));
-    let handles: Vec<Entity> = tc.draw(
-        gs::vecs(handle_from(&target_handles))
-            .min_size(rows.len())
-            .max_size(rows.len()),
-    );
+    let placements: Vec<(Row, Entity)> =
+        tc.draw(gs::vecs(hegel::tuples!(row(), handle_from(&target_handles))).max_size(8));
+    let (rows, handles): (Vec<Row>, Vec<Entity>) = placements.iter().copied().unzip();
 
-    let before = fingerprint(&world);
+    // Every entity the batch does not name keeps its components; a named
+    // handle takes its last row.
+    let mut expected = fingerprint(&world);
+    for &((a, d), e) in &placements {
+        expected.insert(
+            e,
+            Components {
+                a: Some(a),
+                d: Some(d),
+                ..Components::default()
+            },
+        );
+    }
+
     let d_before = ds.live();
     let batch = build_batch(&rows, &ds);
     assert_eq!(
@@ -219,36 +215,11 @@ fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
     );
     world.spawn_column_batch_at(&handles, batch);
 
-    // The last row for an id wins.
-    let mut expected: Vec<(Entity, Components)> = bystanders.clone();
-    let mut placed: Vec<(Entity, Components)> = Vec::new();
-    for (&e, &(a, d)) in handles.iter().zip(&rows) {
-        let cs = Components {
-            a: Some(a),
-            b: None,
-            c: false,
-            d: Some(d),
-        };
-        placed.retain(|(other, _)| other.id() != e.id());
-        placed.push((e, cs));
-    }
-    let replaced: HashSet<u32> = handles.iter().map(|e| e.id()).collect();
-    for (t, &e) in targets.iter().zip(&target_handles) {
-        if t.kind == Kind::Live && !replaced.contains(&e.id()) {
-            expected.push((e, before[&e]));
-        }
-    }
-    expected.extend(placed);
-
-    let after = fingerprint(&world);
     assert_eq!(
-        after.len(),
-        expected.len(),
-        "world holds the wrong number of entities"
+        fingerprint(&world),
+        expected,
+        "world contents after spawn_column_batch_at"
     );
-    for (e, cs) in &expected {
-        assert_eq!(after.get(e), Some(cs), "contents of {e:?} after the batch");
-    }
     check_archetypes(&world, "batch-at world");
     assert_eq!(
         ds.live(),

--- a/tests/column_batch.rs
+++ b/tests/column_batch.rs
@@ -1,0 +1,416 @@
+//! Properties of column-batch spawning: `ColumnBatchType`,
+//! `ColumnBatchBuilder`, `BatchWriter`, `World::spawn_column_batch` and
+//! `World::spawn_column_batch_at`.
+//!
+//! The oracle for a batch is the same rows spawned one at a time, plus the
+//! push order the writers were given. `D` is drop-tracked, which is what makes
+//! the leak properties here meaningful: this machinery moves component data
+//! with raw pointer copies and owns partially initialized storage.
+
+mod common;
+
+use std::collections::HashSet;
+
+use common::*;
+use hecs::{ColumnBatch, ColumnBatchBuilder, ColumnBatchType, Entity, TypeInfo, World};
+use hegel::generators as gs;
+
+/// One entity's worth of batch data: payloads for its `A` and `D` columns.
+type Row = (i32, i32);
+
+fn draw_rows(tc: &hegel::TestCase, max: usize) -> Vec<Row> {
+    let n = tc.draw(gs::integers::<usize>().min_value(0).max_value(max));
+    (0..n).map(|_| (tc.draw(val()), tc.draw(val()))).collect()
+}
+
+/// Build a complete `{A, D}` batch from `rows`, exercising the writer surface
+/// on the way: `writer` for a type outside the batch, `fill`, and a push past
+/// capacity.
+fn build_batch(rows: &[Row]) -> ColumnBatch {
+    let mut types = ColumnBatchType::new();
+    types.add::<A>();
+    types.add::<D>();
+    let builder = types.into_batch(rows.len() as u32);
+
+    assert!(
+        builder.writer::<B>().is_none(),
+        "writer::<B> exists but B is not in the batch type"
+    );
+    {
+        let mut writer = builder.writer::<A>().expect("A is in the batch type");
+        for &(a, _) in rows {
+            writer.push(A(a)).expect("push within capacity");
+        }
+        assert_eq!(writer.fill(), rows.len() as u32, "A column fill");
+        assert_eq!(
+            writer.push(A(0)),
+            Err(A(0)),
+            "a push past capacity must return the value"
+        );
+    }
+    {
+        let mut writer = builder.writer::<D>().expect("D is in the batch type");
+        for &(_, d) in rows {
+            writer.push(D::new(d)).expect("push within capacity");
+        }
+        assert_eq!(writer.fill(), rows.len() as u32, "D column fill");
+    }
+    builder.build().expect("a fully filled batch must build")
+}
+
+/// A world's observable contents as an order-independent multiset.
+fn multiset(world: &World) -> Vec<Spec> {
+    let mut v: Vec<Spec> = fingerprint(world).into_values().collect();
+    v.sort();
+    v
+}
+
+/// `spawn_column_batch` produces the same entities as spawning the same rows
+/// one at a time, and hands out one distinct handle per row carrying that row's
+/// components in push order.
+///
+/// Both worlds are seeded with unrelated archetypes and a non-empty freelist,
+/// the state that made `spawn_column_batch` panic before the fix in
+/// "Fix panic after spawn_column_batch on a world with a nonempty freelist".
+#[hegel::test(settings())]
+fn column_batch_matches_individual_spawns(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let mut batched = World::new();
+    let mut individually = World::new();
+
+    let seeded = tc.draw(gs::integers::<u32>().min_value(0).max_value(6));
+    let mut seed_handles = Vec::new();
+    for _ in 0..seeded {
+        let s = tc.draw(specs());
+        let e = batched.spawn(make_builder(s).build());
+        assert_eq!(
+            e,
+            individually.spawn(make_builder(s).build()),
+            "seeding diverged"
+        );
+        seed_handles.push(e);
+    }
+    for &e in &seed_handles {
+        if tc.draw(gs::booleans()) {
+            batched.despawn(e).expect("despawn of a live seed");
+            individually.despawn(e).expect("despawn of a live seed");
+        }
+    }
+
+    // Two successive batches, so the second one merges into the archetype the
+    // first one created.
+    for _ in 0..tc.draw(gs::integers::<u8>().min_value(1).max_value(2)) {
+        let rows = draw_rows(&tc, 12);
+        let len_before = batched.len();
+        let mut seen: HashSet<Entity> = batched.iter().map(|eref| eref.entity()).collect();
+
+        let iter = batched.spawn_column_batch(build_batch(&rows));
+        assert_eq!(iter.len(), rows.len(), "SpawnColumnBatchIter::len");
+        let handles: Vec<Entity> = iter.collect();
+        assert_eq!(
+            handles.len(),
+            rows.len(),
+            "SpawnColumnBatchIter yielded the wrong count"
+        );
+        assert_eq!(
+            batched.len(),
+            len_before + rows.len() as u32,
+            "world.len() after spawn_column_batch"
+        );
+
+        for (i, (&e, &(a, d))) in handles.iter().zip(&rows).enumerate() {
+            assert!(seen.insert(e), "row {i} reused handle {e:?}");
+            assert!(batched.contains(e), "row {i} handle {e:?} is not contained");
+            assert_eq!(batched.get::<&A>(e).unwrap().0, a, "A of row {i}");
+            assert_eq!(batched.get::<&D>(e).unwrap().0, d, "D of row {i}");
+        }
+
+        for &(a, d) in &rows {
+            individually.spawn((A(a), D::new(d)));
+        }
+        assert_eq!(
+            multiset(&batched),
+            multiset(&individually),
+            "the batch world and the one-at-a-time world hold different entities"
+        );
+        check_archetypes(&batched, "batch world");
+        assert_eq!(
+            d_live(),
+            d_in(&batched) + d_in(&individually),
+            "drop imbalance after a batch"
+        );
+    }
+}
+
+/// How many `D` components a world holds.
+fn d_in(world: &World) -> i64 {
+    world.query::<&D>().iter().count() as i64
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Target {
+    /// Live, with components the batch does not supply; they must not survive.
+    Live,
+    /// Spawned and then despawned; the batch resurrects the exact handle.
+    Despawned,
+}
+
+/// `spawn_column_batch_at` places row `i` on handle `i`, replacing whatever
+/// occupied that id — including the components the batch does not supply — and
+/// leaves every other entity alone.
+///
+/// The handle list may repeat a handle. `spawn_column_batch_at_redundant` in
+/// src/world.rs pins the semantics: the last row for an id wins and the earlier
+/// duplicates are discarded. Repeated handles used to write out of bounds
+/// (issue #449) and then to leave zombie entities behind, so this is the
+/// regression witness for both fixes.
+#[hegel::test(settings())]
+fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let mut world = World::new();
+
+    // Bystanders first, then targets, then despawns: every id stays distinct,
+    // so a repeated handle in the batch list is the only way two rows can
+    // collide.
+    let mut bystanders: Vec<(Entity, Spec)> = Vec::new();
+    for _ in 0..tc.draw(gs::integers::<u32>().min_value(0).max_value(4)) {
+        let s = Spec {
+            b: Some(tc.draw(val())),
+            ..Spec::default()
+        };
+        bystanders.push((world.spawn(make_builder(s).build()), s));
+    }
+
+    let kinds: Vec<Target> = (0..tc.draw(gs::integers::<usize>().min_value(0).max_value(6)))
+        .map(|_| {
+            if tc.draw(gs::booleans()) {
+                Target::Live
+            } else {
+                Target::Despawned
+            }
+        })
+        .collect();
+    let mut targets: Vec<Entity> = Vec::new();
+    for _ in &kinds {
+        // Every target starts with a full component set, so the batch has to
+        // remove B and C as well as overwrite A and D.
+        let s = Spec {
+            a: Some(tc.draw(val())),
+            b: Some(tc.draw(val())),
+            c: true,
+            d: Some(tc.draw(val())),
+        };
+        targets.push(world.spawn(make_builder(s).build()));
+    }
+    for (&kind, &e) in kinds.iter().zip(&targets) {
+        if kind == Target::Despawned {
+            world.despawn(e).expect("despawn of a live target");
+        }
+    }
+
+    if targets.is_empty() {
+        return;
+    }
+    let rows = draw_rows(&tc, 8);
+    let handles: Vec<Entity> = rows.iter().map(|_| pick(&tc, &targets).unwrap()).collect();
+
+    let before = fingerprint(&world);
+    let d_before = d_live();
+    let batch = build_batch(&rows);
+    assert_eq!(
+        d_live(),
+        d_before + rows.len() as i64,
+        "the batch holds one D per row"
+    );
+    world.spawn_column_batch_at(&handles, batch);
+
+    // The last row for an id wins.
+    let mut expected: Vec<(Entity, Spec)> = bystanders.clone();
+    let mut placed: Vec<(Entity, Spec)> = Vec::new();
+    for (&e, &(a, d)) in handles.iter().zip(&rows) {
+        let spec = Spec {
+            a: Some(a),
+            b: None,
+            c: false,
+            d: Some(d),
+        };
+        placed.retain(|(other, _)| other.id() != e.id());
+        placed.push((e, spec));
+    }
+    let replaced: HashSet<u32> = handles.iter().map(|e| e.id()).collect();
+    for (&kind, &e) in kinds.iter().zip(&targets) {
+        if kind == Target::Live && !replaced.contains(&e.id()) {
+            expected.push((e, before[&e]));
+        }
+    }
+    expected.extend(placed);
+
+    let after = fingerprint(&world);
+    assert_eq!(
+        after.len(),
+        expected.len(),
+        "world holds the wrong number of entities"
+    );
+    for (e, spec) in &expected {
+        assert_eq!(
+            after.get(e),
+            Some(spec),
+            "contents of {e:?} after the batch"
+        );
+    }
+    check_archetypes(&world, "batch-at world");
+    assert_eq!(
+        d_live(),
+        d_in(&world),
+        "replaced components leaked or were dropped twice"
+    );
+}
+
+/// The three ways to declare a batch's component types agree: `add::<T>()`,
+/// `add_dynamic(TypeInfo::of::<T>())` — documented as "`add()` but using type
+/// information determined at runtime" — and `add_bundle::<T>()`, documented as
+/// including "all the components in bundle `T`".
+#[hegel::test(settings())]
+fn the_ways_of_declaring_a_batch_type_agree(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let rows = draw_rows(&tc, 8);
+
+    let mut individually = ColumnBatchType::new();
+    individually.add::<A>();
+    individually.add::<D>();
+
+    let mut dynamically = ColumnBatchType::new();
+    dynamically.add_dynamic(TypeInfo::of::<A>());
+    dynamically.add_dynamic(TypeInfo::of::<D>());
+
+    let mut as_bundle = ColumnBatchType::new();
+    as_bundle.add_bundle::<(A, D)>();
+
+    let mut worlds = Vec::new();
+    for types in [individually, dynamically, as_bundle] {
+        let mut world = World::new();
+        // `ColumnBatchBuilder::new` is the non-consuming spelling of
+        // `into_batch`.
+        let builder = ColumnBatchBuilder::new(types, rows.len() as u32);
+        {
+            let mut writer = builder.writer::<A>().expect("A was declared");
+            for &(a, _) in &rows {
+                writer.push(A(a)).expect("push within capacity");
+            }
+        }
+        {
+            let mut writer = builder.writer::<D>().expect("D was declared");
+            for &(_, d) in &rows {
+                writer.push(D::new(d)).expect("push within capacity");
+            }
+        }
+        world.spawn_column_batch(builder.build().expect("a filled batch must build"));
+        worlds.push(world);
+    }
+    let expected = fingerprint(&worlds[0]);
+    for (i, world) in worlds.iter().enumerate().skip(1) {
+        assert_eq!(
+            expected,
+            fingerprint(world),
+            "batch type {i} produced different entities"
+        );
+    }
+}
+
+/// A builder with an underfilled column refuses to build. All the components
+/// here are `Copy`, so this checks only the `Err` half of the contract; the
+/// drop half is `a_refused_build_drops_the_written_components` below.
+#[hegel::test(settings())]
+fn an_underfilled_batch_is_refused(tc: hegel::TestCase) {
+    let capacity = tc.draw(gs::integers::<u32>().min_value(1).max_value(8));
+    let written = tc.draw(gs::integers::<u32>().min_value(0).max_value(capacity - 1));
+
+    let mut types = ColumnBatchType::new();
+    types.add::<A>();
+    types.add::<B>();
+    let builder = types.into_batch(capacity);
+    {
+        let mut writer = builder.writer::<A>().expect("A is in the batch type");
+        for _ in 0..capacity {
+            writer.push(A(0)).expect("push within capacity");
+        }
+    }
+    {
+        let mut writer = builder.writer::<B>().expect("B is in the batch type");
+        for _ in 0..written {
+            writer.push(B(0)).expect("push within capacity");
+        }
+    }
+    let Err(error) = builder.build() else {
+        panic!("build accepted an underfilled column");
+    };
+    assert!(
+        !error.to_string().is_empty(),
+        "BatchIncomplete has no message"
+    );
+}
+
+/// Dropping a `ColumnBatchBuilder` without building drops whatever was written
+/// into it. `ColumnBatchBuilder::drop` stepped a `*mut u8` by byte index and
+/// dropped it as a `u8`, leaking every written component (issue #450); this is
+/// the regression witness.
+#[hegel::test(settings())]
+fn dropping_an_unbuilt_batch_drops_its_components(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let capacity = tc.draw(gs::integers::<u32>().min_value(0).max_value(8));
+    let written = tc.draw(gs::integers::<u32>().min_value(0).max_value(capacity));
+
+    let mut types = ColumnBatchType::new();
+    types.add::<A>();
+    types.add::<D>();
+    let builder = types.into_batch(capacity);
+    {
+        let mut writer = builder.writer::<D>().expect("D is in the batch type");
+        for _ in 0..written {
+            writer
+                .push(D::new(tc.draw(val())))
+                .expect("push within capacity");
+        }
+    }
+    assert_eq!(
+        d_live(),
+        written as i64,
+        "the builder is not holding what was written"
+    );
+    drop(builder);
+    assert_eq!(
+        d_live(),
+        0,
+        "dropping an unbuilt batch leaked {written} components"
+    );
+}
+
+/// A builder with an underfilled column must refuse to build, and the values
+/// already written into it must still be dropped.
+///
+/// `build` moves the archetype out with its length still zero and only then
+/// checks completeness, so the components written so far are leaked. The `Err`
+/// half of the contract holds; the drop half does not. Reproduces on hecs
+/// 0.11.1 — the same defect as issue #450, on the path its fix did not cover
+/// (issue #459).
+#[test]
+#[ignore = "hecs#459: ColumnBatchBuilder::build() -> Err leaks the written components"]
+fn a_refused_build_drops_the_written_components() {
+    assert_d_balanced_at_start();
+    let mut types = ColumnBatchType::new();
+    types.add::<A>();
+    types.add::<D>();
+    let builder = types.into_batch(2);
+    {
+        let mut writer = builder.writer::<D>().expect("D is in the batch type");
+        writer.push(D::new(1)).unwrap();
+        writer.push(D::new(2)).unwrap();
+        // The A column is left empty, so build() must fail.
+    }
+    assert_eq!(d_live(), 2, "the builder is not holding what was written");
+    assert!(
+        builder.build().is_err(),
+        "build() accepted an underfilled column"
+    );
+    assert_eq!(d_live(), 0, "a refused build leaked the written components");
+}

--- a/tests/column_batch.rs
+++ b/tests/column_batch.rs
@@ -285,7 +285,9 @@ fn the_ways_of_declaring_a_batch_type_agree(tc: hegel::TestCase) {
 fn an_underfilled_batch_is_refused(tc: hegel::TestCase) {
     let ds = DropTracker::new();
     let capacity = tc.draw(gs::integers::<u32>().min_value(1).max_value(8));
-    let written = tc.draw(gs::integers::<u32>().min_value(0).max_value(capacity - 1));
+    let a_written = tc.draw(gs::integers::<u32>().min_value(0).max_value(capacity));
+    let d_written = tc.draw(gs::integers::<u32>().min_value(0).max_value(capacity));
+    tc.assume(a_written < capacity || d_written < capacity);
 
     let mut types = ColumnBatchType::new();
     types.add::<A>();
@@ -293,19 +295,19 @@ fn an_underfilled_batch_is_refused(tc: hegel::TestCase) {
     let builder = types.into_batch(capacity);
     {
         let mut writer = builder.writer::<A>().expect("A is in the batch type");
-        for _ in 0..capacity {
+        for _ in 0..a_written {
             writer.push(A(0)).expect("push within capacity");
         }
     }
     {
         let mut writer = builder.writer::<D>().expect("D is in the batch type");
-        for _ in 0..written {
+        for _ in 0..d_written {
             writer.push(D::new(0, &ds)).expect("push within capacity");
         }
     }
     assert_eq!(
         ds.live(),
-        written as usize,
+        d_written as usize,
         "the builder is not holding what was written"
     );
     let Err(error) = builder.build() else {
@@ -374,7 +376,6 @@ fn a_refused_build_drops_the_written_components() {
         let mut writer = builder.writer::<D>().expect("D is in the batch type");
         writer.push(D::new(1, &ds)).unwrap();
         writer.push(D::new(2, &ds)).unwrap();
-        // The A column is left empty, so build() must fail.
     }
     assert_eq!(ds.live(), 2, "the builder is not holding what was written");
     assert!(

--- a/tests/column_batch.rs
+++ b/tests/column_batch.rs
@@ -23,7 +23,7 @@ fn rows_up_to(max: usize) -> impl gs::PrintableGenerator<Vec<Row>> {
 /// Build a complete `{A, D}` batch from `rows`, exercising the writer surface
 /// on the way: `writer` for a type outside the batch, `fill`, and a push past
 /// capacity.
-fn build_batch(rows: &[Row]) -> ColumnBatch {
+fn build_batch(rows: &[Row], ds: &DropTracker) -> ColumnBatch {
     let mut types = ColumnBatchType::new();
     types.add::<A>();
     types.add::<D>();
@@ -48,7 +48,7 @@ fn build_batch(rows: &[Row]) -> ColumnBatch {
     {
         let mut writer = builder.writer::<D>().expect("D is in the batch type");
         for &(_, d) in rows {
-            writer.push(D::new(d)).expect("push within capacity");
+            writer.push(D::new(d, ds)).expect("push within capacity");
         }
         assert_eq!(writer.fill(), rows.len() as u32, "D column fill");
     }
@@ -71,9 +71,9 @@ fn multiset(world: &World) -> Vec<Components> {
 /// "Fix panic after spawn_column_batch on a world with a nonempty freelist".
 #[hegel::test(settings())]
 fn column_batch_matches_individual_spawns(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, 6));
-    let (mut worlds, _pool) = build_twins(&history, 2);
+    let (mut worlds, _pool) = build_twins(&history, 2, &ds);
     let mut individually = worlds.pop().unwrap();
     let mut batched = worlds.pop().unwrap();
 
@@ -85,7 +85,7 @@ fn column_batch_matches_individual_spawns(tc: hegel::TestCase) {
         let len_before = batched.len();
         let mut seen: HashSet<Entity> = batched.iter().map(|eref| eref.entity()).collect();
 
-        let iter = batched.spawn_column_batch(build_batch(&rows));
+        let iter = batched.spawn_column_batch(build_batch(&rows, &ds));
         assert_eq!(iter.len(), rows.len(), "SpawnColumnBatchIter::len");
         let handles: Vec<Entity> = iter.collect();
         assert_eq!(
@@ -103,11 +103,11 @@ fn column_batch_matches_individual_spawns(tc: hegel::TestCase) {
             assert!(seen.insert(e), "row {i} reused handle {e:?}");
             assert!(batched.contains(e), "row {i} handle {e:?} is not contained");
             assert_eq!(batched.get::<&A>(e).unwrap().0, a, "A of row {i}");
-            assert_eq!(batched.get::<&D>(e).unwrap().0, d, "D of row {i}");
+            assert_eq!(batched.get::<&D>(e).unwrap().value, d, "D of row {i}");
         }
 
         for &(a, d) in &rows {
-            individually.spawn((A(a), D::new(d)));
+            individually.spawn((A(a), D::new(d, &ds)));
         }
         assert_eq!(
             multiset(&batched),
@@ -116,7 +116,7 @@ fn column_batch_matches_individual_spawns(tc: hegel::TestCase) {
         );
         check_archetypes(&batched, "batch world");
         assert_eq!(
-            d_live(),
+            ds.live(),
             d_in(&batched) + d_in(&individually),
             "drop imbalance after a batch"
         );
@@ -162,7 +162,7 @@ fn batch_targets(tc: &hegel::TestCase) -> Target {
 /// regression witness for both fixes.
 #[hegel::test(settings())]
 fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let mut world = World::new();
 
     // Bystanders first, then targets, then despawns: every id stays distinct,
@@ -176,7 +176,7 @@ fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
                 b: Some(b),
                 ..Components::default()
             };
-            (world.spawn(cs.builder().build()), cs)
+            (world.spawn(cs.builder(&ds).build()), cs)
         })
         .collect();
 
@@ -190,7 +190,7 @@ fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
                 c: true,
                 d: Some(t.d),
             };
-            world.spawn(cs.builder().build())
+            world.spawn(cs.builder(&ds).build())
         })
         .collect();
     for (t, &e) in targets.iter().zip(&target_handles) {
@@ -210,11 +210,11 @@ fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
     );
 
     let before = fingerprint(&world);
-    let d_before = d_live();
-    let batch = build_batch(&rows);
+    let d_before = ds.live();
+    let batch = build_batch(&rows, &ds);
     assert_eq!(
-        d_live(),
-        d_before + rows.len() as i64,
+        ds.live(),
+        d_before + rows.len(),
         "the batch holds one D per row"
     );
     world.spawn_column_batch_at(&handles, batch);
@@ -251,7 +251,7 @@ fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
     }
     check_archetypes(&world, "batch-at world");
     assert_eq!(
-        d_live(),
+        ds.live(),
         d_in(&world),
         "replaced components leaked or were dropped twice"
     );
@@ -263,7 +263,7 @@ fn column_batch_at_places_each_row_on_its_handle(tc: hegel::TestCase) {
 /// including "all the components in bundle `T`".
 #[hegel::test(settings())]
 fn the_ways_of_declaring_a_batch_type_agree(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let rows = tc.draw(rows_up_to(8));
 
     let mut individually = ColumnBatchType::new();
@@ -292,7 +292,7 @@ fn the_ways_of_declaring_a_batch_type_agree(tc: hegel::TestCase) {
         {
             let mut writer = builder.writer::<D>().expect("D was declared");
             for &(_, d) in &rows {
-                writer.push(D::new(d)).expect("push within capacity");
+                writer.push(D::new(d, &ds)).expect("push within capacity");
             }
         }
         world.spawn_column_batch(builder.build().expect("a filled batch must build"));
@@ -312,7 +312,7 @@ fn the_ways_of_declaring_a_batch_type_agree(tc: hegel::TestCase) {
 /// already written into it are dropped.
 #[hegel::test(settings())]
 fn an_underfilled_batch_is_refused(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let capacity = tc.draw(gs::integers::<u32>().min_value(1).max_value(8));
     let written = tc.draw(gs::integers::<u32>().min_value(0).max_value(capacity - 1));
 
@@ -329,12 +329,12 @@ fn an_underfilled_batch_is_refused(tc: hegel::TestCase) {
     {
         let mut writer = builder.writer::<D>().expect("D is in the batch type");
         for _ in 0..written {
-            writer.push(D::new(0)).expect("push within capacity");
+            writer.push(D::new(0, &ds)).expect("push within capacity");
         }
     }
     assert_eq!(
-        d_live(),
-        written as i64,
+        ds.live(),
+        written as usize,
         "the builder is not holding what was written"
     );
     let Err(error) = builder.build() else {
@@ -344,7 +344,11 @@ fn an_underfilled_batch_is_refused(tc: hegel::TestCase) {
         !error.to_string().is_empty(),
         "BatchIncomplete has no message"
     );
-    assert_eq!(d_live(), 0, "a refused build leaked the written components");
+    assert_eq!(
+        ds.live(),
+        0,
+        "a refused build leaked the written components"
+    );
 }
 
 /// Dropping a `ColumnBatchBuilder` without building drops whatever was written
@@ -353,7 +357,7 @@ fn an_underfilled_batch_is_refused(tc: hegel::TestCase) {
 /// the regression witness.
 #[hegel::test(settings())]
 fn dropping_an_unbuilt_batch_drops_its_components(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let written: Vec<i32> = tc.draw(gs::vecs(val()).max_size(8));
     let capacity = tc.draw(
         gs::integers::<u32>()
@@ -368,17 +372,17 @@ fn dropping_an_unbuilt_batch_drops_its_components(tc: hegel::TestCase) {
     {
         let mut writer = builder.writer::<D>().expect("D is in the batch type");
         for &d in &written {
-            writer.push(D::new(d)).expect("push within capacity");
+            writer.push(D::new(d, &ds)).expect("push within capacity");
         }
     }
     assert_eq!(
-        d_live(),
-        written.len() as i64,
+        ds.live(),
+        written.len(),
         "the builder is not holding what was written"
     );
     drop(builder);
     assert_eq!(
-        d_live(),
+        ds.live(),
         0,
         "dropping an unbuilt batch leaked {} components",
         written.len()
@@ -390,21 +394,25 @@ fn dropping_an_unbuilt_batch_drops_its_components(tc: hegel::TestCase) {
 /// 0.11.1 (issue #459).
 #[test]
 fn a_refused_build_drops_the_written_components() {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let mut types = ColumnBatchType::new();
     types.add::<A>();
     types.add::<D>();
     let builder = types.into_batch(2);
     {
         let mut writer = builder.writer::<D>().expect("D is in the batch type");
-        writer.push(D::new(1)).unwrap();
-        writer.push(D::new(2)).unwrap();
+        writer.push(D::new(1, &ds)).unwrap();
+        writer.push(D::new(2, &ds)).unwrap();
         // The A column is left empty, so build() must fail.
     }
-    assert_eq!(d_live(), 2, "the builder is not holding what was written");
+    assert_eq!(ds.live(), 2, "the builder is not holding what was written");
     assert!(
         builder.build().is_err(),
         "build() accepted an underfilled column"
     );
-    assert_eq!(d_live(), 0, "a refused build leaked the written components");
+    assert_eq!(
+        ds.live(),
+        0,
+        "a refused build leaked the written components"
+    );
 }

--- a/tests/column_batch.rs
+++ b/tests/column_batch.rs
@@ -7,11 +7,9 @@
 //! the leak properties here meaningful: this machinery moves component data
 //! with raw pointer copies and owns partially initialized storage.
 
-mod common;
-
 use std::collections::HashSet;
 
-use common::*;
+use fixtures::*;
 use hecs::{ColumnBatch, ColumnBatchBuilder, ColumnBatchType, Entity, TypeInfo, World};
 use hegel::generators as gs;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,7 +10,7 @@ use std::cell::Cell;
 use std::collections::{BTreeMap, HashSet};
 
 use hecs::{Entity, EntityBuilder, World};
-use hegel::generators as gs;
+use hegel::generators::{self as gs, Generator};
 use serde::{Deserialize, Deserializer, Serialize};
 
 /// Component universe: two same-shaped payload components, a zero-sized marker,
@@ -99,17 +99,10 @@ pub fn val() -> impl gs::PrintableGenerator<i32> {
     gs::integers::<i32>().min_value(-3).max_value(3)
 }
 
-/// Draw from `pool`, which deliberately retains despawned handles.
-pub fn pick(tc: &hegel::TestCase, pool: &[Entity]) -> Option<Entity> {
-    if pool.is_empty() {
-        return None;
-    }
-    let i = tc.draw(
-        gs::integers::<usize>()
-            .min_value(0)
-            .max_value(pool.len() - 1),
-    );
-    Some(pool[i])
+/// A handle from `pool`, which deliberately retains despawned handles. `pool`
+/// must not be empty.
+pub fn pick(pool: &[Entity]) -> impl gs::PrintableGenerator<Entity> + '_ {
+    gs::sampled_from(pool).print_as_debug()
 }
 
 /// An arbitrary subset of the component universe, as drawn payloads. `D`
@@ -142,6 +135,12 @@ pub fn specs(tc: &hegel::TestCase) -> Spec {
         c: tc.draw(gs::booleans()),
         d: tc.draw(gs::optional(val())),
     }
+}
+
+/// `specs()` without `D`, which is not `Clone` and so cannot go into an
+/// `EntityBuilderClone`.
+pub fn specs_without_d() -> impl gs::PrintableGenerator<Spec> {
+    specs().map(|s| Spec { d: None, ..s })
 }
 
 pub fn make_builder(s: Spec) -> EntityBuilder {
@@ -228,38 +227,67 @@ pub fn check_archetypes(world: &World, label: &str) {
     );
 }
 
-/// Build `n_worlds` observationally identical worlds by replaying one drawn
-/// history (spawns of arbitrary specs, then a drawn subset of despawns) into
-/// each, and return them with a target pool that retains the despawned handles.
+/// One step of a world's history: spawn an entity from a spec, or despawn the
+/// `i`th entity spawned so far, which is still live at that point.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, hegel::PrettyPrintable)]
+pub enum Step {
+    Spawn(Spec),
+    Despawn(usize),
+}
+
+/// Between `min_steps` and `max_steps` steps, so at most `max_steps` entities.
+/// Despawns are interleaved with the spawns so that ids get recycled and
+/// generations advance. The first step is always a spawn, so a nonzero
+/// `min_steps` guarantees a non-empty handle pool.
+#[hegel::composite]
+pub fn histories(tc: &hegel::TestCase, min_steps: u32, max_steps: u32) -> Vec<Step> {
+    let n = tc.draw(
+        gs::integers::<u32>()
+            .min_value(min_steps)
+            .max_value(max_steps),
+    );
+    let mut steps = Vec::new();
+    let mut live: Vec<usize> = Vec::new();
+    let mut spawned = 0;
+    for _ in 0..n {
+        if !live.is_empty() && tc.draw(gs::weighted_booleans(0.25)) {
+            let i = tc.draw(gs::sampled_from(&live));
+            live.retain(|&l| l != i);
+            steps.push(Step::Despawn(i));
+        } else {
+            steps.push(Step::Spawn(tc.draw(specs())));
+            live.push(spawned);
+            spawned += 1;
+        }
+    }
+    steps
+}
+
+/// Replay `history` into `n_worlds` fresh worlds and return them with the pool
+/// of every handle spawned, despawned ones included.
 ///
 /// `World` is not `Clone`, so this is how a relation between two executions
 /// "from the same state" is set up. It relies on hecs allocating handles
 /// deterministically, which the `deterministic_ids` test in src/world.rs pins.
 /// The assertions below fail if it ever stops holding.
-pub fn build_twins(
-    tc: &hegel::TestCase,
-    n_worlds: usize,
-    max_entities: u32,
-) -> (Vec<World>, Vec<Entity>) {
+pub fn build_twins(history: &[Step], n_worlds: usize) -> (Vec<World>, Vec<Entity>) {
     let mut worlds: Vec<World> = (0..n_worlds).map(|_| World::new()).collect();
     let mut pool: Vec<Entity> = Vec::new();
-
-    let n = tc.draw(gs::integers::<u32>().min_value(0).max_value(max_entities));
-    for _ in 0..n {
-        let s = tc.draw(specs());
-        let mut handles = worlds.iter_mut().map(|w| w.spawn(make_builder(s).build()));
-        let first = handles.next().expect("at least one world");
-        for h in handles {
-            assert_eq!(first, h, "twin worlds allocated different handles");
-        }
-        pool.push(first);
-    }
-    for &e in &pool {
-        if tc.draw(gs::booleans()) {
-            let mut oks = worlds.iter_mut().map(|w| w.despawn(e).is_ok());
-            let first = oks.next().expect("at least one world");
-            for ok in oks {
-                assert_eq!(first, ok, "twin despawn disagreed for {e:?}");
+    for step in history {
+        match *step {
+            Step::Spawn(s) => {
+                let mut handles = worlds.iter_mut().map(|w| w.spawn(make_builder(s).build()));
+                let first = handles.next().expect("at least one world");
+                for h in handles {
+                    assert_eq!(first, h, "twin worlds allocated different handles");
+                }
+                pool.push(first);
+            }
+            Step::Despawn(i) => {
+                for w in &mut worlds {
+                    w.despawn(pool[i])
+                        .expect("a history only despawns live entities");
+                }
             }
         }
     }
@@ -268,4 +296,9 @@ pub fn build_twins(
         assert_eq!(fp0, fingerprint(w), "twin world {i} diverged during setup");
     }
     (worlds, pool)
+}
+
+/// One world replayed from `history`.
+pub fn build_world(history: &[Step]) -> World {
+    build_twins(history, 1).0.pop().expect("one world")
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,266 @@
+//! Shared fixtures for the property tests: a fixed component universe, an
+//! observational fingerprint of a `World`, and twin worlds replayed from one
+//! drawn history.
+//!
+//! Each integration-test binary compiles this module separately, so parts of it
+//! are unused in some binaries.
+#![allow(dead_code)]
+
+use std::cell::Cell;
+use std::collections::{BTreeMap, HashSet};
+
+use hecs::{Entity, EntityBuilder, World};
+use hegel::generators as gs;
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Component universe: two same-shaped payload components, a zero-sized marker,
+/// and a drop-tracked non-`Copy` component.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct A(pub i32);
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct B(pub i32);
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct C;
+
+thread_local! { static D_LIVE: Cell<i64> = const { Cell::new(0) }; }
+
+/// Every `D` is constructed through `D::new`, which bumps a thread-local count
+/// that `Drop` decrements, so a leak or double-drop in hecs's unsafe component
+/// moves shows up as a count that disagrees with the world's contents.
+#[derive(Debug, Serialize)]
+pub struct D(pub i32);
+
+impl D {
+    pub fn new(v: i32) -> D {
+        D_LIVE.with(|c| c.set(c.get() + 1));
+        D(v)
+    }
+}
+
+impl Drop for D {
+    fn drop(&mut self) {
+        D_LIVE.with(|c| c.set(c.get() - 1));
+    }
+}
+
+impl<'de> Deserialize<'de> for D {
+    fn deserialize<De: Deserializer<'de>>(de: De) -> Result<Self, De::Error> {
+        i32::deserialize(de).map(D::new)
+    }
+}
+
+pub fn d_live() -> i64 {
+    D_LIVE.with(|c| c.get())
+}
+
+/// The thread-local survives hegel's many test cases, so an imbalance at case
+/// start means a previous case leaked or double-dropped.
+pub fn assert_d_balanced_at_start() {
+    assert_eq!(d_live(), 0, "live D count nonzero at case start");
+}
+
+/// Under Miri each operation is interpreted, so these tests run a much smaller
+/// search and serve as a UB oracle for hecs's unsafe component moves rather
+/// than as a search for logic bugs. Two consequences: hegel's `TooSlow` check
+/// would report on interpreter speed rather than on anything about the tests,
+/// and Miri's isolation denies the file and random-device access hegel needs
+/// for its failure database and its seed, so both are turned off.
+#[cfg(miri)]
+pub fn settings() -> hegel::Settings {
+    hegel::Settings::new()
+        .test_cases(4)
+        .derandomize(true)
+        .database(None)
+        .suppress_health_check([hegel::HealthCheck::TooSlow])
+}
+
+#[cfg(not(miri))]
+pub fn settings() -> hegel::Settings {
+    hegel::Settings::new().test_cases(250)
+}
+
+/// Worlds are kept small so that handle collisions, empty archetypes and
+/// stale handles all occur often; the bound protects the tests' runtime, not
+/// any hecs contract.
+#[cfg(miri)]
+pub const MAX_ENTITIES: u32 = 4;
+#[cfg(not(miri))]
+pub const MAX_ENTITIES: u32 = 8;
+
+/// Component payloads are small so that distinct values recur across entities,
+/// which is what makes a swapped or stale component visible.
+pub fn val() -> impl gs::PrintableGenerator<i32> {
+    gs::integers::<i32>().min_value(-3).max_value(3)
+}
+
+/// Draw from `pool`, which deliberately retains despawned handles.
+pub fn pick(tc: &hegel::TestCase, pool: &[Entity]) -> Option<Entity> {
+    if pool.is_empty() {
+        return None;
+    }
+    let i = tc.draw(
+        gs::integers::<usize>()
+            .min_value(0)
+            .max_value(pool.len() - 1),
+    );
+    Some(pool[i])
+}
+
+/// An arbitrary subset of the component universe, as drawn payloads. `D`
+/// instances are materialized only when a bundle is built, so the drop count
+/// tracks exactly the instances that entered a world.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Spec {
+    pub a: Option<i32>,
+    pub b: Option<i32>,
+    pub c: bool,
+    pub d: Option<i32>,
+}
+
+impl Spec {
+    /// How many components an entity built from this spec has.
+    pub fn component_count(&self) -> usize {
+        self.a.is_some() as usize
+            + self.b.is_some() as usize
+            + self.c as usize
+            + self.d.is_some() as usize
+    }
+}
+
+hegel::pretty_print_as_debug!(Spec);
+
+/// An arbitrary component subset.
+#[hegel::composite]
+pub fn specs(tc: &hegel::TestCase) -> Spec {
+    Spec {
+        a: tc.draw(gs::optional(val())),
+        b: tc.draw(gs::optional(val())),
+        c: tc.draw(gs::booleans()),
+        d: tc.draw(gs::optional(val())),
+    }
+}
+
+pub fn make_builder(s: Spec) -> EntityBuilder {
+    let mut b = EntityBuilder::new();
+    if let Some(v) = s.a {
+        b.add(A(v));
+    }
+    if let Some(v) = s.b {
+        b.add(B(v));
+    }
+    if s.c {
+        b.add(C);
+    }
+    if let Some(v) = s.d {
+        b.add(D::new(v));
+    }
+    b
+}
+
+/// Canonical snapshot of everything a caller can observe about a `World`: the
+/// exact `Entity` handles (id and generation) and, per entity, the exact
+/// component set and values. Two worlds are observationally equivalent iff
+/// their fingerprints compare equal.
+pub type Fingerprint = BTreeMap<Entity, Spec>;
+
+pub fn fingerprint(world: &World) -> Fingerprint {
+    let mut fp = Fingerprint::new();
+    for eref in world.iter() {
+        let obs = Spec {
+            a: eref.get::<&A>().map(|r| r.0),
+            b: eref.get::<&B>().map(|r| r.0),
+            c: eref.get::<&C>().is_some(),
+            d: eref.get::<&D>().map(|r| r.0),
+        };
+        assert!(
+            fp.insert(eref.entity(), obs).is_none(),
+            "world.iter() yielded {:?} twice",
+            eref.entity()
+        );
+    }
+    assert_eq!(fp.len() as u32, world.len(), "iter() count != world.len()");
+    fp
+}
+
+/// How many live `D` components a fingerprint accounts for.
+pub fn fingerprint_d_count(fp: &Fingerprint) -> i64 {
+    fp.values().filter(|o| o.d.is_some()).count() as i64
+}
+
+pub fn total_d(worlds: &[World]) -> i64 {
+    worlds
+        .iter()
+        .map(|w| fingerprint_d_count(&fingerprint(w)))
+        .sum()
+}
+
+/// The archetypes partition the live entities: each id appears in exactly one
+/// archetype and the lengths sum to `world.len()`. `Archetype::len` and
+/// `ids()` are the public form of the invariant `World::archetypes_mut` and
+/// `insert_batch` maintain internally.
+pub fn check_archetypes(world: &World, label: &str) {
+    let mut total = 0u32;
+    let mut ids = HashSet::new();
+    for arch in world.archetypes() {
+        total += arch.len();
+        assert_eq!(
+            arch.ids().len(),
+            arch.len() as usize,
+            "{label}: ids() length != len()"
+        );
+        for &id in arch.ids() {
+            assert!(
+                ids.insert(id),
+                "{label}: entity id {id} in more than one archetype"
+            );
+        }
+    }
+    assert_eq!(
+        total,
+        world.len(),
+        "{label}: archetype lengths sum to {total}, world.len() is {}",
+        world.len()
+    );
+}
+
+/// Build `n_worlds` observationally identical worlds by replaying one drawn
+/// history (spawns of arbitrary specs, then a drawn subset of despawns) into
+/// each, and return them with a target pool that retains the despawned handles.
+///
+/// `World` is not `Clone`, so this is how a relation between two executions
+/// "from the same state" is set up. It relies on hecs allocating handles
+/// deterministically (`World::deterministic_ids` in src/world.rs tests pins
+/// that); the assertions below fail loudly if it ever stops holding.
+pub fn build_twins(
+    tc: &hegel::TestCase,
+    n_worlds: usize,
+    max_entities: u32,
+) -> (Vec<World>, Vec<Entity>) {
+    let mut worlds: Vec<World> = (0..n_worlds).map(|_| World::new()).collect();
+    let mut pool: Vec<Entity> = Vec::new();
+
+    let n = tc.draw(gs::integers::<u32>().min_value(0).max_value(max_entities));
+    for _ in 0..n {
+        let s = tc.draw(specs());
+        let mut handles = worlds.iter_mut().map(|w| w.spawn(make_builder(s).build()));
+        let first = handles.next().expect("at least one world");
+        for h in handles {
+            assert_eq!(first, h, "twin worlds allocated different handles");
+        }
+        pool.push(first);
+    }
+    for &e in &pool {
+        if tc.draw(gs::booleans()) {
+            let mut oks = worlds.iter_mut().map(|w| w.despawn(e).is_ok());
+            let first = oks.next().expect("at least one world");
+            for ok in oks {
+                assert_eq!(first, ok, "twin despawn disagreed for {e:?}");
+            }
+        }
+    }
+    let fp0 = fingerprint(&worlds[0]);
+    for (i, w) in worlds.iter().enumerate().skip(1) {
+        assert_eq!(fp0, fingerprint(w), "twin world {i} diverged during setup");
+    }
+    (worlds, pool)
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -195,9 +195,7 @@ pub fn total_d(worlds: &[World]) -> i64 {
 }
 
 /// The archetypes partition the live entities: each id appears in exactly one
-/// archetype and the lengths sum to `world.len()`. `Archetype::len` and
-/// `ids()` are the public form of the invariant `World::archetypes_mut` and
-/// `insert_batch` maintain internally.
+/// archetype and the lengths sum to `world.len()`.
 pub fn check_archetypes(world: &World, label: &str) {
     let mut total = 0u32;
     let mut ids = HashSet::new();
@@ -229,8 +227,8 @@ pub fn check_archetypes(world: &World, label: &str) {
 ///
 /// `World` is not `Clone`, so this is how a relation between two executions
 /// "from the same state" is set up. It relies on hecs allocating handles
-/// deterministically (`World::deterministic_ids` in src/world.rs tests pins
-/// that); the assertions below fail loudly if it ever stops holding.
+/// deterministically, which the `deterministic_ids` test in src/world.rs pins.
+/// The assertions below fail if it ever stops holding.
 pub fn build_twins(
     tc: &hegel::TestCase,
     n_worlds: usize,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,25 @@
 //! Shared fixtures for the property tests: a fixed component universe, an
 //! observational fingerprint of a `World`, and twin worlds replayed from one
-//! drawn history.
+//! generated history.
+//!
+//! A property is a test whose inputs come from a `hegel::TestCase`:
+//!
+//! ```
+//! #[hegel::test(settings())]
+//! fn a_spawned_component_reads_back(tc: hegel::TestCase) {
+//!     assert_d_balanced_at_start();
+//!     let v = tc.draw(val());
+//!     let mut world = World::new();
+//!     let e = world.spawn((A(v),));
+//!     assert_eq!(world.get::<&A>(e).unwrap().0, v);
+//! }
+//! ```
+//!
+//! `tc.draw(g)` returns one value from the generator `g`. hegel runs the body
+//! once per case with fresh draws, and on a failure reruns it on the smallest
+//! inputs it can find and prints them. Every `TestCase` method takes `&self`.
+//! `TestCase` is `Send` but not `Sync`, so drawing from another thread means
+//! moving a clone of it there, which none of these tests do.
 //!
 //! Each integration-test binary compiles this module separately, so parts of it
 //! are unused in some binaries.
@@ -53,18 +72,19 @@ pub fn d_live() -> i64 {
     D_LIVE.with(|c| c.get())
 }
 
-/// The thread-local survives hegel's many test cases, so an imbalance at case
-/// start means a previous case leaked or double-dropped.
+/// hegel runs every case of a property in the test's own thread, one after
+/// another, so the thread-local carries over between cases and an imbalance
+/// at case start means a previous case leaked or double-dropped.
 pub fn assert_d_balanced_at_start() {
     assert_eq!(d_live(), 0, "live D count nonzero at case start");
 }
 
-/// Under Miri each operation is interpreted, so these tests run a much smaller
-/// search and serve as a UB oracle for hecs's unsafe component moves rather
-/// than as a search for logic bugs. Two consequences: hegel's `TooSlow` check
-/// would report on interpreter speed rather than on anything about the tests,
-/// and Miri's isolation denies the file and random-device access hegel needs
-/// for its failure database and its seed, so both are turned off.
+/// Under Miri each operation is interpreted, so these tests run four fixed
+/// cases each and serve as a UB oracle for hecs's unsafe component moves
+/// rather than as a search for logic bugs. Miri's isolation denies the file
+/// and random-device access hegel uses for a fresh seed and for saving
+/// failures, and hegel's check that ten cases arrive within thirty seconds
+/// would report on the interpreter, so all three are turned off.
 #[cfg(miri)]
 pub fn settings() -> hegel::Settings {
     hegel::Settings::new()
@@ -74,6 +94,10 @@ pub fn settings() -> hegel::Settings {
         .suppress_health_check([hegel::HealthCheck::TooSlow])
 }
 
+/// 250 cases per property. Outside CI hegel seeds each run afresh and saves
+/// any failing case under `.hegel/` (gitignored) so the next run replays it
+/// first. When `CI` or `GITHUB_ACTIONS` is set the seed is fixed per test and
+/// nothing is saved, so a failure there reproduces locally with `CI=1`.
 #[cfg(not(miri))]
 pub fn settings() -> hegel::Settings {
     hegel::Settings::new().test_cases(250)
@@ -88,7 +112,9 @@ pub const MAX_ENTITIES: u32 = 4;
 pub const MAX_ENTITIES: u32 = 8;
 
 /// Component payloads are small so that distinct values recur across entities,
-/// which is what makes a swapped or stale component visible.
+/// which is what makes a swapped or stale component visible. Bounds on hegel's
+/// integer generators are inclusive. `draw` accepts only generators that can
+/// print what they drew, which is how a failing case's inputs get reported.
 pub fn val() -> impl gs::PrintableGenerator<i32> {
     gs::integers::<i32>().min_value(-3).max_value(3)
 }
@@ -127,9 +153,13 @@ impl Spec {
     }
 }
 
+// `draw` refuses a generator whose values it cannot print. This prints `Spec`
+// with its `Debug` impl.
 hegel::pretty_print_as_debug!(Spec);
 
-/// An arbitrary component subset.
+/// An arbitrary component subset. The attribute turns this into a
+/// zero-argument `specs()` returning a generator of `Spec`, and
+/// `tc.draw(specs())` supplies the `TestCase`.
 #[hegel::composite]
 pub fn specs(tc: &hegel::TestCase) -> Spec {
     Spec {
@@ -187,6 +217,9 @@ pub fn fingerprint_d_count(fp: &Fingerprint) -> i64 {
     fp.values().filter(|o| o.d.is_some()).count() as i64
 }
 
+/// Live `D` components summed over `worlds`. Each twin holds its own copy of
+/// every `D` it was fed, so `d_live()` should equal this sum rather than one
+/// world's count.
 pub fn total_d(worlds: &[World]) -> i64 {
     worlds
         .iter()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -135,7 +135,7 @@ pub fn pick(tc: &hegel::TestCase, pool: &[Entity]) -> Option<Entity> {
 /// An arbitrary subset of the component universe, as drawn payloads. `D`
 /// instances are materialized only when a bundle is built, so the drop count
 /// tracks exactly the instances that entered a world.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, hegel::PrettyPrintable)]
 pub struct Spec {
     pub a: Option<i32>,
     pub b: Option<i32>,
@@ -152,10 +152,6 @@ impl Spec {
             + self.d.is_some() as usize
     }
 }
-
-// `draw` refuses a generator whose values it cannot print. This prints `Spec`
-// with its `Debug` impl.
-hegel::pretty_print_as_debug!(Spec);
 
 /// An arbitrary component subset. The attribute turns this into a
 /// zero-argument `specs()` returning a generator of `Spec`, and

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,25 +2,6 @@
 //! observational fingerprint of a `World`, and twin worlds replayed from one
 //! generated history.
 //!
-//! A property is a test whose inputs come from a `hegel::TestCase`:
-//!
-//! ```
-//! #[hegel::test(settings())]
-//! fn a_spawned_component_reads_back(tc: hegel::TestCase) {
-//!     assert_d_balanced_at_start();
-//!     let v = tc.draw(val());
-//!     let mut world = World::new();
-//!     let e = world.spawn((A(v),));
-//!     assert_eq!(world.get::<&A>(e).unwrap().0, v);
-//! }
-//! ```
-//!
-//! `tc.draw(g)` returns one value from the generator `g`. hegel runs the body
-//! once per case with fresh draws, and on a failure reruns it on the smallest
-//! inputs it can find and prints them. Every `TestCase` method takes `&self`.
-//! `TestCase` is `Send` but not `Sync`, so drawing from another thread means
-//! moving a clone of it there, which none of these tests do.
-//!
 //! Each integration-test binary compiles this module separately, so parts of it
 //! are unused in some binaries.
 #![allow(dead_code)]
@@ -72,9 +53,9 @@ pub fn d_live() -> i64 {
     D_LIVE.with(|c| c.get())
 }
 
-/// hegel runs every case of a property in the test's own thread, one after
-/// another, so the thread-local carries over between cases and an imbalance
-/// at case start means a previous case leaked or double-dropped.
+/// Cases run one after another on the test's thread, so the thread-local
+/// carries over and an imbalance at case start means a previous case leaked or
+/// double-dropped.
 pub fn assert_d_balanced_at_start() {
     assert_eq!(d_live(), 0, "live D count nonzero at case start");
 }
@@ -112,9 +93,8 @@ pub const MAX_ENTITIES: u32 = 4;
 pub const MAX_ENTITIES: u32 = 8;
 
 /// Component payloads are small so that distinct values recur across entities,
-/// which is what makes a swapped or stale component visible. Bounds on hegel's
-/// integer generators are inclusive. `draw` accepts only generators that can
-/// print what they drew, which is how a failing case's inputs get reported.
+/// which is what makes a swapped or stale component visible. Bounds are
+/// inclusive.
 pub fn val() -> impl gs::PrintableGenerator<i32> {
     gs::integers::<i32>().min_value(-3).max_value(3)
 }
@@ -153,9 +133,7 @@ impl Spec {
     }
 }
 
-/// An arbitrary component subset. The attribute turns this into a
-/// zero-argument `specs()` returning a generator of `Spec`, and
-/// `tc.draw(specs())` supplies the `TestCase`.
+/// An arbitrary component subset.
 #[hegel::composite]
 pub fn specs(tc: &hegel::TestCase) -> Spec {
     Spec {

--- a/tests/construction_paths.rs
+++ b/tests/construction_paths.rs
@@ -68,7 +68,7 @@ fn spawn_incrementally(world: &mut World, s: Spec) -> Entity {
     e
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, hegel::PrettyPrintable)]
 enum Mutation {
     InsertOne(u8, i32),
     RemoveOne(u8),
@@ -77,8 +77,6 @@ enum Mutation {
     Despawn,
     ExchangeAToB(i32),
 }
-
-hegel::pretty_print_as_debug!(Mutation);
 
 #[hegel::composite]
 fn mutations(tc: &hegel::TestCase) -> Mutation {
@@ -239,8 +237,6 @@ enum Command {
     RemoveOne(Entity, u8),
     Despawn(Entity),
 }
-
-hegel::pretty_print_as_debug!(Command);
 
 fn record(buffer: &mut CommandBuffer, c: Command) {
     match c {

--- a/tests/construction_paths.rs
+++ b/tests/construction_paths.rs
@@ -243,6 +243,14 @@ fn apply_eagerly(world: &mut World, c: Command, ds: &DropTracker) {
     }
 }
 
+/// What is done with the buffer once a round of commands is recorded.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, hegel::PrettyPrintable)]
+enum Outcome {
+    Run,
+    Clear,
+    Drop,
+}
+
 /// How many `D` values a recorded sequence is holding inside the buffer.
 fn pending_d(commands: &[Command]) -> usize {
     commands
@@ -298,9 +306,11 @@ fn command_buffer_matches_eager_application(tc: hegel::TestCase) {
             "a buffered D was dropped early or leaked"
         );
 
-        let outcome = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
+        let outcome = tc.draw(gs::sampled_from(
+            &[Outcome::Run, Outcome::Clear, Outcome::Drop][..],
+        ));
         match outcome {
-            0 | 1 => {
+            Outcome::Run => {
                 buffer.run_on(&mut worlds[1]);
                 for &c in &commands {
                     apply_eagerly(&mut worlds[0], c, &ds);
@@ -320,7 +330,7 @@ fn command_buffer_matches_eager_application(tc: hegel::TestCase) {
                 );
             }
             // `clear` discards the recorded commands.
-            2 => {
+            Outcome::Clear => {
                 buffer.clear();
                 buffer.run_on(&mut worlds[1]);
                 assert_eq!(
@@ -330,7 +340,7 @@ fn command_buffer_matches_eager_application(tc: hegel::TestCase) {
                 );
             }
             // Dropping a non-empty buffer must release its stored components.
-            _ => buffer = CommandBuffer::new(),
+            Outcome::Drop => buffer = CommandBuffer::new(),
         }
 
         assert_eq!(

--- a/tests/construction_paths.rs
+++ b/tests/construction_paths.rs
@@ -14,7 +14,7 @@ mod common;
 
 use common::*;
 use hecs::{CommandBuffer, Entity, World};
-use hegel::generators as gs;
+use hegel::generators::{self as gs, Generator};
 
 const ROUTES: usize = 5;
 
@@ -123,10 +123,10 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
     // A shared history puts every allocator into the same non-trivial state
     // (non-empty freelist, advanced generations) before the routes diverge.
-    let (mut worlds, mut pool) = build_twins(&tc, ROUTES, MAX_ENTITIES);
+    let history = tc.draw(histories(0, MAX_ENTITIES));
+    let (mut worlds, mut pool) = build_twins(&history, ROUTES);
 
-    let n = tc.draw(gs::integers::<u32>().min_value(0).max_value(MAX_ENTITIES));
-    let specs: Vec<Spec> = (0..n).map(|_| tc.draw(specs())).collect();
+    let specs: Vec<Spec> = tc.draw(gs::vecs(specs()).max_size(MAX_ENTITIES as usize));
 
     let mut buffer = CommandBuffer::new();
     for &s in &specs {
@@ -195,9 +195,12 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
         "drop imbalance across construction routes"
     );
 
+    if pool.is_empty() {
+        return;
+    }
     let steps = tc.draw(gs::integers::<u32>().min_value(0).max_value(MAX_ENTITIES));
     for _ in 0..steps {
-        let Some(e) = pick(&tc, &pool) else { break };
+        let e = tc.draw(pick(&pool));
         let m = tc.draw(mutations());
         let mut results = worlds.iter_mut().map(|w| apply(w, e, m));
         let first = results.next().expect("at least one world");
@@ -236,6 +239,26 @@ enum Command {
     RemoveCD(Entity),
     RemoveOne(Entity, u8),
     Despawn(Entity),
+}
+
+/// A command on a handle from `pool`, or a spawn. Two of the eight kinds
+/// spawn, so the pool grows fast enough for the other commands to have
+/// entities to act on. An empty pool only gets spawns.
+#[hegel::composite]
+fn commands_on(tc: &hegel::TestCase, pool: &[Entity]) -> Command {
+    let which = gs::integers::<u8>().min_value(0).max_value(3);
+    let kinds = gs::integers::<u8>()
+        .min_value(0)
+        .max_value(if pool.is_empty() { 1 } else { 7 });
+    match tc.draw(kinds) {
+        0 | 1 => Command::Spawn(tc.draw(specs())),
+        2 => Command::Insert(tc.draw(pick(pool)), tc.draw(specs())),
+        3 => Command::InsertOne(tc.draw(pick(pool)), tc.draw(which), tc.draw(val())),
+        4 => Command::RemoveAB(tc.draw(pick(pool))),
+        5 => Command::RemoveCD(tc.draw(pick(pool))),
+        6 => Command::RemoveOne(tc.draw(pick(pool)), tc.draw(which)),
+        _ => Command::Despawn(tc.draw(pick(pool))),
+    }
 }
 
 fn record(buffer: &mut CommandBuffer, c: Command) {
@@ -306,59 +329,26 @@ fn pending_d(commands: &[Command]) -> i64 {
 #[hegel::test(settings())]
 fn command_buffer_matches_eager_application(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let (mut worlds, mut pool) = build_twins(&tc, 2, MAX_ENTITIES);
+    let history = tc.draw(histories(0, MAX_ENTITIES));
+    let (mut worlds, mut pool) = build_twins(&history, 2);
 
     // `CommandBuffer::insert` documents `reserve_entity` as the way to obtain a
     // handle for an entity that does not exist yet.
-    if tc.draw(gs::booleans()) {
-        let k = tc.draw(gs::integers::<u32>().min_value(1).max_value(3));
-        for _ in 0..k {
-            let eager = worlds[0].reserve_entity();
-            let buffered = worlds[1].reserve_entity();
-            assert_eq!(eager, buffered, "reserve_entity was not deterministic");
-            pool.push(eager);
-        }
+    let reserved = tc.draw(gs::integers::<u32>().min_value(0).max_value(3));
+    for _ in 0..reserved {
+        let eager = worlds[0].reserve_entity();
+        let buffered = worlds[1].reserve_entity();
+        assert_eq!(eager, buffered, "reserve_entity was not deterministic");
+        pool.push(eager);
     }
 
     let mut buffer = CommandBuffer::new();
     let rounds = tc.draw(gs::integers::<u32>().min_value(1).max_value(4));
     for _ in 0..rounds {
-        let mut commands: Vec<Command> = Vec::new();
-        let n = tc.draw(gs::integers::<u32>().min_value(0).max_value(12));
-        for _ in 0..n {
-            let which = gs::integers::<u8>().min_value(0).max_value(3);
-            // Weighted rather than a `one_of!`: two of the eight indices spawn,
-            // so the pool grows fast enough for the other commands to have
-            // entities to act on.
-            let c = match tc.draw(gs::integers::<u8>().min_value(0).max_value(7)) {
-                0 | 1 => Command::Spawn(tc.draw(specs())),
-                2 => match pick(&tc, &pool) {
-                    Some(e) => Command::Insert(e, tc.draw(specs())),
-                    None => continue,
-                },
-                3 => match pick(&tc, &pool) {
-                    Some(e) => Command::InsertOne(e, tc.draw(which), tc.draw(val())),
-                    None => continue,
-                },
-                4 => match pick(&tc, &pool) {
-                    Some(e) => Command::RemoveAB(e),
-                    None => continue,
-                },
-                5 => match pick(&tc, &pool) {
-                    Some(e) => Command::RemoveCD(e),
-                    None => continue,
-                },
-                6 => match pick(&tc, &pool) {
-                    Some(e) => Command::RemoveOne(e, tc.draw(which)),
-                    None => continue,
-                },
-                _ => match pick(&tc, &pool) {
-                    Some(e) => Command::Despawn(e),
-                    None => continue,
-                },
-            };
+        let commands: Vec<Command> =
+            tc.draw(gs::vecs(commands_on(&pool).print_as_debug()).max_size(12));
+        for &c in &commands {
             record(&mut buffer, c);
-            commands.push(c);
         }
 
         // Recording must not touch either world, and every `D` handed to the
@@ -374,7 +364,8 @@ fn command_buffer_matches_eager_application(tc: hegel::TestCase) {
             "a buffered D was dropped early or leaked"
         );
 
-        match tc.draw(gs::integers::<u8>().min_value(0).max_value(3)) {
+        let outcome = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
+        match outcome {
             0 | 1 => {
                 buffer.run_on(&mut worlds[1]);
                 for &c in &commands {

--- a/tests/construction_paths.rs
+++ b/tests/construction_paths.rs
@@ -68,8 +68,8 @@ fn spawn_incrementally(world: &mut World, cs: Components, ds: &DropTracker) -> E
 
 #[derive(Clone, Copy, Debug, hegel::PrettyPrintable)]
 enum Mutation {
-    InsertOne(u8, i32),
-    RemoveOne(u8),
+    InsertOne(Kind, i32),
+    RemoveOne(Kind),
     InsertBundle(Components),
     RemoveAB,
     Despawn,
@@ -78,12 +78,9 @@ enum Mutation {
 
 #[hegel::composite]
 fn mutations(tc: &hegel::TestCase) -> Mutation {
-    fn which() -> impl hegel::generators::PrintableGenerator<u8> {
-        gs::integers::<u8>().min_value(0).max_value(3)
-    }
     tc.draw(hegel::one_of!(
-        hegel::compose!(|tc| { Mutation::InsertOne(tc.draw(which()), tc.draw(val())) }),
-        hegel::compose!(|tc| { Mutation::RemoveOne(tc.draw(which())) }),
+        hegel::compose!(|tc| { Mutation::InsertOne(tc.draw(kinds()), tc.draw(val())) }),
+        hegel::compose!(|tc| { Mutation::RemoveOne(tc.draw(kinds())) }),
         hegel::compose!(|tc| { Mutation::InsertBundle(tc.draw(components())) }),
         gs::just(Mutation::RemoveAB),
         gs::just(Mutation::Despawn),
@@ -93,18 +90,8 @@ fn mutations(tc: &hegel::TestCase) -> Mutation {
 
 fn apply(world: &mut World, e: Entity, m: Mutation, ds: &DropTracker) -> bool {
     match m {
-        Mutation::InsertOne(which, v) => match which {
-            0 => world.insert_one(e, A(v)).is_ok(),
-            1 => world.insert_one(e, B(v)).is_ok(),
-            2 => world.insert_one(e, C).is_ok(),
-            _ => world.insert_one(e, D::new(v, ds)).is_ok(),
-        },
-        Mutation::RemoveOne(which) => match which {
-            0 => world.remove_one::<A>(e).is_ok(),
-            1 => world.remove_one::<B>(e).is_ok(),
-            2 => world.remove_one::<C>(e).is_ok(),
-            _ => world.remove_one::<D>(e).is_ok(),
-        },
+        Mutation::InsertOne(kind, v) => kind.insert_one(world, e, v, ds).is_ok(),
+        Mutation::RemoveOne(kind) => kind.remove_one(world, e).is_ok(),
         Mutation::InsertBundle(cs) => world.insert(e, cs.builder(ds).build()).is_ok(),
         Mutation::RemoveAB => world.remove::<(A, B)>(e).is_ok(),
         Mutation::Despawn => world.despawn(e).is_ok(),
@@ -232,10 +219,10 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
 enum Command {
     Spawn(Components),
     Insert(Entity, Components),
-    InsertOne(Entity, u8, i32),
+    InsertOne(Entity, Kind, i32),
     RemoveAB(Entity),
     RemoveCD(Entity),
-    RemoveOne(Entity, u8),
+    RemoveOne(Entity, Kind),
     Despawn(Entity),
 }
 
@@ -244,17 +231,16 @@ enum Command {
 /// entities to act on. An empty pool only gets spawns.
 #[hegel::composite]
 fn commands_on(tc: &hegel::TestCase, pool: &[Entity]) -> Command {
-    let which = gs::integers::<u8>().min_value(0).max_value(3);
-    let kinds = gs::integers::<u8>()
+    let which = gs::integers::<u8>()
         .min_value(0)
         .max_value(if pool.is_empty() { 1 } else { 7 });
-    match tc.draw(kinds) {
+    match tc.draw(which) {
         0 | 1 => Command::Spawn(tc.draw(components())),
         2 => Command::Insert(tc.draw(handle_from(pool)), tc.draw(components())),
-        3 => Command::InsertOne(tc.draw(handle_from(pool)), tc.draw(which), tc.draw(val())),
+        3 => Command::InsertOne(tc.draw(handle_from(pool)), tc.draw(kinds()), tc.draw(val())),
         4 => Command::RemoveAB(tc.draw(handle_from(pool))),
         5 => Command::RemoveCD(tc.draw(handle_from(pool))),
-        6 => Command::RemoveOne(tc.draw(handle_from(pool)), tc.draw(which)),
+        6 => Command::RemoveOne(tc.draw(handle_from(pool)), tc.draw(kinds())),
         _ => Command::Despawn(tc.draw(handle_from(pool))),
     }
 }
@@ -263,20 +249,10 @@ fn record(buffer: &mut CommandBuffer, c: Command, ds: &DropTracker) {
     match c {
         Command::Spawn(cs) => buffer.spawn(cs.builder(ds).build()),
         Command::Insert(e, cs) => buffer.insert(e, cs.builder(ds).build()),
-        Command::InsertOne(e, which, v) => match which {
-            0 => buffer.insert_one(e, A(v)),
-            1 => buffer.insert_one(e, B(v)),
-            2 => buffer.insert_one(e, C),
-            _ => buffer.insert_one(e, D::new(v, ds)),
-        },
+        Command::InsertOne(e, kind, v) => kind.buffer_insert_one(buffer, e, v, ds),
         Command::RemoveAB(e) => buffer.remove::<(A, B)>(e),
         Command::RemoveCD(e) => buffer.remove::<(C, D)>(e),
-        Command::RemoveOne(e, which) => match which {
-            0 => buffer.remove_one::<A>(e),
-            1 => buffer.remove_one::<B>(e),
-            2 => buffer.remove_one::<C>(e),
-            _ => buffer.remove_one::<D>(e),
-        },
+        Command::RemoveOne(e, kind) => kind.buffer_remove_one(buffer, e),
         Command::Despawn(e) => buffer.despawn(e),
     }
 }
@@ -289,20 +265,10 @@ fn apply_eagerly(world: &mut World, c: Command, ds: &DropTracker) {
             world.spawn(cs.builder(ds).build());
         }
         Command::Insert(e, cs) => drop(world.insert(e, cs.builder(ds).build())),
-        Command::InsertOne(e, which, v) => match which {
-            0 => drop(world.insert_one(e, A(v))),
-            1 => drop(world.insert_one(e, B(v))),
-            2 => drop(world.insert_one(e, C)),
-            _ => drop(world.insert_one(e, D::new(v, ds))),
-        },
+        Command::InsertOne(e, kind, v) => drop(kind.insert_one(world, e, v, ds)),
         Command::RemoveAB(e) => drop(world.remove::<(A, B)>(e)),
         Command::RemoveCD(e) => drop(world.remove::<(C, D)>(e)),
-        Command::RemoveOne(e, which) => match which {
-            0 => drop(world.remove_one::<A>(e)),
-            1 => drop(world.remove_one::<B>(e)),
-            2 => drop(world.remove_one::<C>(e)),
-            _ => drop(world.remove_one::<D>(e)),
-        },
+        Command::RemoveOne(e, kind) => drop(kind.remove_one(world, e)),
         Command::Despawn(e) => drop(world.despawn(e)),
     }
 }
@@ -313,7 +279,7 @@ fn pending_d(commands: &[Command]) -> usize {
         .iter()
         .map(|c| match c {
             Command::Spawn(cs) | Command::Insert(_, cs) => cs.d.is_some() as usize,
-            Command::InsertOne(_, 3, _) => 1,
+            Command::InsertOne(_, Kind::D, _) => 1,
             _ => 0,
         })
         .sum()

--- a/tests/construction_paths.rs
+++ b/tests/construction_paths.rs
@@ -14,9 +14,26 @@ use fixtures::*;
 use hecs::{CommandBuffer, Entity, World};
 use hegel::generators::{self as gs, Generator};
 
-const ROUTES: usize = 5;
+/// The routes that spawn drawn components and return the handle. The
+/// `CommandBuffer` route is driven separately, since `CommandBuffer::spawn`
+/// does not return one.
+const ROUTES: [(&str, fn(&mut World, Components, &DropTracker) -> Entity); 4] = [
+    ("EntityBuilder", spawn_builder),
+    ("static tuple", spawn_tuple),
+    ("reserve_entity + insert", spawn_reserved),
+    ("insert_one chain", spawn_incrementally),
+];
 
-/// Route 2: the static `Bundle` impls, one concrete tuple type per subset of
+/// The name of the `i`th twin world: a `ROUTES` entry, then the buffer world.
+fn route_name(i: usize) -> &'static str {
+    ROUTES.get(i).map_or("CommandBuffer", |route| route.0)
+}
+
+fn spawn_builder(world: &mut World, cs: Components, ds: &DropTracker) -> Entity {
+    world.spawn(cs.builder(ds).build())
+}
+
+/// The static `Bundle` impls, one concrete tuple type per subset of
 /// `{A, B, C, D}`.
 fn spawn_tuple(world: &mut World, cs: Components, ds: &DropTracker) -> Entity {
     match (cs.a, cs.b, cs.c, cs.d) {
@@ -39,8 +56,15 @@ fn spawn_tuple(world: &mut World, cs: Components, ds: &DropTracker) -> Entity {
     }
 }
 
-/// Route 5: an empty entity migrated through one intermediate archetype per
-/// component.
+fn spawn_reserved(world: &mut World, cs: Components, ds: &DropTracker) -> Entity {
+    let e = world.reserve_entity();
+    world
+        .insert(e, cs.builder(ds).build())
+        .expect("insert on a freshly reserved entity");
+    e
+}
+
+/// An empty entity migrated through one intermediate archetype per component.
 fn spawn_incrementally(world: &mut World, cs: Components, ds: &DropTracker) -> Entity {
     let e = world.spawn(());
     if let Some(v) = cs.a {
@@ -76,7 +100,7 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
     // A shared history puts every allocator into the same non-trivial state
     // (non-empty freelist, advanced generations) before the routes diverge.
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let (mut worlds, mut pool) = build_twins(&history, ROUTES, &ds);
+    let (mut worlds, mut pool) = build_twins(&history, ROUTES.len() + 1, &ds);
 
     let to_spawn: Vec<Components> = tc.draw(gs::vecs(components()).max_size(MAX_ENTITIES as usize));
 
@@ -85,43 +109,20 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
         buffer.spawn(cs.builder(&ds).build());
     }
 
-    let mut handles: Vec<Vec<Entity>> = Vec::with_capacity(ROUTES);
-    handles.push(
-        to_spawn
-            .iter()
-            .map(|&cs| worlds[0].spawn(cs.builder(&ds).build()))
-            .collect(),
-    );
-    handles.push(
-        to_spawn
-            .iter()
-            .map(|&cs| spawn_tuple(&mut worlds[1], cs, &ds))
-            .collect(),
-    );
-    handles.push(
-        to_spawn
-            .iter()
-            .map(|&cs| {
-                let e = worlds[2].reserve_entity();
-                worlds[2]
-                    .insert(e, cs.builder(&ds).build())
-                    .expect("insert on a freshly reserved entity");
-                e
-            })
-            .collect(),
-    );
+    let handles: Vec<Vec<Entity>> = ROUTES
+        .iter()
+        .zip(&mut worlds)
+        .map(|(&(_, route), world)| to_spawn.iter().map(|&cs| route(world, cs, &ds)).collect())
+        .collect();
     // CommandBuffer does not surface the handles it allocates; they are
     // recovered from the fingerprint comparison below.
-    buffer.run_on(&mut worlds[3]);
-    handles.push(
-        to_spawn
-            .iter()
-            .map(|&cs| spawn_incrementally(&mut worlds[4], cs, &ds))
-            .collect(),
-    );
+    buffer.run_on(&mut worlds[ROUTES.len()]);
 
-    for (i, route) in handles.iter().enumerate().skip(1) {
-        assert_eq!(&handles[0], route, "route {i} allocated different handles");
+    for (&(name, _), route) in ROUTES.iter().zip(&handles).skip(1) {
+        assert_eq!(
+            &handles[0], route,
+            "the {name} route allocated different handles"
+        );
     }
     pool.extend(handles[0].iter().copied());
 
@@ -137,7 +138,8 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
         assert_eq!(
             expected,
             fingerprint(w),
-            "route {i} built an observationally different world"
+            "the {} route built an observationally different world",
+            route_name(i)
         );
         check_archetypes(w, "constructed world");
     }
@@ -160,8 +162,8 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
             assert_eq!(
                 first,
                 r,
-                "{m:?} on {e:?} returned a different result in route {}",
-                i + 1
+                "{m:?} on {e:?} returned a different result in the {} route",
+                route_name(i + 1)
             );
         }
         let after = fingerprint(&worlds[0]);
@@ -169,7 +171,8 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
             assert_eq!(
                 after,
                 fingerprint(w),
-                "route {i} diverged after {m:?} on {e:?}"
+                "the {} route diverged after {m:?} on {e:?}",
+                route_name(i)
             );
         }
     }

--- a/tests/construction_paths.rs
+++ b/tests/construction_paths.rs
@@ -14,10 +14,12 @@ use fixtures::*;
 use hecs::{CommandBuffer, Entity, World};
 use hegel::generators::{self as gs, Generator};
 
+type Route = fn(&mut World, Components, &DropTracker) -> Entity;
+
 /// The routes that spawn drawn components and return the handle. The
 /// `CommandBuffer` route is driven separately, since `CommandBuffer::spawn`
 /// does not return one.
-const ROUTES: [(&str, fn(&mut World, Components, &DropTracker) -> Entity); 4] = [
+const ROUTES: [(&str, Route); 4] = [
     ("EntityBuilder", spawn_builder),
     ("static tuple", spawn_tuple),
     ("reserve_entity + insert", spawn_reserved),

--- a/tests/construction_paths.rs
+++ b/tests/construction_paths.rs
@@ -193,23 +193,26 @@ enum Command {
     Despawn(Entity),
 }
 
-/// A command on a handle from `pool`, or a spawn. Two of the eight kinds
+/// A command on a handle from `pool`, or a spawn. A quarter of the commands
 /// spawn, so the pool grows fast enough for the other commands to have
 /// entities to act on. An empty pool only gets spawns.
 #[hegel::composite]
 fn commands_on(tc: &hegel::TestCase, pool: &[Entity]) -> Command {
-    let which = gs::integers::<u8>()
-        .min_value(0)
-        .max_value(if pool.is_empty() { 1 } else { 7 });
-    match tc.draw(which) {
-        0 | 1 => Command::Spawn(tc.draw(components())),
-        2 => Command::Insert(tc.draw(handle_from(pool)), tc.draw(components())),
-        3 => Command::InsertOne(tc.draw(handle_from(pool)), tc.draw(kinds()), tc.draw(val())),
-        4 => Command::RemoveAB(tc.draw(handle_from(pool))),
-        5 => Command::RemoveCD(tc.draw(handle_from(pool))),
-        6 => Command::RemoveOne(tc.draw(handle_from(pool)), tc.draw(kinds())),
-        _ => Command::Despawn(tc.draw(handle_from(pool))),
+    if pool.is_empty() || tc.draw(gs::weighted_booleans(0.25)) {
+        return Command::Spawn(tc.draw(components()));
     }
+    let e = tc.draw(handle_from(pool));
+    tc.draw(
+        hegel::one_of!(
+            hegel::compose!(|tc| { Command::Insert(e, tc.draw(components())) }),
+            hegel::compose!(|tc| { Command::InsertOne(e, tc.draw(kinds()), tc.draw(val())) }),
+            gs::just(Command::RemoveAB(e)),
+            gs::just(Command::RemoveCD(e)),
+            hegel::compose!(|tc| { Command::RemoveOne(e, tc.draw(kinds())) }),
+            gs::just(Command::Despawn(e)),
+        )
+        .print_as_debug(),
+    )
 }
 
 fn record(buffer: &mut CommandBuffer, c: Command, ds: &DropTracker) {

--- a/tests/construction_paths.rs
+++ b/tests/construction_paths.rs
@@ -66,39 +66,6 @@ fn spawn_incrementally(world: &mut World, cs: Components, ds: &DropTracker) -> E
     e
 }
 
-#[derive(Clone, Copy, Debug, hegel::PrettyPrintable)]
-enum Mutation {
-    InsertOne(Kind, i32),
-    RemoveOne(Kind),
-    InsertBundle(Components),
-    RemoveAB,
-    Despawn,
-    ExchangeAToB(i32),
-}
-
-#[hegel::composite]
-fn mutations(tc: &hegel::TestCase) -> Mutation {
-    tc.draw(hegel::one_of!(
-        hegel::compose!(|tc| { Mutation::InsertOne(tc.draw(kinds()), tc.draw(val())) }),
-        hegel::compose!(|tc| { Mutation::RemoveOne(tc.draw(kinds())) }),
-        hegel::compose!(|tc| { Mutation::InsertBundle(tc.draw(components())) }),
-        gs::just(Mutation::RemoveAB),
-        gs::just(Mutation::Despawn),
-        hegel::compose!(|tc| { Mutation::ExchangeAToB(tc.draw(val())) }),
-    ))
-}
-
-fn apply(world: &mut World, e: Entity, m: Mutation, ds: &DropTracker) -> bool {
-    match m {
-        Mutation::InsertOne(kind, v) => kind.insert_one(world, e, v, ds).is_ok(),
-        Mutation::RemoveOne(kind) => kind.remove_one(world, e).is_ok(),
-        Mutation::InsertBundle(cs) => world.insert(e, cs.builder(ds).build()).is_ok(),
-        Mutation::RemoveAB => world.remove::<(A, B)>(e).is_ok(),
-        Mutation::Despawn => world.despawn(e).is_ok(),
-        Mutation::ExchangeAToB(v) => world.exchange_one::<A, B>(e, B(v)).is_ok(),
-    }
-}
-
 /// The same entities built through `EntityBuilder`, static tuple bundles,
 /// `reserve_entity` + `insert`, `CommandBuffer::spawn`, and a chain of
 /// `insert_one` calls are observationally identical, and stay identical under
@@ -186,7 +153,7 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
     let steps = tc.draw(gs::integers::<u32>().min_value(0).max_value(MAX_ENTITIES));
     for _ in 0..steps {
         let e = tc.draw(handle_from(&pool));
-        let m = tc.draw(mutations());
+        let m = tc.draw(ops());
         let mut results = worlds.iter_mut().map(|w| apply(w, e, m, &ds));
         let first = results.next().expect("at least one world");
         for (i, r) in results.enumerate() {

--- a/tests/construction_paths.rs
+++ b/tests/construction_paths.rs
@@ -18,30 +18,30 @@ const ROUTES: usize = 5;
 
 /// Route 2: the static `Bundle` impls, one concrete tuple type per subset of
 /// `{A, B, C, D}`.
-fn spawn_tuple(world: &mut World, cs: Components) -> Entity {
+fn spawn_tuple(world: &mut World, cs: Components, ds: &DropTracker) -> Entity {
     match (cs.a, cs.b, cs.c, cs.d) {
         (None, None, false, None) => world.spawn(()),
         (Some(a), None, false, None) => world.spawn((A(a),)),
         (None, Some(b), false, None) => world.spawn((B(b),)),
         (None, None, true, None) => world.spawn((C,)),
-        (None, None, false, Some(d)) => world.spawn((D::new(d),)),
+        (None, None, false, Some(d)) => world.spawn((D::new(d, ds),)),
         (Some(a), Some(b), false, None) => world.spawn((A(a), B(b))),
         (Some(a), None, true, None) => world.spawn((A(a), C)),
-        (Some(a), None, false, Some(d)) => world.spawn((A(a), D::new(d))),
+        (Some(a), None, false, Some(d)) => world.spawn((A(a), D::new(d, ds))),
         (None, Some(b), true, None) => world.spawn((B(b), C)),
-        (None, Some(b), false, Some(d)) => world.spawn((B(b), D::new(d))),
-        (None, None, true, Some(d)) => world.spawn((C, D::new(d))),
+        (None, Some(b), false, Some(d)) => world.spawn((B(b), D::new(d, ds))),
+        (None, None, true, Some(d)) => world.spawn((C, D::new(d, ds))),
         (Some(a), Some(b), true, None) => world.spawn((A(a), B(b), C)),
-        (Some(a), Some(b), false, Some(d)) => world.spawn((A(a), B(b), D::new(d))),
-        (Some(a), None, true, Some(d)) => world.spawn((A(a), C, D::new(d))),
-        (None, Some(b), true, Some(d)) => world.spawn((B(b), C, D::new(d))),
-        (Some(a), Some(b), true, Some(d)) => world.spawn((A(a), B(b), C, D::new(d))),
+        (Some(a), Some(b), false, Some(d)) => world.spawn((A(a), B(b), D::new(d, ds))),
+        (Some(a), None, true, Some(d)) => world.spawn((A(a), C, D::new(d, ds))),
+        (None, Some(b), true, Some(d)) => world.spawn((B(b), C, D::new(d, ds))),
+        (Some(a), Some(b), true, Some(d)) => world.spawn((A(a), B(b), C, D::new(d, ds))),
     }
 }
 
 /// Route 5: an empty entity migrated through one intermediate archetype per
 /// component.
-fn spawn_incrementally(world: &mut World, cs: Components) -> Entity {
+fn spawn_incrementally(world: &mut World, cs: Components, ds: &DropTracker) -> Entity {
     let e = world.spawn(());
     if let Some(v) = cs.a {
         world
@@ -60,7 +60,7 @@ fn spawn_incrementally(world: &mut World, cs: Components) -> Entity {
     }
     if let Some(v) = cs.d {
         world
-            .insert_one(e, D::new(v))
+            .insert_one(e, D::new(v, ds))
             .expect("insert on a just-spawned entity");
     }
     e
@@ -91,13 +91,13 @@ fn mutations(tc: &hegel::TestCase) -> Mutation {
     ))
 }
 
-fn apply(world: &mut World, e: Entity, m: Mutation) -> bool {
+fn apply(world: &mut World, e: Entity, m: Mutation, ds: &DropTracker) -> bool {
     match m {
         Mutation::InsertOne(which, v) => match which {
             0 => world.insert_one(e, A(v)).is_ok(),
             1 => world.insert_one(e, B(v)).is_ok(),
             2 => world.insert_one(e, C).is_ok(),
-            _ => world.insert_one(e, D::new(v)).is_ok(),
+            _ => world.insert_one(e, D::new(v, ds)).is_ok(),
         },
         Mutation::RemoveOne(which) => match which {
             0 => world.remove_one::<A>(e).is_ok(),
@@ -105,7 +105,7 @@ fn apply(world: &mut World, e: Entity, m: Mutation) -> bool {
             2 => world.remove_one::<C>(e).is_ok(),
             _ => world.remove_one::<D>(e).is_ok(),
         },
-        Mutation::InsertBundle(cs) => world.insert(e, cs.builder().build()).is_ok(),
+        Mutation::InsertBundle(cs) => world.insert(e, cs.builder(ds).build()).is_ok(),
         Mutation::RemoveAB => world.remove::<(A, B)>(e).is_ok(),
         Mutation::Despawn => world.despawn(e).is_ok(),
         Mutation::ExchangeAToB(v) => world.exchange_one::<A, B>(e, B(v)).is_ok(),
@@ -118,30 +118,30 @@ fn apply(world: &mut World, e: Entity, m: Mutation) -> bool {
 /// any subsequent operations.
 #[hegel::test(settings())]
 fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     // A shared history puts every allocator into the same non-trivial state
     // (non-empty freelist, advanced generations) before the routes diverge.
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let (mut worlds, mut pool) = build_twins(&history, ROUTES);
+    let (mut worlds, mut pool) = build_twins(&history, ROUTES, &ds);
 
     let to_spawn: Vec<Components> = tc.draw(gs::vecs(components()).max_size(MAX_ENTITIES as usize));
 
     let mut buffer = CommandBuffer::new();
     for &cs in &to_spawn {
-        buffer.spawn(cs.builder().build());
+        buffer.spawn(cs.builder(&ds).build());
     }
 
     let mut handles: Vec<Vec<Entity>> = Vec::with_capacity(ROUTES);
     handles.push(
         to_spawn
             .iter()
-            .map(|&cs| worlds[0].spawn(cs.builder().build()))
+            .map(|&cs| worlds[0].spawn(cs.builder(&ds).build()))
             .collect(),
     );
     handles.push(
         to_spawn
             .iter()
-            .map(|&cs| spawn_tuple(&mut worlds[1], cs))
+            .map(|&cs| spawn_tuple(&mut worlds[1], cs, &ds))
             .collect(),
     );
     handles.push(
@@ -150,7 +150,7 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
             .map(|&cs| {
                 let e = worlds[2].reserve_entity();
                 worlds[2]
-                    .insert(e, cs.builder().build())
+                    .insert(e, cs.builder(&ds).build())
                     .expect("insert on a freshly reserved entity");
                 e
             })
@@ -162,7 +162,7 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
     handles.push(
         to_spawn
             .iter()
-            .map(|&cs| spawn_incrementally(&mut worlds[4], cs))
+            .map(|&cs| spawn_incrementally(&mut worlds[4], cs, &ds))
             .collect(),
     );
 
@@ -188,7 +188,7 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
         check_archetypes(w, "constructed world");
     }
     assert_eq!(
-        d_live(),
+        ds.live(),
         total_d(&worlds),
         "drop imbalance across construction routes"
     );
@@ -200,7 +200,7 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
     for _ in 0..steps {
         let e = tc.draw(handle_from(&pool));
         let m = tc.draw(mutations());
-        let mut results = worlds.iter_mut().map(|w| apply(w, e, m));
+        let mut results = worlds.iter_mut().map(|w| apply(w, e, m, &ds));
         let first = results.next().expect("at least one world");
         for (i, r) in results.enumerate() {
             assert_eq!(
@@ -220,7 +220,7 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
         }
     }
     assert_eq!(
-        d_live(),
+        ds.live(),
         total_d(&worlds),
         "drop imbalance after the mutation phase"
     );
@@ -259,15 +259,15 @@ fn commands_on(tc: &hegel::TestCase, pool: &[Entity]) -> Command {
     }
 }
 
-fn record(buffer: &mut CommandBuffer, c: Command) {
+fn record(buffer: &mut CommandBuffer, c: Command, ds: &DropTracker) {
     match c {
-        Command::Spawn(cs) => buffer.spawn(cs.builder().build()),
-        Command::Insert(e, cs) => buffer.insert(e, cs.builder().build()),
+        Command::Spawn(cs) => buffer.spawn(cs.builder(ds).build()),
+        Command::Insert(e, cs) => buffer.insert(e, cs.builder(ds).build()),
         Command::InsertOne(e, which, v) => match which {
             0 => buffer.insert_one(e, A(v)),
             1 => buffer.insert_one(e, B(v)),
             2 => buffer.insert_one(e, C),
-            _ => buffer.insert_one(e, D::new(v)),
+            _ => buffer.insert_one(e, D::new(v, ds)),
         },
         Command::RemoveAB(e) => buffer.remove::<(A, B)>(e),
         Command::RemoveCD(e) => buffer.remove::<(C, D)>(e),
@@ -283,17 +283,17 @@ fn record(buffer: &mut CommandBuffer, c: Command) {
 
 /// `run_on` is documented to replay commands in order, ignoring failures, so
 /// each command's eager equivalent discards its error.
-fn apply_eagerly(world: &mut World, c: Command) {
+fn apply_eagerly(world: &mut World, c: Command, ds: &DropTracker) {
     match c {
         Command::Spawn(cs) => {
-            world.spawn(cs.builder().build());
+            world.spawn(cs.builder(ds).build());
         }
-        Command::Insert(e, cs) => drop(world.insert(e, cs.builder().build())),
+        Command::Insert(e, cs) => drop(world.insert(e, cs.builder(ds).build())),
         Command::InsertOne(e, which, v) => match which {
             0 => drop(world.insert_one(e, A(v))),
             1 => drop(world.insert_one(e, B(v))),
             2 => drop(world.insert_one(e, C)),
-            _ => drop(world.insert_one(e, D::new(v))),
+            _ => drop(world.insert_one(e, D::new(v, ds))),
         },
         Command::RemoveAB(e) => drop(world.remove::<(A, B)>(e)),
         Command::RemoveCD(e) => drop(world.remove::<(C, D)>(e)),
@@ -308,11 +308,11 @@ fn apply_eagerly(world: &mut World, c: Command) {
 }
 
 /// How many `D` values a recorded sequence is holding inside the buffer.
-fn pending_d(commands: &[Command]) -> i64 {
+fn pending_d(commands: &[Command]) -> usize {
     commands
         .iter()
         .map(|c| match c {
-            Command::Spawn(cs) | Command::Insert(_, cs) => cs.d.is_some() as i64,
+            Command::Spawn(cs) | Command::Insert(_, cs) => cs.d.is_some() as usize,
             Command::InsertOne(_, 3, _) => 1,
             _ => 0,
         })
@@ -326,9 +326,9 @@ fn pending_d(commands: &[Command]) -> i64 {
 /// the handle the eager `spawn` at the same position did.
 #[hegel::test(settings())]
 fn command_buffer_matches_eager_application(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let (mut worlds, mut pool) = build_twins(&history, 2);
+    let (mut worlds, mut pool) = build_twins(&history, 2, &ds);
 
     // `CommandBuffer::insert` documents `reserve_entity` as the way to obtain a
     // handle for an entity that does not exist yet.
@@ -346,7 +346,7 @@ fn command_buffer_matches_eager_application(tc: hegel::TestCase) {
         let commands: Vec<Command> =
             tc.draw(gs::vecs(commands_on(&pool).print_as_debug()).max_size(12));
         for &c in &commands {
-            record(&mut buffer, c);
+            record(&mut buffer, c, &ds);
         }
 
         // Recording must not touch either world, and every `D` handed to the
@@ -357,7 +357,7 @@ fn command_buffer_matches_eager_application(tc: hegel::TestCase) {
             "recording commands changed a world"
         );
         assert_eq!(
-            d_live(),
+            ds.live(),
             total_d(&worlds) + pending_d(&commands),
             "a buffered D was dropped early or leaked"
         );
@@ -367,7 +367,7 @@ fn command_buffer_matches_eager_application(tc: hegel::TestCase) {
             0 | 1 => {
                 buffer.run_on(&mut worlds[1]);
                 for &c in &commands {
-                    apply_eagerly(&mut worlds[0], c);
+                    apply_eagerly(&mut worlds[0], c, &ds);
                 }
                 assert_eq!(
                     fingerprint(&worlds[0]),
@@ -398,7 +398,7 @@ fn command_buffer_matches_eager_application(tc: hegel::TestCase) {
         }
 
         assert_eq!(
-            d_live(),
+            ds.live(),
             total_d(&worlds),
             "drop imbalance after the buffer was consumed or discarded"
         );

--- a/tests/construction_paths.rs
+++ b/tests/construction_paths.rs
@@ -1,0 +1,428 @@
+//! Differential tests over the several API routes that build the same logical
+//! world, plus `CommandBuffer` against eager application.
+//!
+//! hecs allocates handles deterministically, so worlds built by different
+//! routes from the same drawn specs must be observationally identical — same
+//! handles, same component sets, same values. The specs themselves are the
+//! ground truth, so the routes cannot all agree on a wrong answer. After
+//! construction, the same mutations are applied to every world: internally they
+//! differ (the incremental route left a chain of intermediate archetypes behind,
+//! the tuple route did not), so this phase checks that construction history is
+//! not observable.
+
+mod common;
+
+use common::*;
+use hecs::{CommandBuffer, Entity, World};
+use hegel::generators as gs;
+
+const ROUTES: usize = 5;
+
+/// Route 2: the static `Bundle` impls, one concrete tuple type per subset of
+/// the component universe.
+fn spawn_tuple(world: &mut World, s: Spec) -> Entity {
+    match (s.a, s.b, s.c, s.d) {
+        (None, None, false, None) => world.spawn(()),
+        (Some(a), None, false, None) => world.spawn((A(a),)),
+        (None, Some(b), false, None) => world.spawn((B(b),)),
+        (None, None, true, None) => world.spawn((C,)),
+        (None, None, false, Some(d)) => world.spawn((D::new(d),)),
+        (Some(a), Some(b), false, None) => world.spawn((A(a), B(b))),
+        (Some(a), None, true, None) => world.spawn((A(a), C)),
+        (Some(a), None, false, Some(d)) => world.spawn((A(a), D::new(d))),
+        (None, Some(b), true, None) => world.spawn((B(b), C)),
+        (None, Some(b), false, Some(d)) => world.spawn((B(b), D::new(d))),
+        (None, None, true, Some(d)) => world.spawn((C, D::new(d))),
+        (Some(a), Some(b), true, None) => world.spawn((A(a), B(b), C)),
+        (Some(a), Some(b), false, Some(d)) => world.spawn((A(a), B(b), D::new(d))),
+        (Some(a), None, true, Some(d)) => world.spawn((A(a), C, D::new(d))),
+        (None, Some(b), true, Some(d)) => world.spawn((B(b), C, D::new(d))),
+        (Some(a), Some(b), true, Some(d)) => world.spawn((A(a), B(b), C, D::new(d))),
+    }
+}
+
+/// Route 5: an empty entity migrated through one intermediate archetype per
+/// component.
+fn spawn_incrementally(world: &mut World, s: Spec) -> Entity {
+    let e = world.spawn(());
+    if let Some(v) = s.a {
+        world
+            .insert_one(e, A(v))
+            .expect("insert on a just-spawned entity");
+    }
+    if let Some(v) = s.b {
+        world
+            .insert_one(e, B(v))
+            .expect("insert on a just-spawned entity");
+    }
+    if s.c {
+        world
+            .insert_one(e, C)
+            .expect("insert on a just-spawned entity");
+    }
+    if let Some(v) = s.d {
+        world
+            .insert_one(e, D::new(v))
+            .expect("insert on a just-spawned entity");
+    }
+    e
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Mutation {
+    InsertOne(u8, i32),
+    RemoveOne(u8),
+    InsertBundle(Spec),
+    RemoveAB,
+    Despawn,
+    ExchangeAToB(i32),
+}
+
+hegel::pretty_print_as_debug!(Mutation);
+
+#[hegel::composite]
+fn mutations(tc: &hegel::TestCase) -> Mutation {
+    fn which() -> impl hegel::generators::PrintableGenerator<u8> {
+        gs::integers::<u8>().min_value(0).max_value(3)
+    }
+    tc.draw(hegel::one_of!(
+        hegel::compose!(|tc| { Mutation::InsertOne(tc.draw(which()), tc.draw(val())) }),
+        hegel::compose!(|tc| { Mutation::RemoveOne(tc.draw(which())) }),
+        hegel::compose!(|tc| { Mutation::InsertBundle(tc.draw(specs())) }),
+        gs::just(Mutation::RemoveAB),
+        gs::just(Mutation::Despawn),
+        hegel::compose!(|tc| { Mutation::ExchangeAToB(tc.draw(val())) }),
+    ))
+}
+
+fn apply(world: &mut World, e: Entity, m: Mutation) -> bool {
+    match m {
+        Mutation::InsertOne(which, v) => match which {
+            0 => world.insert_one(e, A(v)).is_ok(),
+            1 => world.insert_one(e, B(v)).is_ok(),
+            2 => world.insert_one(e, C).is_ok(),
+            _ => world.insert_one(e, D::new(v)).is_ok(),
+        },
+        Mutation::RemoveOne(which) => match which {
+            0 => world.remove_one::<A>(e).is_ok(),
+            1 => world.remove_one::<B>(e).is_ok(),
+            2 => world.remove_one::<C>(e).is_ok(),
+            _ => world.remove_one::<D>(e).is_ok(),
+        },
+        Mutation::InsertBundle(s) => world.insert(e, make_builder(s).build()).is_ok(),
+        Mutation::RemoveAB => world.remove::<(A, B)>(e).is_ok(),
+        Mutation::Despawn => world.despawn(e).is_ok(),
+        Mutation::ExchangeAToB(v) => world.exchange_one::<A, B>(e, B(v)).is_ok(),
+    }
+}
+
+/// The same entities built through `EntityBuilder`, static tuple bundles,
+/// `reserve_entity` + `insert`, `CommandBuffer::spawn`, and a chain of
+/// `insert_one` calls are observationally identical, and stay identical under
+/// any subsequent operations.
+#[hegel::test(settings())]
+fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    // A shared history puts every allocator into the same non-trivial state
+    // (non-empty freelist, advanced generations) before the routes diverge.
+    let (mut worlds, mut pool) = build_twins(&tc, ROUTES, MAX_ENTITIES);
+
+    let n = tc.draw(gs::integers::<u32>().min_value(0).max_value(MAX_ENTITIES));
+    let specs: Vec<Spec> = (0..n).map(|_| tc.draw(specs())).collect();
+
+    let mut buffer = CommandBuffer::new();
+    for &s in &specs {
+        buffer.spawn(make_builder(s).build());
+    }
+
+    let mut handles: Vec<Vec<Entity>> = Vec::with_capacity(ROUTES);
+    handles.push(
+        specs
+            .iter()
+            .map(|&s| worlds[0].spawn(make_builder(s).build()))
+            .collect(),
+    );
+    handles.push(
+        specs
+            .iter()
+            .map(|&s| spawn_tuple(&mut worlds[1], s))
+            .collect(),
+    );
+    handles.push(
+        specs
+            .iter()
+            .map(|&s| {
+                let e = worlds[2].reserve_entity();
+                worlds[2]
+                    .insert(e, make_builder(s).build())
+                    .expect("insert on a freshly reserved entity");
+                e
+            })
+            .collect(),
+    );
+    // CommandBuffer does not surface the handles it allocates; they are
+    // recovered from the fingerprint comparison below.
+    buffer.run_on(&mut worlds[3]);
+    handles.push(
+        specs
+            .iter()
+            .map(|&s| spawn_incrementally(&mut worlds[4], s))
+            .collect(),
+    );
+
+    for (i, route) in handles.iter().enumerate().skip(1) {
+        assert_eq!(&handles[0], route, "route {i} allocated different handles");
+    }
+    pool.extend(handles[0].iter().copied());
+
+    let expected = fingerprint(&worlds[0]);
+    for (e, s) in handles[0].iter().zip(&specs) {
+        assert_eq!(
+            expected.get(e),
+            Some(s),
+            "the builder route disagrees with the spec for {e:?}"
+        );
+    }
+    for (i, w) in worlds.iter().enumerate().skip(1) {
+        assert_eq!(
+            expected,
+            fingerprint(w),
+            "route {i} built an observationally different world"
+        );
+        check_archetypes(w, "constructed world");
+    }
+    assert_eq!(
+        d_live(),
+        total_d(&worlds),
+        "drop imbalance across construction routes"
+    );
+
+    let steps = tc.draw(gs::integers::<u32>().min_value(0).max_value(MAX_ENTITIES));
+    for _ in 0..steps {
+        let Some(e) = pick(&tc, &pool) else { break };
+        let m = tc.draw(mutations());
+        let mut results = worlds.iter_mut().map(|w| apply(w, e, m));
+        let first = results.next().expect("at least one world");
+        for (i, r) in results.enumerate() {
+            assert_eq!(
+                first,
+                r,
+                "{m:?} on {e:?} returned a different result in route {}",
+                i + 1
+            );
+        }
+        let after = fingerprint(&worlds[0]);
+        for (i, w) in worlds.iter().enumerate().skip(1) {
+            assert_eq!(
+                after,
+                fingerprint(w),
+                "route {i} diverged after {m:?} on {e:?}"
+            );
+        }
+    }
+    assert_eq!(
+        d_live(),
+        total_d(&worlds),
+        "drop imbalance after the mutation phase"
+    );
+}
+
+/// One logical operation, recorded into a `CommandBuffer` and also applied
+/// directly.
+#[derive(Clone, Copy, Debug)]
+enum Command {
+    Spawn(Spec),
+    Insert(Entity, Spec),
+    InsertOne(Entity, u8, i32),
+    RemoveAB(Entity),
+    RemoveCD(Entity),
+    RemoveOne(Entity, u8),
+    Despawn(Entity),
+}
+
+hegel::pretty_print_as_debug!(Command);
+
+fn record(buffer: &mut CommandBuffer, c: Command) {
+    match c {
+        Command::Spawn(s) => buffer.spawn(make_builder(s).build()),
+        Command::Insert(e, s) => buffer.insert(e, make_builder(s).build()),
+        Command::InsertOne(e, which, v) => match which {
+            0 => buffer.insert_one(e, A(v)),
+            1 => buffer.insert_one(e, B(v)),
+            2 => buffer.insert_one(e, C),
+            _ => buffer.insert_one(e, D::new(v)),
+        },
+        Command::RemoveAB(e) => buffer.remove::<(A, B)>(e),
+        Command::RemoveCD(e) => buffer.remove::<(C, D)>(e),
+        Command::RemoveOne(e, which) => match which {
+            0 => buffer.remove_one::<A>(e),
+            1 => buffer.remove_one::<B>(e),
+            2 => buffer.remove_one::<C>(e),
+            _ => buffer.remove_one::<D>(e),
+        },
+        Command::Despawn(e) => buffer.despawn(e),
+    }
+}
+
+/// `run_on` is documented to replay commands in order, ignoring failures, so
+/// each command's eager equivalent discards its error.
+fn apply_eagerly(world: &mut World, c: Command) {
+    match c {
+        Command::Spawn(s) => {
+            world.spawn(make_builder(s).build());
+        }
+        Command::Insert(e, s) => drop(world.insert(e, make_builder(s).build())),
+        Command::InsertOne(e, which, v) => match which {
+            0 => drop(world.insert_one(e, A(v))),
+            1 => drop(world.insert_one(e, B(v))),
+            2 => drop(world.insert_one(e, C)),
+            _ => drop(world.insert_one(e, D::new(v))),
+        },
+        Command::RemoveAB(e) => drop(world.remove::<(A, B)>(e)),
+        Command::RemoveCD(e) => drop(world.remove::<(C, D)>(e)),
+        Command::RemoveOne(e, which) => match which {
+            0 => drop(world.remove_one::<A>(e)),
+            1 => drop(world.remove_one::<B>(e)),
+            2 => drop(world.remove_one::<C>(e)),
+            _ => drop(world.remove_one::<D>(e)),
+        },
+        Command::Despawn(e) => drop(world.despawn(e)),
+    }
+}
+
+/// How many `D` values a recorded sequence is holding inside the buffer.
+fn pending_d(commands: &[Command]) -> i64 {
+    commands
+        .iter()
+        .map(|c| match c {
+            Command::Spawn(s) | Command::Insert(_, s) => s.d.is_some() as i64,
+            Command::InsertOne(_, 3, _) => 1,
+            _ => 0,
+        })
+        .sum()
+}
+
+/// Replaying a `CommandBuffer` is equivalent to applying the same operations
+/// directly and ignoring failures. Comparing the worlds exactly (handles
+/// included) is well-defined because both undergo the same logical sequence,
+/// so `CommandBuffer::spawn` — whose handle is never surfaced — must allocate
+/// the handle the eager `spawn` at the same position did.
+#[hegel::test(settings())]
+fn command_buffer_matches_eager_application(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let (mut worlds, mut pool) = build_twins(&tc, 2, MAX_ENTITIES);
+
+    // `CommandBuffer::insert` documents `reserve_entity` as the way to obtain a
+    // handle for an entity that does not exist yet.
+    if tc.draw(gs::booleans()) {
+        let k = tc.draw(gs::integers::<u32>().min_value(1).max_value(3));
+        for _ in 0..k {
+            let eager = worlds[0].reserve_entity();
+            let buffered = worlds[1].reserve_entity();
+            assert_eq!(eager, buffered, "reserve_entity was not deterministic");
+            pool.push(eager);
+        }
+    }
+
+    let mut buffer = CommandBuffer::new();
+    let rounds = tc.draw(gs::integers::<u32>().min_value(1).max_value(4));
+    for _ in 0..rounds {
+        let mut commands: Vec<Command> = Vec::new();
+        let n = tc.draw(gs::integers::<u32>().min_value(0).max_value(12));
+        for _ in 0..n {
+            let which = gs::integers::<u8>().min_value(0).max_value(3);
+            // Weighted rather than a `one_of!`: two of the eight indices spawn,
+            // so the pool grows fast enough for the other commands to have
+            // entities to act on.
+            let c = match tc.draw(gs::integers::<u8>().min_value(0).max_value(7)) {
+                0 | 1 => Command::Spawn(tc.draw(specs())),
+                2 => match pick(&tc, &pool) {
+                    Some(e) => Command::Insert(e, tc.draw(specs())),
+                    None => continue,
+                },
+                3 => match pick(&tc, &pool) {
+                    Some(e) => Command::InsertOne(e, tc.draw(which), tc.draw(val())),
+                    None => continue,
+                },
+                4 => match pick(&tc, &pool) {
+                    Some(e) => Command::RemoveAB(e),
+                    None => continue,
+                },
+                5 => match pick(&tc, &pool) {
+                    Some(e) => Command::RemoveCD(e),
+                    None => continue,
+                },
+                6 => match pick(&tc, &pool) {
+                    Some(e) => Command::RemoveOne(e, tc.draw(which)),
+                    None => continue,
+                },
+                _ => match pick(&tc, &pool) {
+                    Some(e) => Command::Despawn(e),
+                    None => continue,
+                },
+            };
+            record(&mut buffer, c);
+            commands.push(c);
+        }
+
+        // Recording must not touch either world, and every `D` handed to the
+        // buffer must still be alive and unduplicated inside it.
+        assert_eq!(
+            fingerprint(&worlds[0]),
+            fingerprint(&worlds[1]),
+            "recording commands changed a world"
+        );
+        assert_eq!(
+            d_live(),
+            total_d(&worlds) + pending_d(&commands),
+            "a buffered D was dropped early or leaked"
+        );
+
+        match tc.draw(gs::integers::<u8>().min_value(0).max_value(3)) {
+            0 | 1 => {
+                buffer.run_on(&mut worlds[1]);
+                for &c in &commands {
+                    apply_eagerly(&mut worlds[0], c);
+                }
+                assert_eq!(
+                    fingerprint(&worlds[0]),
+                    fingerprint(&worlds[1]),
+                    "run_on diverged from eager application"
+                );
+                // `run_on` empties the buffer, so replaying it is a no-op and
+                // the buffer is reusable for the next round.
+                buffer.run_on(&mut worlds[1]);
+                assert_eq!(
+                    fingerprint(&worlds[0]),
+                    fingerprint(&worlds[1]),
+                    "a second run_on applied the commands again"
+                );
+            }
+            // `clear` discards the recorded commands.
+            2 => {
+                buffer.clear();
+                buffer.run_on(&mut worlds[1]);
+                assert_eq!(
+                    fingerprint(&worlds[0]),
+                    fingerprint(&worlds[1]),
+                    "commands survived clear()"
+                );
+            }
+            // Dropping a non-empty buffer must release its stored components.
+            _ => buffer = CommandBuffer::new(),
+        }
+
+        assert_eq!(
+            d_live(),
+            total_d(&worlds),
+            "drop imbalance after the buffer was consumed or discarded"
+        );
+
+        for eref in worlds[0].iter() {
+            let e = eref.entity();
+            if !pool.contains(&e) {
+                pool.push(e);
+            }
+        }
+    }
+}

--- a/tests/construction_paths.rs
+++ b/tests/construction_paths.rs
@@ -10,9 +10,7 @@
 //! the tuple route did not), so this phase checks that construction history is
 //! not observable.
 
-mod common;
-
-use common::*;
+use fixtures::*;
 use hecs::{CommandBuffer, Entity, World};
 use hegel::generators::{self as gs, Generator};
 

--- a/tests/construction_paths.rs
+++ b/tests/construction_paths.rs
@@ -2,9 +2,9 @@
 //! world, plus `CommandBuffer` against eager application.
 //!
 //! hecs allocates handles deterministically, so worlds built by different
-//! routes from the same drawn specs must be observationally identical — same
-//! handles, same component sets, same values. The specs themselves are the
-//! ground truth, so the routes cannot all agree on a wrong answer. After
+//! routes from the same drawn components must be observationally identical:
+//! same handles, same component sets, same values. The drawn components are
+//! the ground truth, so the routes cannot all agree on a wrong answer. After
 //! construction, the same mutations are applied to every world: internally they
 //! differ (the incremental route left a chain of intermediate archetypes behind,
 //! the tuple route did not), so this phase checks that construction history is
@@ -17,9 +17,9 @@ use hegel::generators::{self as gs, Generator};
 const ROUTES: usize = 5;
 
 /// Route 2: the static `Bundle` impls, one concrete tuple type per subset of
-/// the component universe.
-fn spawn_tuple(world: &mut World, s: Spec) -> Entity {
-    match (s.a, s.b, s.c, s.d) {
+/// `{A, B, C, D}`.
+fn spawn_tuple(world: &mut World, cs: Components) -> Entity {
+    match (cs.a, cs.b, cs.c, cs.d) {
         (None, None, false, None) => world.spawn(()),
         (Some(a), None, false, None) => world.spawn((A(a),)),
         (None, Some(b), false, None) => world.spawn((B(b),)),
@@ -41,24 +41,24 @@ fn spawn_tuple(world: &mut World, s: Spec) -> Entity {
 
 /// Route 5: an empty entity migrated through one intermediate archetype per
 /// component.
-fn spawn_incrementally(world: &mut World, s: Spec) -> Entity {
+fn spawn_incrementally(world: &mut World, cs: Components) -> Entity {
     let e = world.spawn(());
-    if let Some(v) = s.a {
+    if let Some(v) = cs.a {
         world
             .insert_one(e, A(v))
             .expect("insert on a just-spawned entity");
     }
-    if let Some(v) = s.b {
+    if let Some(v) = cs.b {
         world
             .insert_one(e, B(v))
             .expect("insert on a just-spawned entity");
     }
-    if s.c {
+    if cs.c {
         world
             .insert_one(e, C)
             .expect("insert on a just-spawned entity");
     }
-    if let Some(v) = s.d {
+    if let Some(v) = cs.d {
         world
             .insert_one(e, D::new(v))
             .expect("insert on a just-spawned entity");
@@ -70,7 +70,7 @@ fn spawn_incrementally(world: &mut World, s: Spec) -> Entity {
 enum Mutation {
     InsertOne(u8, i32),
     RemoveOne(u8),
-    InsertBundle(Spec),
+    InsertBundle(Components),
     RemoveAB,
     Despawn,
     ExchangeAToB(i32),
@@ -84,7 +84,7 @@ fn mutations(tc: &hegel::TestCase) -> Mutation {
     tc.draw(hegel::one_of!(
         hegel::compose!(|tc| { Mutation::InsertOne(tc.draw(which()), tc.draw(val())) }),
         hegel::compose!(|tc| { Mutation::RemoveOne(tc.draw(which())) }),
-        hegel::compose!(|tc| { Mutation::InsertBundle(tc.draw(specs())) }),
+        hegel::compose!(|tc| { Mutation::InsertBundle(tc.draw(components())) }),
         gs::just(Mutation::RemoveAB),
         gs::just(Mutation::Despawn),
         hegel::compose!(|tc| { Mutation::ExchangeAToB(tc.draw(val())) }),
@@ -105,7 +105,7 @@ fn apply(world: &mut World, e: Entity, m: Mutation) -> bool {
             2 => world.remove_one::<C>(e).is_ok(),
             _ => world.remove_one::<D>(e).is_ok(),
         },
-        Mutation::InsertBundle(s) => world.insert(e, make_builder(s).build()).is_ok(),
+        Mutation::InsertBundle(cs) => world.insert(e, cs.builder().build()).is_ok(),
         Mutation::RemoveAB => world.remove::<(A, B)>(e).is_ok(),
         Mutation::Despawn => world.despawn(e).is_ok(),
         Mutation::ExchangeAToB(v) => world.exchange_one::<A, B>(e, B(v)).is_ok(),
@@ -124,33 +124,33 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
     let history = tc.draw(histories(0, MAX_ENTITIES));
     let (mut worlds, mut pool) = build_twins(&history, ROUTES);
 
-    let specs: Vec<Spec> = tc.draw(gs::vecs(specs()).max_size(MAX_ENTITIES as usize));
+    let to_spawn: Vec<Components> = tc.draw(gs::vecs(components()).max_size(MAX_ENTITIES as usize));
 
     let mut buffer = CommandBuffer::new();
-    for &s in &specs {
-        buffer.spawn(make_builder(s).build());
+    for &cs in &to_spawn {
+        buffer.spawn(cs.builder().build());
     }
 
     let mut handles: Vec<Vec<Entity>> = Vec::with_capacity(ROUTES);
     handles.push(
-        specs
+        to_spawn
             .iter()
-            .map(|&s| worlds[0].spawn(make_builder(s).build()))
+            .map(|&cs| worlds[0].spawn(cs.builder().build()))
             .collect(),
     );
     handles.push(
-        specs
+        to_spawn
             .iter()
-            .map(|&s| spawn_tuple(&mut worlds[1], s))
+            .map(|&cs| spawn_tuple(&mut worlds[1], cs))
             .collect(),
     );
     handles.push(
-        specs
+        to_spawn
             .iter()
-            .map(|&s| {
+            .map(|&cs| {
                 let e = worlds[2].reserve_entity();
                 worlds[2]
-                    .insert(e, make_builder(s).build())
+                    .insert(e, cs.builder().build())
                     .expect("insert on a freshly reserved entity");
                 e
             })
@@ -160,9 +160,9 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
     // recovered from the fingerprint comparison below.
     buffer.run_on(&mut worlds[3]);
     handles.push(
-        specs
+        to_spawn
             .iter()
-            .map(|&s| spawn_incrementally(&mut worlds[4], s))
+            .map(|&cs| spawn_incrementally(&mut worlds[4], cs))
             .collect(),
     );
 
@@ -172,11 +172,11 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
     pool.extend(handles[0].iter().copied());
 
     let expected = fingerprint(&worlds[0]);
-    for (e, s) in handles[0].iter().zip(&specs) {
+    for (e, cs) in handles[0].iter().zip(&to_spawn) {
         assert_eq!(
             expected.get(e),
-            Some(s),
-            "the builder route disagrees with the spec for {e:?}"
+            Some(cs),
+            "the builder route disagrees with the drawn components for {e:?}"
         );
     }
     for (i, w) in worlds.iter().enumerate().skip(1) {
@@ -198,7 +198,7 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
     }
     let steps = tc.draw(gs::integers::<u32>().min_value(0).max_value(MAX_ENTITIES));
     for _ in 0..steps {
-        let e = tc.draw(pick(&pool));
+        let e = tc.draw(handle_from(&pool));
         let m = tc.draw(mutations());
         let mut results = worlds.iter_mut().map(|w| apply(w, e, m));
         let first = results.next().expect("at least one world");
@@ -230,8 +230,8 @@ fn construction_routes_are_observationally_equal(tc: hegel::TestCase) {
 /// directly.
 #[derive(Clone, Copy, Debug)]
 enum Command {
-    Spawn(Spec),
-    Insert(Entity, Spec),
+    Spawn(Components),
+    Insert(Entity, Components),
     InsertOne(Entity, u8, i32),
     RemoveAB(Entity),
     RemoveCD(Entity),
@@ -249,20 +249,20 @@ fn commands_on(tc: &hegel::TestCase, pool: &[Entity]) -> Command {
         .min_value(0)
         .max_value(if pool.is_empty() { 1 } else { 7 });
     match tc.draw(kinds) {
-        0 | 1 => Command::Spawn(tc.draw(specs())),
-        2 => Command::Insert(tc.draw(pick(pool)), tc.draw(specs())),
-        3 => Command::InsertOne(tc.draw(pick(pool)), tc.draw(which), tc.draw(val())),
-        4 => Command::RemoveAB(tc.draw(pick(pool))),
-        5 => Command::RemoveCD(tc.draw(pick(pool))),
-        6 => Command::RemoveOne(tc.draw(pick(pool)), tc.draw(which)),
-        _ => Command::Despawn(tc.draw(pick(pool))),
+        0 | 1 => Command::Spawn(tc.draw(components())),
+        2 => Command::Insert(tc.draw(handle_from(pool)), tc.draw(components())),
+        3 => Command::InsertOne(tc.draw(handle_from(pool)), tc.draw(which), tc.draw(val())),
+        4 => Command::RemoveAB(tc.draw(handle_from(pool))),
+        5 => Command::RemoveCD(tc.draw(handle_from(pool))),
+        6 => Command::RemoveOne(tc.draw(handle_from(pool)), tc.draw(which)),
+        _ => Command::Despawn(tc.draw(handle_from(pool))),
     }
 }
 
 fn record(buffer: &mut CommandBuffer, c: Command) {
     match c {
-        Command::Spawn(s) => buffer.spawn(make_builder(s).build()),
-        Command::Insert(e, s) => buffer.insert(e, make_builder(s).build()),
+        Command::Spawn(cs) => buffer.spawn(cs.builder().build()),
+        Command::Insert(e, cs) => buffer.insert(e, cs.builder().build()),
         Command::InsertOne(e, which, v) => match which {
             0 => buffer.insert_one(e, A(v)),
             1 => buffer.insert_one(e, B(v)),
@@ -285,10 +285,10 @@ fn record(buffer: &mut CommandBuffer, c: Command) {
 /// each command's eager equivalent discards its error.
 fn apply_eagerly(world: &mut World, c: Command) {
     match c {
-        Command::Spawn(s) => {
-            world.spawn(make_builder(s).build());
+        Command::Spawn(cs) => {
+            world.spawn(cs.builder().build());
         }
-        Command::Insert(e, s) => drop(world.insert(e, make_builder(s).build())),
+        Command::Insert(e, cs) => drop(world.insert(e, cs.builder().build())),
         Command::InsertOne(e, which, v) => match which {
             0 => drop(world.insert_one(e, A(v))),
             1 => drop(world.insert_one(e, B(v))),
@@ -312,7 +312,7 @@ fn pending_d(commands: &[Command]) -> i64 {
     commands
         .iter()
         .map(|c| match c {
-            Command::Spawn(s) | Command::Insert(_, s) => s.d.is_some() as i64,
+            Command::Spawn(cs) | Command::Insert(_, cs) => cs.d.is_some() as i64,
             Command::InsertOne(_, 3, _) => 1,
             _ => 0,
         })

--- a/tests/fixtures/Cargo.toml
+++ b/tests/fixtures/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "fixtures"
+description = "Shared fixtures for the property tests in ../"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+hecs = { path = "../..", default-features = false }
+hegel = { package = "hegeltest", version = "0.35.0" }
+serde = { version = "1.0.117", features = ["derive"] }

--- a/tests/fixtures/src/lib.rs
+++ b/tests/fixtures/src/lib.rs
@@ -1,4 +1,4 @@
-//! Shared fixtures for the property tests: a fixed component universe, an
+//! Shared fixtures for the property tests: four component types, an
 //! observational fingerprint of a `World`, and twin worlds replayed from one
 //! generated history.
 
@@ -9,8 +9,8 @@ use hecs::{Entity, EntityBuilder, World};
 use hegel::generators::{self as gs, Generator};
 use serde::{Deserialize, Deserializer, Serialize};
 
-/// Component universe: two same-shaped payload components, a zero-sized marker,
-/// and a drop-tracked non-`Copy` component.
+/// The component types the tests use: two same-shaped payload components, a
+/// zero-sized marker, and a drop-tracked non-`Copy` component.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct A(pub i32);
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -95,37 +95,57 @@ pub fn val() -> impl gs::PrintableGenerator<i32> {
     gs::integers::<i32>().min_value(-3).max_value(3)
 }
 
-/// A handle from `pool`, which deliberately retains despawned handles. `pool`
-/// must not be empty.
-pub fn pick(pool: &[Entity]) -> impl gs::PrintableGenerator<Entity> + '_ {
-    gs::sampled_from(pool).print_as_debug()
+/// One of `handles`, drawn uniformly: `sampled_from` made printable, since
+/// `Entity` is not `PrettyPrintable`. Callers pass every handle their world
+/// has issued, despawned ones included, so a draw often names a dead entity
+/// and the `NoSuchEntity` paths get exercised too. `handles` must not be
+/// empty.
+pub fn handle_from(handles: &[Entity]) -> impl gs::PrintableGenerator<Entity> + '_ {
+    gs::sampled_from(handles).print_as_debug()
 }
 
-/// An arbitrary subset of the component universe, as drawn payloads. `D`
-/// instances are materialized only when a bundle is built, so the drop count
-/// tracks exactly the instances that entered a world.
+/// The components of one entity: the payloads of its `A`, `B` and `D`, and
+/// whether it has a `C`. `D` payloads stay as `i32` here and become `D`
+/// values in `builder`, so the drop count only ever counts values that were
+/// handed to hecs.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, hegel::PrettyPrintable)]
-pub struct Spec {
+pub struct Components {
     pub a: Option<i32>,
     pub b: Option<i32>,
     pub c: bool,
     pub d: Option<i32>,
 }
 
-impl Spec {
-    /// How many components an entity built from this spec has.
+impl Components {
     pub fn component_count(&self) -> usize {
         self.a.is_some() as usize
             + self.b.is_some() as usize
             + self.c as usize
             + self.d.is_some() as usize
     }
+
+    pub fn builder(&self) -> EntityBuilder {
+        let mut b = EntityBuilder::new();
+        if let Some(v) = self.a {
+            b.add(A(v));
+        }
+        if let Some(v) = self.b {
+            b.add(B(v));
+        }
+        if self.c {
+            b.add(C);
+        }
+        if let Some(v) = self.d {
+            b.add(D::new(v));
+        }
+        b
+    }
 }
 
-/// An arbitrary component subset.
+/// Each component present or absent independently, with a drawn payload.
 #[hegel::composite]
-pub fn specs(tc: &hegel::TestCase) -> Spec {
-    Spec {
+pub fn components(tc: &hegel::TestCase) -> Components {
+    Components {
         a: tc.draw(gs::optional(val())),
         b: tc.draw(gs::optional(val())),
         c: tc.draw(gs::booleans()),
@@ -133,39 +153,22 @@ pub fn specs(tc: &hegel::TestCase) -> Spec {
     }
 }
 
-/// `specs()` without `D`, which is not `Clone` and so cannot go into an
+/// `components()` without `D`, which is not `Clone` and so cannot go into an
 /// `EntityBuilderClone`.
-pub fn specs_without_d() -> impl gs::PrintableGenerator<Spec> {
-    specs().map(|s| Spec { d: None, ..s })
-}
-
-pub fn make_builder(s: Spec) -> EntityBuilder {
-    let mut b = EntityBuilder::new();
-    if let Some(v) = s.a {
-        b.add(A(v));
-    }
-    if let Some(v) = s.b {
-        b.add(B(v));
-    }
-    if s.c {
-        b.add(C);
-    }
-    if let Some(v) = s.d {
-        b.add(D::new(v));
-    }
-    b
+pub fn components_without_d() -> impl gs::PrintableGenerator<Components> {
+    components().map(|cs| Components { d: None, ..cs })
 }
 
 /// Canonical snapshot of everything a caller can observe about a `World`: the
 /// exact `Entity` handles (id and generation) and, per entity, the exact
 /// component set and values. Two worlds are observationally equivalent iff
 /// their fingerprints compare equal.
-pub type Fingerprint = BTreeMap<Entity, Spec>;
+pub type Fingerprint = BTreeMap<Entity, Components>;
 
 pub fn fingerprint(world: &World) -> Fingerprint {
     let mut fp = Fingerprint::new();
     for eref in world.iter() {
-        let obs = Spec {
+        let obs = Components {
             a: eref.get::<&A>().map(|r| r.0),
             b: eref.get::<&B>().map(|r| r.0),
             c: eref.get::<&C>().is_some(),
@@ -223,11 +226,12 @@ pub fn check_archetypes(world: &World, label: &str) {
     );
 }
 
-/// One step of a world's history: spawn an entity from a spec, or despawn the
-/// `i`th entity spawned so far, which is still live at that point.
+/// One step of a world's history: spawn an entity with the given components,
+/// or despawn the `i`th entity spawned so far, which is still live at that
+/// point.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, hegel::PrettyPrintable)]
 pub enum Step {
-    Spawn(Spec),
+    Spawn(Components),
     Despawn(usize),
 }
 
@@ -251,7 +255,7 @@ pub fn histories(tc: &hegel::TestCase, min_steps: u32, max_steps: u32) -> Vec<St
             live.retain(|&l| l != i);
             steps.push(Step::Despawn(i));
         } else {
-            steps.push(Step::Spawn(tc.draw(specs())));
+            steps.push(Step::Spawn(tc.draw(components())));
             live.push(spawned);
             spawned += 1;
         }
@@ -271,8 +275,8 @@ pub fn build_twins(history: &[Step], n_worlds: usize) -> (Vec<World>, Vec<Entity
     let mut pool: Vec<Entity> = Vec::new();
     for step in history {
         match *step {
-            Step::Spawn(s) => {
-                let mut handles = worlds.iter_mut().map(|w| w.spawn(make_builder(s).build()));
+            Step::Spawn(cs) => {
+                let mut handles = worlds.iter_mut().map(|w| w.spawn(cs.builder().build()));
                 let first = handles.next().expect("at least one world");
                 for h in handles {
                     assert_eq!(first, h, "twin worlds allocated different handles");

--- a/tests/fixtures/src/lib.rs
+++ b/tests/fixtures/src/lib.rs
@@ -1,10 +1,6 @@
 //! Shared fixtures for the property tests: a fixed component universe, an
 //! observational fingerprint of a `World`, and twin worlds replayed from one
 //! generated history.
-//!
-//! Each integration-test binary compiles this module separately, so parts of it
-//! are unused in some binaries.
-#![allow(dead_code)]
 
 use std::cell::Cell;
 use std::collections::{BTreeMap, HashSet};
@@ -186,7 +182,7 @@ pub fn fingerprint(world: &World) -> Fingerprint {
 }
 
 /// How many live `D` components a fingerprint accounts for.
-pub fn fingerprint_d_count(fp: &Fingerprint) -> i64 {
+fn fingerprint_d_count(fp: &Fingerprint) -> i64 {
     fp.values().filter(|o| o.d.is_some()).count() as i64
 }
 

--- a/tests/fixtures/src/lib.rs
+++ b/tests/fixtures/src/lib.rs
@@ -103,11 +103,10 @@ pub fn settings() -> hegel::Settings {
 /// any hecs contract.
 pub const MAX_ENTITIES: u32 = if cfg!(miri) { 4 } else { 8 };
 
-/// Component payloads are small so that distinct values recur across entities,
-/// which is what makes a swapped or stale component visible. Bounds are
-/// inclusive.
+/// Any `i32`, so that two entities rarely hold the same payload and a swapped
+/// or stale component shows up as a wrong value.
 pub fn val() -> impl gs::PrintableGenerator<i32> {
-    gs::integers::<i32>().min_value(-3).max_value(3)
+    gs::integers::<i32>()
 }
 
 /// One of `handles`, drawn uniformly: `sampled_from` made printable, since

--- a/tests/fixtures/src/lib.rs
+++ b/tests/fixtures/src/lib.rs
@@ -275,6 +275,61 @@ pub fn components_without_d() -> impl gs::PrintableGenerator<Components> {
     components().map(|cs| Components { d: None, ..cs })
 }
 
+/// A single-entity operation, for tests that apply one operation to several
+/// worlds. Spawning is excluded: the handle a spawn returns depends on
+/// allocation order, so spawns do not commute.
+#[derive(Clone, Copy, Debug, hegel::PrettyPrintable)]
+pub enum Op {
+    InsertOne(Kind, i32),
+    RemoveOne(Kind),
+    InsertBundle(Components),
+    RemoveAB,
+    RemoveCD,
+    Despawn,
+    Take,
+    MutateA(i32),
+    ExchangeAToB(i32),
+    ExchangeDToA(i32),
+}
+
+#[hegel::composite]
+pub fn ops(tc: &hegel::TestCase) -> Op {
+    tc.draw(hegel::one_of!(
+        hegel::compose!(|tc| { Op::InsertOne(tc.draw(kinds()), tc.draw(val())) }),
+        hegel::compose!(|tc| { Op::RemoveOne(tc.draw(kinds())) }),
+        hegel::compose!(|tc| { Op::InsertBundle(tc.draw(components())) }),
+        gs::just(Op::RemoveAB),
+        gs::just(Op::RemoveCD),
+        gs::just(Op::Despawn),
+        gs::just(Op::Take),
+        hegel::compose!(|tc| { Op::MutateA(tc.draw(val())) }),
+        hegel::compose!(|tc| { Op::ExchangeAToB(tc.draw(val())) }),
+        hegel::compose!(|tc| { Op::ExchangeDToA(tc.draw(val())) }),
+    ))
+}
+
+/// Apply `op` to `e` and report whether it succeeded.
+pub fn apply(world: &mut World, e: Entity, op: Op, ds: &DropTracker) -> bool {
+    match op {
+        Op::InsertOne(kind, v) => kind.insert_one(world, e, v, ds).is_ok(),
+        Op::RemoveOne(kind) => kind.remove_one(world, e).is_ok(),
+        Op::InsertBundle(cs) => world.insert(e, cs.builder(ds).build()).is_ok(),
+        Op::RemoveAB => world.remove::<(A, B)>(e).is_ok(),
+        Op::RemoveCD => world.remove::<(C, D)>(e).is_ok(),
+        Op::Despawn => world.despawn(e).is_ok(),
+        Op::Take => world.take(e).is_ok(),
+        Op::MutateA(v) => match world.get::<&mut A>(e) {
+            Ok(mut a) => {
+                a.0 = v;
+                true
+            }
+            Err(_) => false,
+        },
+        Op::ExchangeAToB(v) => world.exchange_one::<A, B>(e, B(v)).is_ok(),
+        Op::ExchangeDToA(v) => world.exchange_one::<D, A>(e, A(v)).is_ok(),
+    }
+}
+
 /// Canonical snapshot of everything a caller can observe about a `World`: the
 /// exact `Entity` handles (id and generation) and, per entity, the exact
 /// component set and values. Two worlds are observationally equivalent iff

--- a/tests/fixtures/src/lib.rs
+++ b/tests/fixtures/src/lib.rs
@@ -138,7 +138,8 @@ pub fn kinds() -> impl gs::PrintableGenerator<Kind> {
 }
 
 impl Kind {
-    /// `insert_one` of this kind's component with payload `v`; `C` has none.
+    /// `insert_one` of this kind's component, with payload `v` where it has
+    /// one.
     pub fn insert_one(
         self,
         world: &mut World,
@@ -154,7 +155,7 @@ impl Kind {
         }
     }
 
-    /// `remove_one` of this kind's component; the removed value is dropped.
+    /// `remove_one` of this kind's component. The removed value is dropped.
     pub fn remove_one(self, world: &mut World, e: Entity) -> Result<(), ComponentError> {
         match self {
             Kind::A => world.remove_one::<A>(e).map(drop),

--- a/tests/fixtures/src/lib.rs
+++ b/tests/fixtures/src/lib.rs
@@ -2,12 +2,14 @@
 //! observational fingerprint of a `World`, and twin worlds replayed from one
 //! generated history.
 
-use std::cell::Cell;
 use std::collections::{BTreeMap, HashSet};
+use std::fmt;
+use std::sync::Arc;
 
 use hecs::{Entity, EntityBuilder, World};
 use hegel::generators::{self as gs, Generator};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::de::DeserializeSeed;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// The component types the tests use: two same-shaped payload components, a
 /// zero-sized marker, and a drop-tracked non-`Copy` component.
@@ -18,42 +20,63 @@ pub struct B(pub i32);
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct C;
 
-thread_local! { static D_LIVE: Cell<i64> = const { Cell::new(0) }; }
+/// Counts live `D` values: each holds a clone of the `Arc`, so the strong
+/// count is one more than the number alive. A leak or a double drop in hecs's
+/// unsafe component moves shows up as a count that disagrees with the worlds'
+/// contents.
+#[derive(Default)]
+pub struct DropTracker(Arc<()>);
 
-/// Every `D` is constructed through `D::new`, which bumps a thread-local count
-/// that `Drop` decrements, so a leak or double-drop in hecs's unsafe component
-/// moves shows up as a count that disagrees with the world's contents.
-#[derive(Debug, Serialize)]
-pub struct D(pub i32);
+impl DropTracker {
+    pub fn new() -> DropTracker {
+        DropTracker::default()
+    }
+
+    /// How many `D` values made from this tracker are alive.
+    pub fn live(&self) -> usize {
+        Arc::strong_count(&self.0) - 1
+    }
+}
+
+/// A non-`Copy` component counted by the `DropTracker` it was made from.
+pub struct D {
+    pub value: i32,
+    _live: Arc<()>,
+}
 
 impl D {
-    pub fn new(v: i32) -> D {
-        D_LIVE.with(|c| c.set(c.get() + 1));
-        D(v)
+    pub fn new(value: i32, ds: &DropTracker) -> D {
+        D {
+            value,
+            _live: ds.0.clone(),
+        }
     }
 }
 
-impl Drop for D {
-    fn drop(&mut self) {
-        D_LIVE.with(|c| c.set(c.get() - 1));
+impl fmt::Debug for D {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("D").field(&self.value).finish()
     }
 }
 
-impl<'de> Deserialize<'de> for D {
-    fn deserialize<De: Deserializer<'de>>(de: De) -> Result<Self, De::Error> {
-        i32::deserialize(de).map(D::new)
+/// The wire form is the payload alone, as `#[derive(Serialize)]` on a newtype
+/// `D(i32)` would give.
+impl Serialize for D {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_newtype_struct("D", &self.value)
     }
 }
 
-pub fn d_live() -> i64 {
-    D_LIVE.with(|c| c.get())
-}
+/// Deserializes a `D` counted by the given tracker. `D` has no `Deserialize`
+/// impl, because a bare `D` would belong to no tracker.
+pub struct DSeed<'a>(pub &'a DropTracker);
 
-/// Cases run one after another on the test's thread, so the thread-local
-/// carries over and an imbalance at case start means a previous case leaked or
-/// double-dropped.
-pub fn assert_d_balanced_at_start() {
-    assert_eq!(d_live(), 0, "live D count nonzero at case start");
+impl<'de> DeserializeSeed<'de> for DSeed<'_> {
+    type Value = D;
+
+    fn deserialize<De: Deserializer<'de>>(self, de: De) -> Result<D, De::Error> {
+        i32::deserialize(de).map(|v| D::new(v, self.0))
+    }
 }
 
 /// Under Miri each operation is interpreted, so these tests run four fixed
@@ -106,8 +129,8 @@ pub fn handle_from(handles: &[Entity]) -> impl gs::PrintableGenerator<Entity> + 
 
 /// The components of one entity: the payloads of its `A`, `B` and `D`, and
 /// whether it has a `C`. `D` payloads stay as `i32` here and become `D`
-/// values in `builder`, so the drop count only ever counts values that were
-/// handed to hecs.
+/// values in `builder`, so a tracker only ever counts values that were handed
+/// to hecs.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, hegel::PrettyPrintable)]
 pub struct Components {
     pub a: Option<i32>,
@@ -124,7 +147,7 @@ impl Components {
             + self.d.is_some() as usize
     }
 
-    pub fn builder(&self) -> EntityBuilder {
+    pub fn builder(&self, ds: &DropTracker) -> EntityBuilder {
         let mut b = EntityBuilder::new();
         if let Some(v) = self.a {
             b.add(A(v));
@@ -136,7 +159,7 @@ impl Components {
             b.add(C);
         }
         if let Some(v) = self.d {
-            b.add(D::new(v));
+            b.add(D::new(v, ds));
         }
         b
     }
@@ -172,7 +195,7 @@ pub fn fingerprint(world: &World) -> Fingerprint {
             a: eref.get::<&A>().map(|r| r.0),
             b: eref.get::<&B>().map(|r| r.0),
             c: eref.get::<&C>().is_some(),
-            d: eref.get::<&D>().map(|r| r.0),
+            d: eref.get::<&D>().map(|r| r.value),
         };
         assert!(
             fp.insert(eref.entity(), obs).is_none(),
@@ -185,13 +208,14 @@ pub fn fingerprint(world: &World) -> Fingerprint {
 }
 
 /// How many `D` components `world` holds.
-pub fn d_in(world: &World) -> i64 {
-    world.query::<&D>().iter().count() as i64
+pub fn d_in(world: &World) -> usize {
+    world.query::<&D>().iter().count()
 }
 
 /// `d_in` summed over `worlds`. Each twin holds its own copy of every `D` it
-/// was fed, so `d_live()` should equal this sum rather than one world's count.
-pub fn total_d(worlds: &[World]) -> i64 {
+/// was fed, so the tracker's `live()` should equal this sum rather than one
+/// world's count.
+pub fn total_d(worlds: &[World]) -> usize {
     worlds.iter().map(d_in).sum()
 }
 
@@ -270,13 +294,17 @@ pub fn histories(tc: &hegel::TestCase, min_steps: u32, max_steps: u32) -> Vec<St
 /// handles into every twin. The replay relies instead on hecs allocating
 /// handles deterministically, which the `deterministic_ids` test in
 /// src/world.rs pins. The assertions below fail if that ever stops holding.
-pub fn build_twins(history: &[Step], n_worlds: usize) -> (Vec<World>, Vec<Entity>) {
+pub fn build_twins(
+    history: &[Step],
+    n_worlds: usize,
+    ds: &DropTracker,
+) -> (Vec<World>, Vec<Entity>) {
     let mut worlds: Vec<World> = (0..n_worlds).map(|_| World::new()).collect();
     let mut handles: Vec<Entity> = Vec::new();
     for step in history {
         match *step {
             Step::Spawn(cs) => {
-                let mut spawned = worlds.iter_mut().map(|w| w.spawn(cs.builder().build()));
+                let mut spawned = worlds.iter_mut().map(|w| w.spawn(cs.builder(ds).build()));
                 let first = spawned.next().expect("at least one world");
                 for h in spawned {
                     assert_eq!(first, h, "twin worlds allocated different handles");
@@ -299,12 +327,12 @@ pub fn build_twins(history: &[Step], n_worlds: usize) -> (Vec<World>, Vec<Entity
 }
 
 /// One world replayed from `history`, with the same handle `Vec`.
-pub fn build_world_with_handles(history: &[Step]) -> (World, Vec<Entity>) {
-    let (mut worlds, handles) = build_twins(history, 1);
+pub fn build_world_with_handles(history: &[Step], ds: &DropTracker) -> (World, Vec<Entity>) {
+    let (mut worlds, handles) = build_twins(history, 1, ds);
     (worlds.pop().expect("one world"), handles)
 }
 
 /// One world replayed from `history`.
-pub fn build_world(history: &[Step]) -> World {
-    build_world_with_handles(history).0
+pub fn build_world(history: &[Step], ds: &DropTracker) -> World {
+    build_world_with_handles(history, ds).0
 }

--- a/tests/fixtures/src/lib.rs
+++ b/tests/fixtures/src/lib.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 use std::sync::Arc;
 
-use hecs::{Entity, EntityBuilder, World};
+use hecs::{CommandBuffer, ComponentError, Entity, EntityBuilder, NoSuchEntity, World};
 use hegel::generators::{self as gs, Generator};
 use serde::de::DeserializeSeed;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -118,6 +118,76 @@ pub fn handle_from(handles: &[Entity]) -> impl gs::PrintableGenerator<Entity> + 
     gs::sampled_from(handles).print_as_debug()
 }
 
+/// One of the four component types, for operations that name a single
+/// component.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, hegel::PrettyPrintable)]
+pub enum Kind {
+    A,
+    B,
+    C,
+    D,
+}
+
+pub const KINDS: [Kind; 4] = [Kind::A, Kind::B, Kind::C, Kind::D];
+
+pub fn kinds() -> impl gs::PrintableGenerator<Kind> {
+    gs::sampled_from(&KINDS[..])
+}
+
+impl Kind {
+    /// `insert_one` of this kind's component with payload `v`; `C` has none.
+    pub fn insert_one(
+        self,
+        world: &mut World,
+        e: Entity,
+        v: i32,
+        ds: &DropTracker,
+    ) -> Result<(), NoSuchEntity> {
+        match self {
+            Kind::A => world.insert_one(e, A(v)),
+            Kind::B => world.insert_one(e, B(v)),
+            Kind::C => world.insert_one(e, C),
+            Kind::D => world.insert_one(e, D::new(v, ds)),
+        }
+    }
+
+    /// `remove_one` of this kind's component; the removed value is dropped.
+    pub fn remove_one(self, world: &mut World, e: Entity) -> Result<(), ComponentError> {
+        match self {
+            Kind::A => world.remove_one::<A>(e).map(drop),
+            Kind::B => world.remove_one::<B>(e).map(drop),
+            Kind::C => world.remove_one::<C>(e).map(drop),
+            Kind::D => world.remove_one::<D>(e).map(drop),
+        }
+    }
+
+    /// `CommandBuffer::insert_one` of this kind's component.
+    pub fn buffer_insert_one(
+        self,
+        buffer: &mut CommandBuffer,
+        e: Entity,
+        v: i32,
+        ds: &DropTracker,
+    ) {
+        match self {
+            Kind::A => buffer.insert_one(e, A(v)),
+            Kind::B => buffer.insert_one(e, B(v)),
+            Kind::C => buffer.insert_one(e, C),
+            Kind::D => buffer.insert_one(e, D::new(v, ds)),
+        }
+    }
+
+    /// `CommandBuffer::remove_one` of this kind's component.
+    pub fn buffer_remove_one(self, buffer: &mut CommandBuffer, e: Entity) {
+        match self {
+            Kind::A => buffer.remove_one::<A>(e),
+            Kind::B => buffer.remove_one::<B>(e),
+            Kind::C => buffer.remove_one::<C>(e),
+            Kind::D => buffer.remove_one::<D>(e),
+        }
+    }
+}
+
 /// The components of one entity: the payloads of its `A`, `B` and `D`, and
 /// whether it has a `C`. `D` payloads stay as `i32` here and become `D`
 /// values in `builder`, so a tracker only ever counts values that were handed
@@ -136,6 +206,38 @@ impl Components {
             + self.b.is_some() as usize
             + self.c as usize
             + self.d.is_some() as usize
+    }
+
+    pub fn has(&self, kind: Kind) -> bool {
+        match kind {
+            Kind::A => self.a.is_some(),
+            Kind::B => self.b.is_some(),
+            Kind::C => self.c,
+            Kind::D => self.d.is_some(),
+        }
+    }
+
+    /// `self` with the `kind` component present, holding `v` where it has a
+    /// payload.
+    pub fn with(mut self, kind: Kind, v: i32) -> Components {
+        match kind {
+            Kind::A => self.a = Some(v),
+            Kind::B => self.b = Some(v),
+            Kind::C => self.c = true,
+            Kind::D => self.d = Some(v),
+        }
+        self
+    }
+
+    /// `self` with the `kind` component absent.
+    pub fn without(mut self, kind: Kind) -> Components {
+        match kind {
+            Kind::A => self.a = None,
+            Kind::B => self.b = None,
+            Kind::C => self.c = false,
+            Kind::D => self.d = None,
+        }
+        self
     }
 
     pub fn builder(&self, ds: &DropTracker) -> EntityBuilder {

--- a/tests/fixtures/src/lib.rs
+++ b/tests/fixtures/src/lib.rs
@@ -6,7 +6,10 @@ use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 use std::sync::Arc;
 
-use hecs::{CommandBuffer, ComponentError, Entity, EntityBuilder, NoSuchEntity, World};
+use hecs::{
+    CommandBuffer, ComponentError, Entity, EntityBuilder, EntityBuilderClone, EntityRef,
+    NoSuchEntity, World,
+};
 use hegel::generators::{self as gs, Generator};
 use serde::de::DeserializeSeed;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -240,6 +243,16 @@ impl Components {
         self
     }
 
+    /// What `eref` holds right now.
+    pub fn observed(eref: EntityRef<'_>) -> Components {
+        Components {
+            a: eref.get::<&A>().map(|r| r.0),
+            b: eref.get::<&B>().map(|r| r.0),
+            c: eref.get::<&C>().is_some(),
+            d: eref.get::<&D>().map(|r| r.value),
+        }
+    }
+
     pub fn builder(&self, ds: &DropTracker) -> EntityBuilder {
         let mut b = EntityBuilder::new();
         if let Some(v) = self.a {
@@ -253,6 +266,23 @@ impl Components {
         }
         if let Some(v) = self.d {
             b.add(D::new(v, ds));
+        }
+        b
+    }
+
+    /// `builder` for `EntityBuilderClone`, which cannot hold the non-`Clone`
+    /// `D`.
+    pub fn clone_builder(&self) -> EntityBuilderClone {
+        assert!(self.d.is_none(), "D is not Clone");
+        let mut b = EntityBuilderClone::new();
+        if let Some(v) = self.a {
+            b.add(A(v));
+        }
+        if let Some(v) = self.b {
+            b.add(B(v));
+        }
+        if self.c {
+            b.add(C);
         }
         b
     }
@@ -339,14 +369,9 @@ pub type Fingerprint = BTreeMap<Entity, Components>;
 pub fn fingerprint(world: &World) -> Fingerprint {
     let mut fp = Fingerprint::new();
     for eref in world.iter() {
-        let obs = Components {
-            a: eref.get::<&A>().map(|r| r.0),
-            b: eref.get::<&B>().map(|r| r.0),
-            c: eref.get::<&C>().is_some(),
-            d: eref.get::<&D>().map(|r| r.value),
-        };
         assert!(
-            fp.insert(eref.entity(), obs).is_none(),
+            fp.insert(eref.entity(), Components::observed(eref))
+                .is_none(),
             "world.iter() yielded {:?} twice",
             eref.entity()
         );

--- a/tests/fixtures/src/lib.rs
+++ b/tests/fixtures/src/lib.rs
@@ -184,19 +184,15 @@ pub fn fingerprint(world: &World) -> Fingerprint {
     fp
 }
 
-/// How many live `D` components a fingerprint accounts for.
-fn fingerprint_d_count(fp: &Fingerprint) -> i64 {
-    fp.values().filter(|o| o.d.is_some()).count() as i64
+/// How many `D` components `world` holds.
+pub fn d_in(world: &World) -> i64 {
+    world.query::<&D>().iter().count() as i64
 }
 
-/// Live `D` components summed over `worlds`. Each twin holds its own copy of
-/// every `D` it was fed, so `d_live()` should equal this sum rather than one
-/// world's count.
+/// `d_in` summed over `worlds`. Each twin holds its own copy of every `D` it
+/// was fed, so `d_live()` should equal this sum rather than one world's count.
 pub fn total_d(worlds: &[World]) -> i64 {
-    worlds
-        .iter()
-        .map(|w| fingerprint_d_count(&fingerprint(w)))
-        .sum()
+    worlds.iter().map(d_in).sum()
 }
 
 /// The archetypes partition the live entities: each id appears in exactly one
@@ -263,29 +259,33 @@ pub fn histories(tc: &hegel::TestCase, min_steps: u32, max_steps: u32) -> Vec<St
     steps
 }
 
-/// Replay `history` into `n_worlds` fresh worlds and return them with the pool
-/// of every handle spawned, despawned ones included.
+/// Replay `history` into `n_worlds` fresh worlds. Also returns every handle
+/// the replay spawned, in spawn order and despawned ones included, as the
+/// `Vec` callers draw their targets from.
 ///
 /// `World` is not `Clone`, so this is how a relation between two executions
-/// "from the same state" is set up. It relies on hecs allocating handles
-/// deterministically, which the `deterministic_ids` test in src/world.rs pins.
-/// The assertions below fail if it ever stops holding.
+/// "from the same state" is set up. Cloning through the column API as in
+/// examples/cloning.rs would not serve: that example says the clone may hand
+/// out different entity ids (issue #332), and the tests here drive one set of
+/// handles into every twin. The replay relies instead on hecs allocating
+/// handles deterministically, which the `deterministic_ids` test in
+/// src/world.rs pins. The assertions below fail if that ever stops holding.
 pub fn build_twins(history: &[Step], n_worlds: usize) -> (Vec<World>, Vec<Entity>) {
     let mut worlds: Vec<World> = (0..n_worlds).map(|_| World::new()).collect();
-    let mut pool: Vec<Entity> = Vec::new();
+    let mut handles: Vec<Entity> = Vec::new();
     for step in history {
         match *step {
             Step::Spawn(cs) => {
-                let mut handles = worlds.iter_mut().map(|w| w.spawn(cs.builder().build()));
-                let first = handles.next().expect("at least one world");
-                for h in handles {
+                let mut spawned = worlds.iter_mut().map(|w| w.spawn(cs.builder().build()));
+                let first = spawned.next().expect("at least one world");
+                for h in spawned {
                     assert_eq!(first, h, "twin worlds allocated different handles");
                 }
-                pool.push(first);
+                handles.push(first);
             }
             Step::Despawn(i) => {
                 for w in &mut worlds {
-                    w.despawn(pool[i])
+                    w.despawn(handles[i])
                         .expect("a history only despawns live entities");
                 }
             }
@@ -295,10 +295,16 @@ pub fn build_twins(history: &[Step], n_worlds: usize) -> (Vec<World>, Vec<Entity
     for (i, w) in worlds.iter().enumerate().skip(1) {
         assert_eq!(fp0, fingerprint(w), "twin world {i} diverged during setup");
     }
-    (worlds, pool)
+    (worlds, handles)
+}
+
+/// One world replayed from `history`, with the same handle `Vec`.
+pub fn build_world_with_handles(history: &[Step]) -> (World, Vec<Entity>) {
+    let (mut worlds, handles) = build_twins(history, 1);
+    (worlds.pop().expect("one world"), handles)
 }
 
 /// One world replayed from `history`.
 pub fn build_world(history: &[Step]) -> World {
-    build_twins(history, 1).0.pop().expect("one world")
+    build_world_with_handles(history).0
 }

--- a/tests/fixtures/src/lib.rs
+++ b/tests/fixtures/src/lib.rs
@@ -79,37 +79,29 @@ impl<'de> DeserializeSeed<'de> for DSeed<'_> {
     }
 }
 
-/// Under Miri each operation is interpreted, so these tests run four fixed
+/// Under Miri each operation is interpreted, so the tests run four fixed
 /// cases each and serve as a UB oracle for hecs's unsafe component moves
 /// rather than as a search for logic bugs. Miri's isolation denies the file
-/// and random-device access hegel uses for a fresh seed and for saving
-/// failures, and hegel's check that ten cases arrive within thirty seconds
-/// would report on the interpreter, so all three are turned off.
-#[cfg(miri)]
+/// and random-device access behind hegel's fresh seeds and failure database,
+/// and its slow-test health check would report on the interpreter, so those
+/// are turned off. Outside Miri each property runs 250 cases.
 pub fn settings() -> hegel::Settings {
-    hegel::Settings::new()
-        .test_cases(4)
-        .derandomize(true)
-        .database(None)
-        .suppress_health_check([hegel::HealthCheck::TooSlow])
-}
-
-/// 250 cases per property. Outside CI hegel seeds each run afresh and saves
-/// any failing case under `.hegel/` (gitignored) so the next run replays it
-/// first. When `CI` or `GITHUB_ACTIONS` is set the seed is fixed per test and
-/// nothing is saved, so a failure there reproduces locally with `CI=1`.
-#[cfg(not(miri))]
-pub fn settings() -> hegel::Settings {
-    hegel::Settings::new().test_cases(250)
+    let settings = hegel::Settings::new();
+    if cfg!(miri) {
+        settings
+            .test_cases(4)
+            .derandomize(true)
+            .database(None)
+            .suppress_health_check([hegel::HealthCheck::TooSlow])
+    } else {
+        settings.test_cases(250)
+    }
 }
 
 /// Worlds are kept small so that handle collisions, empty archetypes and
 /// stale handles all occur often; the bound protects the tests' runtime, not
 /// any hecs contract.
-#[cfg(miri)]
-pub const MAX_ENTITIES: u32 = 4;
-#[cfg(not(miri))]
-pub const MAX_ENTITIES: u32 = 8;
+pub const MAX_ENTITIES: u32 = if cfg!(miri) { 4 } else { 8 };
 
 /// Component payloads are small so that distinct values recur across entities,
 /// which is what makes a swapped or stale component visible. Bounds are

--- a/tests/query_surface.rs
+++ b/tests/query_surface.rs
@@ -34,11 +34,11 @@ fn collect(it: impl Iterator<Item = (Entity, i32)>, label: &str) -> BTreeMap<Ent
 #[hegel::test(settings())]
 fn satisfies_reports_query_matching_for_every_entity(tc: hegel::TestCase) {
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let (worlds, _pool) = build_twins(&history, 1);
-    let fp = fingerprint(&worlds[0]);
+    let world = build_world(&history);
+    let fp = fingerprint(&world);
 
     let mut got: BTreeMap<Entity, (bool, bool)> = BTreeMap::new();
-    for (e, one, both) in worlds[0]
+    for (e, one, both) in world
         .query::<(Entity, Satisfies<&A>, Satisfies<(&A, &B)>)>()
         .iter()
     {
@@ -60,9 +60,8 @@ fn satisfies_reports_query_matching_for_every_entity(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn writes_through_a_unique_query_are_visible(tc: hegel::TestCase) {
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let (mut worlds, _pool) = build_twins(&history, 1);
-    let world = &mut worlds[0];
-    let mut fp = fingerprint(world);
+    let world = build_world(&history);
+    let mut fp = fingerprint(&world);
     let v = tc.draw(val());
 
     {
@@ -90,7 +89,7 @@ fn writes_through_a_unique_query_are_visible(tc: hegel::TestCase) {
         }
     }
     assert_eq!(
-        fingerprint(world),
+        fingerprint(&world),
         fp,
         "writes through query::<&mut A> were lost"
     );
@@ -101,11 +100,11 @@ fn writes_through_a_unique_query_are_visible(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn or_accessors_agree_with_the_matched_variant(tc: hegel::TestCase) {
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let (worlds, _pool) = build_twins(&history, 1);
-    let fp = fingerprint(&worlds[0]);
+    let world = build_world(&history);
+    let fp = fingerprint(&world);
 
     let mut seen = 0usize;
-    for (e, or) in worlds[0].query::<(Entity, Or<&A, &B>)>().iter() {
+    for (e, or) in world.query::<(Entity, Or<&A, &B>)>().iter() {
         let o = fp[&e];
         assert!(
             o.a.is_some() || o.b.is_some(),
@@ -143,9 +142,8 @@ fn or_accessors_agree_with_the_matched_variant(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn query_filters_select_by_component_presence(tc: hegel::TestCase) {
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let (mut worlds, _pool) = build_twins(&history, 1);
-    let world = &mut worlds[0];
-    let fp = fingerprint(world);
+    let mut world = build_world(&history);
+    let fp = fingerprint(&world);
 
     let with_b: BTreeMap<Entity, i32> = fp
         .iter()
@@ -205,9 +203,8 @@ fn query_filters_select_by_component_presence(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn batched_iteration_partitions_the_matches(tc: hegel::TestCase) {
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let (mut worlds, _pool) = build_twins(&history, 1);
-    let world = &mut worlds[0];
-    let want = expected_a(&fingerprint(world));
+    let mut world = build_world(&history);
+    let want = expected_a(&fingerprint(&world));
     // A batch size of 0 is documented to panic.
     let size = tc.draw(gs::integers::<u32>().min_value(1).max_value(4));
 
@@ -239,9 +236,8 @@ fn batched_iteration_partitions_the_matches(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn view_iteration_visits_every_match(tc: hegel::TestCase) {
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let (mut worlds, _pool) = build_twins(&history, 1);
-    let world = &mut worlds[0];
-    let want = expected_a(&fingerprint(world));
+    let mut world = build_world(&history);
+    let want = expected_a(&fingerprint(&world));
 
     {
         let mut view = world.view_mut::<(Entity, &mut A)>();
@@ -260,7 +256,7 @@ fn view_iteration_visits_every_match(tc: hegel::TestCase) {
     }
     {
         let mut prepared = PreparedQuery::<(Entity, &A)>::default();
-        let mut view = prepared.view_mut(world);
+        let mut view = prepared.view_mut(&mut world);
         let got = collect(
             (&mut view).into_iter().map(|(e, a)| (e, a.0)),
             "&mut PreparedView",
@@ -280,9 +276,8 @@ fn view_iteration_visits_every_match(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn random_access_views_agree_with_iteration(tc: hegel::TestCase) {
     let history = tc.draw(histories(1, MAX_ENTITIES));
-    let (mut worlds, pool) = build_twins(&history, 1);
-    let world = &mut worlds[0];
-    let fp = fingerprint(world);
+    let (mut world, pool) = build_world_with_handles(&history);
+    let fp = fingerprint(&world);
     let e1 = tc.draw(handle_from(&pool));
     let e2 = tc.draw(handle_from(&pool));
 
@@ -337,7 +332,7 @@ fn random_access_views_agree_with_iteration(tc: hegel::TestCase) {
     }
     {
         let mut prepared = PreparedQuery::<(Entity, &A)>::new();
-        let mut view = prepared.view_mut(world);
+        let mut view = prepared.view_mut(&mut world);
         for (&e, o) in &fp {
             assert_eq!(
                 view.get_mut(e).map(|(got, a)| (got, a.0)),
@@ -368,7 +363,7 @@ fn random_access_views_agree_with_iteration(tc: hegel::TestCase) {
     }
 
     assert_eq!(
-        fingerprint(world),
+        fingerprint(&world),
         fp,
         "a read-only shape mutated the world"
     );

--- a/tests/query_surface.rs
+++ b/tests/query_surface.rs
@@ -1,0 +1,372 @@
+//! Every public way of reading a `World` must project the same state.
+//!
+//! Ground truth is the observational fingerprint, taken once with plain
+//! per-entity reads. Each property then drives one read shape — a query
+//! combinator, a batched iterator, a random-access view — and asserts it
+//! yields exactly the entities and values the fingerprint predicts, with no
+//! duplicates.
+
+mod common;
+
+use std::collections::BTreeMap;
+
+use common::*;
+use hecs::{Entity, Or, PreparedQuery, Satisfies};
+use hegel::generators as gs;
+
+/// The `A` values the fingerprint predicts, keyed by entity.
+fn expected_a(fp: &Fingerprint) -> BTreeMap<Entity, i32> {
+    fp.iter()
+        .filter_map(|(&e, o)| o.a.map(|v| (e, v)))
+        .collect()
+}
+
+/// Collect `(Entity, value)` pairs, failing on a repeated entity.
+fn collect(it: impl Iterator<Item = (Entity, i32)>, label: &str) -> BTreeMap<Entity, i32> {
+    let mut got = BTreeMap::new();
+    for (e, v) in it {
+        assert!(got.insert(e, v).is_none(), "{label} yielded {e:?} twice");
+    }
+    got
+}
+
+/// `Satisfies<Q>` matches every entity and reports whether it satisfies `Q`,
+/// unlike `Q` itself, which filters. It must agree with component presence even
+/// for entities with no components at all.
+#[hegel::test(settings())]
+fn satisfies_reports_query_matching_for_every_entity(tc: hegel::TestCase) {
+    let (worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let fp = fingerprint(&worlds[0]);
+
+    let mut got: BTreeMap<Entity, (bool, bool)> = BTreeMap::new();
+    for (e, one, both) in worlds[0]
+        .query::<(Entity, Satisfies<&A>, Satisfies<(&A, &B)>)>()
+        .iter()
+    {
+        assert!(
+            got.insert(e, (one, both)).is_none(),
+            "Satisfies yielded {e:?} twice"
+        );
+    }
+    let want: BTreeMap<Entity, (bool, bool)> = fp
+        .iter()
+        .map(|(&e, o)| (e, (o.a.is_some(), o.a.is_some() && o.b.is_some())))
+        .collect();
+    assert_eq!(got, want, "query::<Satisfies<..>>");
+}
+
+/// A `&mut` fetch through the dynamically borrow-checked `query()` path reads
+/// the current values and its writes are visible afterwards. `QueryIter` is an
+/// `ExactSizeIterator`, so its length must be the number of matches.
+#[hegel::test(settings())]
+fn writes_through_a_unique_query_are_visible(tc: hegel::TestCase) {
+    let (mut worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let world = &mut worlds[0];
+    let mut fp = fingerprint(world);
+    let v = tc.draw(val());
+
+    {
+        let mut q = world.query::<(Entity, &mut A)>();
+        let mut it = q.iter();
+        let matches = expected_a(&fp).len();
+        assert_eq!(it.len(), matches, "QueryIter::len");
+        assert_eq!(
+            it.size_hint(),
+            (matches, Some(matches)),
+            "QueryIter::size_hint"
+        );
+        for (e, a) in &mut it {
+            assert_eq!(
+                Some(a.0),
+                fp[&e].a,
+                "query::<&mut A> read a stale value for {e:?}"
+            );
+            a.0 = v;
+        }
+    }
+    for o in fp.values_mut() {
+        if o.a.is_some() {
+            o.a = Some(v);
+        }
+    }
+    assert_eq!(
+        fingerprint(world),
+        fp,
+        "writes through query::<&mut A> were lost"
+    );
+}
+
+/// Every `Or` accessor reports the same thing about which side is present:
+/// `split`, `left`, `right`, and `cloned().as_mut()`.
+#[hegel::test(settings())]
+fn or_accessors_agree_with_the_matched_variant(tc: hegel::TestCase) {
+    let (worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let fp = fingerprint(&worlds[0]);
+
+    let mut seen = 0usize;
+    for (e, or) in worlds[0].query::<(Entity, Or<&A, &B>)>().iter() {
+        let o = fp[&e];
+        assert!(
+            o.a.is_some() || o.b.is_some(),
+            "Or matched {e:?} with neither A nor B"
+        );
+        let (left, right) = or.split();
+        assert_eq!(left.map(|a| a.0), o.a, "Or::split left for {e:?}");
+        assert_eq!(right.map(|b| b.0), o.b, "Or::split right for {e:?}");
+        assert_eq!(or.left().map(|a| a.0), o.a, "Or::left for {e:?}");
+        assert_eq!(or.right().map(|b| b.0), o.b, "Or::right for {e:?}");
+        let mut owned: Or<A, B> = or.cloned();
+        let (left, right) = owned.as_mut().split();
+        assert_eq!(
+            left.map(|a| a.0),
+            o.a,
+            "Or::cloned().as_mut() left for {e:?}"
+        );
+        assert_eq!(
+            right.map(|b| b.0),
+            o.b,
+            "Or::cloned().as_mut() right for {e:?}"
+        );
+        seen += 1;
+    }
+    let want = fp
+        .values()
+        .filter(|o| o.a.is_some() || o.b.is_some())
+        .count();
+    assert_eq!(seen, want, "query::<Or<&A, &B>> matched the wrong entities");
+}
+
+/// `with` and `without` filter by the presence of a component without
+/// borrowing it, identically on the shared-borrow (`QueryBorrow`) and
+/// unique-borrow (`QueryMut`) paths.
+#[hegel::test(settings())]
+fn query_filters_select_by_component_presence(tc: hegel::TestCase) {
+    let (mut worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let world = &mut worlds[0];
+    let fp = fingerprint(world);
+
+    let with_b: BTreeMap<Entity, i32> = fp
+        .iter()
+        .filter_map(|(&e, o)| o.b.and(o.a).map(|v| (e, v)))
+        .collect();
+    let without_b: BTreeMap<Entity, i32> = fp
+        .iter()
+        .filter_map(|(&e, o)| match (o.a, o.b) {
+            (Some(v), None) => Some((e, v)),
+            _ => None,
+        })
+        .collect();
+
+    let got = collect(
+        world
+            .query::<(Entity, &A)>()
+            .with::<&B>()
+            .iter()
+            .map(|(e, a)| (e, a.0)),
+        "QueryBorrow::with",
+    );
+    assert_eq!(got, with_b, "QueryBorrow::with::<&B>");
+
+    let got = collect(
+        world
+            .query::<(Entity, &A)>()
+            .without::<&B>()
+            .iter()
+            .map(|(e, a)| (e, a.0)),
+        "QueryBorrow::without",
+    );
+    assert_eq!(got, without_b, "QueryBorrow::without::<&B>");
+
+    let got = collect(
+        world
+            .query_mut::<(Entity, &A)>()
+            .with::<&B>()
+            .into_iter()
+            .map(|(e, a)| (e, a.0)),
+        "QueryMut::with",
+    );
+    assert_eq!(got, with_b, "QueryMut::with::<&B>");
+
+    let got = collect(
+        world
+            .query_mut::<(Entity, &A)>()
+            .without::<&B>()
+            .into_iter()
+            .map(|(e, a)| (e, a.0)),
+        "QueryMut::without",
+    );
+    assert_eq!(got, without_b, "QueryMut::without::<&B>");
+}
+
+/// Batched iteration partitions the matches: taken together the batches visit
+/// exactly what flat iteration does, whatever the batch size.
+#[hegel::test(settings())]
+fn batched_iteration_partitions_the_matches(tc: hegel::TestCase) {
+    let (mut worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let world = &mut worlds[0];
+    let want = expected_a(&fingerprint(world));
+    // A batch size of 0 is documented to panic.
+    let size = tc.draw(gs::integers::<u32>().min_value(1).max_value(4));
+
+    let mut got = BTreeMap::new();
+    for batch in world.query::<(Entity, &A)>().iter_batched(size) {
+        for (e, a) in batch {
+            assert!(
+                got.insert(e, a.0).is_none(),
+                "iter_batched yielded {e:?} twice"
+            );
+        }
+    }
+    assert_eq!(got, want, "QueryBorrow::iter_batched({size})");
+
+    let mut got = BTreeMap::new();
+    for batch in world.query_mut::<(Entity, &A)>().into_iter_batched(size) {
+        for (e, a) in batch {
+            assert!(
+                got.insert(e, a.0).is_none(),
+                "into_iter_batched yielded {e:?} twice"
+            );
+        }
+    }
+    assert_eq!(got, want, "QueryMut::into_iter_batched({size})");
+}
+
+/// Iterating a view — `View`, `ViewBorrow` or `PreparedView` — visits the same
+/// matches as a query.
+#[hegel::test(settings())]
+fn view_iteration_visits_every_match(tc: hegel::TestCase) {
+    let (mut worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let world = &mut worlds[0];
+    let want = expected_a(&fingerprint(world));
+
+    {
+        let mut view = world.view_mut::<(Entity, &mut A)>();
+        let got = collect((&mut view).into_iter().map(|(e, a)| (e, a.0)), "&mut View");
+        assert_eq!(got, want, "IntoIterator for &mut View");
+        let got = collect(view.iter_mut().map(|(e, a)| (e, a.0)), "View::iter_mut");
+        assert_eq!(got, want, "View::iter_mut");
+    }
+    {
+        let mut view = world.view::<(Entity, &A)>();
+        let got = collect(
+            (&mut view).into_iter().map(|(e, a)| (e, a.0)),
+            "&mut ViewBorrow",
+        );
+        assert_eq!(got, want, "IntoIterator for &mut ViewBorrow");
+    }
+    {
+        let mut prepared = PreparedQuery::<(Entity, &A)>::default();
+        let mut view = prepared.view_mut(world);
+        let got = collect(
+            (&mut view).into_iter().map(|(e, a)| (e, a.0)),
+            "&mut PreparedView",
+        );
+        assert_eq!(got, want, "IntoIterator for &mut PreparedView");
+        let got = collect(
+            view.iter_mut().map(|(e, a)| (e, a.0)),
+            "PreparedView::iter_mut",
+        );
+        assert_eq!(got, want, "PreparedView::iter_mut");
+    }
+}
+
+/// Reaching an entity by handle through a view agrees with iterating: `get`,
+/// `get_mut`, `get_unchecked` and `get_disjoint_mut` all resolve the same
+/// component, and miss exactly the entities the query does not match.
+#[hegel::test(settings())]
+fn random_access_views_agree_with_iteration(tc: hegel::TestCase) {
+    let (mut worlds, pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let world = &mut worlds[0];
+    let fp = fingerprint(world);
+
+    {
+        let mut q = world.query::<&A>();
+        let view = q.view();
+        for (&e, o) in &fp {
+            assert_eq!(
+                view.get(e).map(|a| a.0),
+                o.a,
+                "QueryBorrow::view().get({e:?})"
+            );
+        }
+    }
+    {
+        let mut q = world.query_mut::<&A>();
+        let view = q.view();
+        for (&e, o) in &fp {
+            assert_eq!(view.get(e).map(|a| a.0), o.a, "QueryMut::view().get({e:?})");
+        }
+    }
+    {
+        let mut view = world.view::<(Entity, &A)>();
+        for (&e, o) in &fp {
+            assert_eq!(
+                view.get_mut(e).map(|(got, a)| (got, a.0)),
+                o.a.map(|v| (e, v)),
+                "ViewBorrow::get_mut({e:?})"
+            );
+            // SAFETY: the query yields only shared references and no unique
+            // borrow of A is alive here.
+            let unchecked = unsafe { view.get_unchecked(e) };
+            assert_eq!(
+                unchecked.map(|(got, a)| (got, a.0)),
+                o.a.map(|v| (e, v)),
+                "ViewBorrow::get_unchecked({e:?})"
+            );
+        }
+        if let (Some(e1), Some(e2)) = (pick(&tc, &pool), pick(&tc, &pool)) {
+            if e1 != e2 {
+                let [first, second] = view.get_disjoint_mut([e1, e2]);
+                assert_eq!(
+                    first.map(|(_, a)| a.0),
+                    fp.get(&e1).and_then(|o| o.a),
+                    "ViewBorrow::get_disjoint_mut({e1:?})"
+                );
+                assert_eq!(
+                    second.map(|(_, a)| a.0),
+                    fp.get(&e2).and_then(|o| o.a),
+                    "ViewBorrow::get_disjoint_mut({e2:?})"
+                );
+            }
+        }
+    }
+    {
+        let mut prepared = PreparedQuery::<(Entity, &A)>::new();
+        let mut view = prepared.view_mut(world);
+        for (&e, o) in &fp {
+            assert_eq!(
+                view.get_mut(e).map(|(got, a)| (got, a.0)),
+                o.a.map(|v| (e, v)),
+                "PreparedView::get_mut({e:?})"
+            );
+            // SAFETY: as above, the query is read-only and nothing else borrows A.
+            let unchecked = unsafe { view.get_unchecked(e) };
+            assert_eq!(
+                unchecked.map(|(got, a)| (got, a.0)),
+                o.a.map(|v| (e, v)),
+                "PreparedView::get_unchecked({e:?})"
+            );
+        }
+        if let (Some(e1), Some(e2)) = (pick(&tc, &pool), pick(&tc, &pool)) {
+            if e1 != e2 {
+                let [first, second] = view.get_disjoint_mut([e1, e2]);
+                assert_eq!(
+                    first.map(|(_, a)| a.0),
+                    fp.get(&e1).and_then(|o| o.a),
+                    "PreparedView::get_disjoint_mut({e1:?})"
+                );
+                assert_eq!(
+                    second.map(|(_, a)| a.0),
+                    fp.get(&e2).and_then(|o| o.a),
+                    "PreparedView::get_disjoint_mut({e2:?})"
+                );
+            }
+        }
+    }
+
+    assert_eq!(
+        fingerprint(world),
+        fp,
+        "a read-only shape mutated the world"
+    );
+}

--- a/tests/query_surface.rs
+++ b/tests/query_surface.rs
@@ -35,7 +35,8 @@ fn collect(it: impl Iterator<Item = (Entity, i32)>, label: &str) -> BTreeMap<Ent
 /// for entities with no components at all.
 #[hegel::test(settings())]
 fn satisfies_reports_query_matching_for_every_entity(tc: hegel::TestCase) {
-    let (worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let history = tc.draw(histories(0, MAX_ENTITIES));
+    let (worlds, _pool) = build_twins(&history, 1);
     let fp = fingerprint(&worlds[0]);
 
     let mut got: BTreeMap<Entity, (bool, bool)> = BTreeMap::new();
@@ -60,7 +61,8 @@ fn satisfies_reports_query_matching_for_every_entity(tc: hegel::TestCase) {
 /// `ExactSizeIterator`, so its length must be the number of matches.
 #[hegel::test(settings())]
 fn writes_through_a_unique_query_are_visible(tc: hegel::TestCase) {
-    let (mut worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let history = tc.draw(histories(0, MAX_ENTITIES));
+    let (mut worlds, _pool) = build_twins(&history, 1);
     let world = &mut worlds[0];
     let mut fp = fingerprint(world);
     let v = tc.draw(val());
@@ -100,7 +102,8 @@ fn writes_through_a_unique_query_are_visible(tc: hegel::TestCase) {
 /// `split`, `left`, `right`, and `cloned().as_mut()`.
 #[hegel::test(settings())]
 fn or_accessors_agree_with_the_matched_variant(tc: hegel::TestCase) {
-    let (worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let history = tc.draw(histories(0, MAX_ENTITIES));
+    let (worlds, _pool) = build_twins(&history, 1);
     let fp = fingerprint(&worlds[0]);
 
     let mut seen = 0usize;
@@ -141,7 +144,8 @@ fn or_accessors_agree_with_the_matched_variant(tc: hegel::TestCase) {
 /// unique-borrow (`QueryMut`) paths.
 #[hegel::test(settings())]
 fn query_filters_select_by_component_presence(tc: hegel::TestCase) {
-    let (mut worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let history = tc.draw(histories(0, MAX_ENTITIES));
+    let (mut worlds, _pool) = build_twins(&history, 1);
     let world = &mut worlds[0];
     let fp = fingerprint(world);
 
@@ -202,7 +206,8 @@ fn query_filters_select_by_component_presence(tc: hegel::TestCase) {
 /// exactly what flat iteration does, whatever the batch size.
 #[hegel::test(settings())]
 fn batched_iteration_partitions_the_matches(tc: hegel::TestCase) {
-    let (mut worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let history = tc.draw(histories(0, MAX_ENTITIES));
+    let (mut worlds, _pool) = build_twins(&history, 1);
     let world = &mut worlds[0];
     let want = expected_a(&fingerprint(world));
     // A batch size of 0 is documented to panic.
@@ -235,7 +240,8 @@ fn batched_iteration_partitions_the_matches(tc: hegel::TestCase) {
 /// matches as a query.
 #[hegel::test(settings())]
 fn view_iteration_visits_every_match(tc: hegel::TestCase) {
-    let (mut worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let history = tc.draw(histories(0, MAX_ENTITIES));
+    let (mut worlds, _pool) = build_twins(&history, 1);
     let world = &mut worlds[0];
     let want = expected_a(&fingerprint(world));
 
@@ -275,9 +281,12 @@ fn view_iteration_visits_every_match(tc: hegel::TestCase) {
 /// component, and miss exactly the entities the query does not match.
 #[hegel::test(settings())]
 fn random_access_views_agree_with_iteration(tc: hegel::TestCase) {
-    let (mut worlds, pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let history = tc.draw(histories(1, MAX_ENTITIES));
+    let (mut worlds, pool) = build_twins(&history, 1);
     let world = &mut worlds[0];
     let fp = fingerprint(world);
+    let e1 = tc.draw(pick(&pool));
+    let e2 = tc.draw(pick(&pool));
 
     {
         let mut q = world.query::<&A>();
@@ -314,20 +323,18 @@ fn random_access_views_agree_with_iteration(tc: hegel::TestCase) {
                 "ViewBorrow::get_unchecked({e:?})"
             );
         }
-        if let (Some(e1), Some(e2)) = (pick(&tc, &pool), pick(&tc, &pool)) {
-            if e1 != e2 {
-                let [first, second] = view.get_disjoint_mut([e1, e2]);
-                assert_eq!(
-                    first.map(|(_, a)| a.0),
-                    fp.get(&e1).and_then(|o| o.a),
-                    "ViewBorrow::get_disjoint_mut({e1:?})"
-                );
-                assert_eq!(
-                    second.map(|(_, a)| a.0),
-                    fp.get(&e2).and_then(|o| o.a),
-                    "ViewBorrow::get_disjoint_mut({e2:?})"
-                );
-            }
+        if e1 != e2 {
+            let [first, second] = view.get_disjoint_mut([e1, e2]);
+            assert_eq!(
+                first.map(|(_, a)| a.0),
+                fp.get(&e1).and_then(|o| o.a),
+                "ViewBorrow::get_disjoint_mut({e1:?})"
+            );
+            assert_eq!(
+                second.map(|(_, a)| a.0),
+                fp.get(&e2).and_then(|o| o.a),
+                "ViewBorrow::get_disjoint_mut({e2:?})"
+            );
         }
     }
     {
@@ -347,20 +354,18 @@ fn random_access_views_agree_with_iteration(tc: hegel::TestCase) {
                 "PreparedView::get_unchecked({e:?})"
             );
         }
-        if let (Some(e1), Some(e2)) = (pick(&tc, &pool), pick(&tc, &pool)) {
-            if e1 != e2 {
-                let [first, second] = view.get_disjoint_mut([e1, e2]);
-                assert_eq!(
-                    first.map(|(_, a)| a.0),
-                    fp.get(&e1).and_then(|o| o.a),
-                    "PreparedView::get_disjoint_mut({e1:?})"
-                );
-                assert_eq!(
-                    second.map(|(_, a)| a.0),
-                    fp.get(&e2).and_then(|o| o.a),
-                    "PreparedView::get_disjoint_mut({e2:?})"
-                );
-            }
+        if e1 != e2 {
+            let [first, second] = view.get_disjoint_mut([e1, e2]);
+            assert_eq!(
+                first.map(|(_, a)| a.0),
+                fp.get(&e1).and_then(|o| o.a),
+                "PreparedView::get_disjoint_mut({e1:?})"
+            );
+            assert_eq!(
+                second.map(|(_, a)| a.0),
+                fp.get(&e2).and_then(|o| o.a),
+                "PreparedView::get_disjoint_mut({e2:?})"
+            );
         }
     }
 

--- a/tests/query_surface.rs
+++ b/tests/query_surface.rs
@@ -6,11 +6,9 @@
 //! yields exactly the entities and values the fingerprint predicts, with no
 //! duplicates.
 
-mod common;
-
 use std::collections::BTreeMap;
 
-use common::*;
+use fixtures::*;
 use hecs::{Entity, Or, PreparedQuery, Satisfies};
 use hegel::generators as gs;
 

--- a/tests/query_surface.rs
+++ b/tests/query_surface.rs
@@ -33,8 +33,9 @@ fn collect(it: impl Iterator<Item = (Entity, i32)>, label: &str) -> BTreeMap<Ent
 /// for entities with no components at all.
 #[hegel::test(settings())]
 fn satisfies_reports_query_matching_for_every_entity(tc: hegel::TestCase) {
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let world = build_world(&history);
+    let world = build_world(&history, &ds);
     let fp = fingerprint(&world);
 
     let mut got: BTreeMap<Entity, (bool, bool)> = BTreeMap::new();
@@ -59,8 +60,9 @@ fn satisfies_reports_query_matching_for_every_entity(tc: hegel::TestCase) {
 /// `ExactSizeIterator`, so its length must be the number of matches.
 #[hegel::test(settings())]
 fn writes_through_a_unique_query_are_visible(tc: hegel::TestCase) {
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let world = build_world(&history);
+    let world = build_world(&history, &ds);
     let mut fp = fingerprint(&world);
     let v = tc.draw(val());
 
@@ -99,8 +101,9 @@ fn writes_through_a_unique_query_are_visible(tc: hegel::TestCase) {
 /// `split`, `left`, `right`, and `cloned().as_mut()`.
 #[hegel::test(settings())]
 fn or_accessors_agree_with_the_matched_variant(tc: hegel::TestCase) {
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let world = build_world(&history);
+    let world = build_world(&history, &ds);
     let fp = fingerprint(&world);
 
     let mut seen = 0usize;
@@ -141,8 +144,9 @@ fn or_accessors_agree_with_the_matched_variant(tc: hegel::TestCase) {
 /// unique-borrow (`QueryMut`) paths.
 #[hegel::test(settings())]
 fn query_filters_select_by_component_presence(tc: hegel::TestCase) {
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let mut world = build_world(&history);
+    let mut world = build_world(&history, &ds);
     let fp = fingerprint(&world);
 
     let with_b: BTreeMap<Entity, i32> = fp
@@ -202,8 +206,9 @@ fn query_filters_select_by_component_presence(tc: hegel::TestCase) {
 /// exactly what flat iteration does, whatever the batch size.
 #[hegel::test(settings())]
 fn batched_iteration_partitions_the_matches(tc: hegel::TestCase) {
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let mut world = build_world(&history);
+    let mut world = build_world(&history, &ds);
     let want = expected_a(&fingerprint(&world));
     // A batch size of 0 is documented to panic.
     let size = tc.draw(gs::integers::<u32>().min_value(1).max_value(4));
@@ -235,8 +240,9 @@ fn batched_iteration_partitions_the_matches(tc: hegel::TestCase) {
 /// matches as a query.
 #[hegel::test(settings())]
 fn view_iteration_visits_every_match(tc: hegel::TestCase) {
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let mut world = build_world(&history);
+    let mut world = build_world(&history, &ds);
     let want = expected_a(&fingerprint(&world));
 
     {
@@ -275,8 +281,9 @@ fn view_iteration_visits_every_match(tc: hegel::TestCase) {
 /// component, and miss exactly the entities the query does not match.
 #[hegel::test(settings())]
 fn random_access_views_agree_with_iteration(tc: hegel::TestCase) {
+    let ds = DropTracker::new();
     let history = tc.draw(histories(1, MAX_ENTITIES));
-    let (mut world, pool) = build_world_with_handles(&history);
+    let (mut world, pool) = build_world_with_handles(&history, &ds);
     let fp = fingerprint(&world);
     let e1 = tc.draw(handle_from(&pool));
     let e2 = tc.draw(handle_from(&pool));

--- a/tests/query_surface.rs
+++ b/tests/query_surface.rs
@@ -20,7 +20,7 @@ fn expected_a(fp: &Fingerprint) -> BTreeMap<Entity, i32> {
 }
 
 /// Collect `(Entity, value)` pairs, failing on a repeated entity.
-fn collect(it: impl Iterator<Item = (Entity, i32)>, label: &str) -> BTreeMap<Entity, i32> {
+fn collect<V>(it: impl Iterator<Item = (Entity, V)>, label: &str) -> BTreeMap<Entity, V> {
     let mut got = BTreeMap::new();
     for (e, v) in it {
         assert!(got.insert(e, v).is_none(), "{label} yielded {e:?} twice");
@@ -38,16 +38,13 @@ fn satisfies_reports_query_matching_for_every_entity(tc: hegel::TestCase) {
     let world = build_world(&history, &ds);
     let fp = fingerprint(&world);
 
-    let mut got: BTreeMap<Entity, (bool, bool)> = BTreeMap::new();
-    for (e, one, both) in world
-        .query::<(Entity, Satisfies<&A>, Satisfies<(&A, &B)>)>()
-        .iter()
-    {
-        assert!(
-            got.insert(e, (one, both)).is_none(),
-            "Satisfies yielded {e:?} twice"
-        );
-    }
+    let got = collect(
+        world
+            .query::<(Entity, Satisfies<&A>, Satisfies<(&A, &B)>)>()
+            .iter()
+            .map(|(e, one, both)| (e, (one, both))),
+        "Satisfies",
+    );
     let want: BTreeMap<Entity, (bool, bool)> = fp
         .iter()
         .map(|(&e, o)| (e, (o.a.is_some(), o.a.is_some() && o.b.is_some())))
@@ -213,26 +210,24 @@ fn batched_iteration_partitions_the_matches(tc: hegel::TestCase) {
     // A batch size of 0 is documented to panic.
     let size = tc.draw(gs::integers::<u32>().min_value(1).max_value(4));
 
-    let mut got = BTreeMap::new();
-    for batch in world.query::<(Entity, &A)>().iter_batched(size) {
-        for (e, a) in batch {
-            assert!(
-                got.insert(e, a.0).is_none(),
-                "iter_batched yielded {e:?} twice"
-            );
-        }
-    }
+    let got = collect(
+        world
+            .query::<(Entity, &A)>()
+            .iter_batched(size)
+            .flatten()
+            .map(|(e, a)| (e, a.0)),
+        "iter_batched",
+    );
     assert_eq!(got, want, "QueryBorrow::iter_batched({size})");
 
-    let mut got = BTreeMap::new();
-    for batch in world.query_mut::<(Entity, &A)>().into_iter_batched(size) {
-        for (e, a) in batch {
-            assert!(
-                got.insert(e, a.0).is_none(),
-                "into_iter_batched yielded {e:?} twice"
-            );
-        }
-    }
+    let got = collect(
+        world
+            .query_mut::<(Entity, &A)>()
+            .into_iter_batched(size)
+            .flatten()
+            .map(|(e, a)| (e, a.0)),
+        "into_iter_batched",
+    );
     assert_eq!(got, want, "QueryMut::into_iter_batched({size})");
 }
 

--- a/tests/query_surface.rs
+++ b/tests/query_surface.rs
@@ -283,8 +283,8 @@ fn random_access_views_agree_with_iteration(tc: hegel::TestCase) {
     let (mut worlds, pool) = build_twins(&history, 1);
     let world = &mut worlds[0];
     let fp = fingerprint(world);
-    let e1 = tc.draw(pick(&pool));
-    let e2 = tc.draw(pick(&pool));
+    let e1 = tc.draw(handle_from(&pool));
+    let e2 = tc.draw(handle_from(&pool));
 
     {
         let mut q = world.query::<&A>();

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -12,6 +12,8 @@
 use std::any::TypeId;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
+use std::fmt;
+
 use bincode::Options;
 use fixtures::*;
 use hecs::serialize::{column, row};
@@ -19,7 +21,8 @@ use hecs::{
     Archetype, ColumnBatchBuilder, ColumnBatchType, Entity, EntityBuilder, EntityRef, Query, World,
 };
 use hegel::generators as gs;
-use serde::{Deserialize, Serialize};
+use serde::de::{self, DeserializeSeed, SeqAccess, Unexpected, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// Wire identifiers for the four component types. The bincode encoding of these
 /// discriminants is `A = 0 .. D = 3`, so anything above 3 is an unknown-variant
@@ -54,7 +57,9 @@ impl row::SerializeContext for Row {
     }
 }
 
-impl row::DeserializeContext for Row {
+struct RowDe<'a>(&'a DropTracker);
+
+impl row::DeserializeContext for RowDe<'_> {
     fn deserialize_entity<'de, M>(
         &mut self,
         mut map: M,
@@ -68,7 +73,7 @@ impl row::DeserializeContext for Row {
                 Id::A => entity.add::<A>(map.next_value()?),
                 Id::B => entity.add::<B>(map.next_value()?),
                 Id::C => entity.add::<C>(map.next_value()?),
-                Id::D => entity.add::<D>(map.next_value()?),
+                Id::D => entity.add::<D>(map.next_value_seed(DSeed(self.0))?),
             };
         }
         Ok(())
@@ -90,9 +95,9 @@ fn row_satisfying_bytes<Q: Query>(world: &World) -> Vec<u8> {
     buf
 }
 
-fn row_world(bytes: &[u8]) -> Result<World, bincode::Error> {
+fn row_world(bytes: &[u8], ds: &DropTracker) -> Result<World, bincode::Error> {
     let mut de = bincode::Deserializer::with_reader(bytes, bincode::options());
-    row::deserialize(&mut Row, &mut de)
+    row::deserialize(&mut RowDe(ds), &mut de)
 }
 
 // ---- column format ----
@@ -137,12 +142,12 @@ impl column::SerializeContext for ColumnSer {
     }
 }
 
-#[derive(Default)]
-struct ColumnDe {
+struct ColumnDe<'a> {
     components: Vec<Id>,
+    ds: &'a DropTracker,
 }
 
-impl column::DeserializeContext for ColumnDe {
+impl column::DeserializeContext for ColumnDe<'_> {
     fn deserialize_component_ids<'de, S>(&mut self, mut seq: S) -> Result<ColumnBatchType, S::Error>
     where
         S: serde::de::SeqAccess<'de>,
@@ -175,8 +180,67 @@ impl column::DeserializeContext for ColumnDe {
                 Id::A => column::deserialize_column::<A, _>(entity_count, &mut seq, batch)?,
                 Id::B => column::deserialize_column::<B, _>(entity_count, &mut seq, batch)?,
                 Id::C => column::deserialize_column::<C, _>(entity_count, &mut seq, batch)?,
-                Id::D => column::deserialize_column::<D, _>(entity_count, &mut seq, batch)?,
+                Id::D => d_column(entity_count, &mut seq, batch, self.ds)?,
             }
+        }
+        Ok(())
+    }
+}
+
+/// `column::deserialize_column::<D, _>`, except that each `D` is read through
+/// `DSeed` so it counts towards `ds`.
+fn d_column<'de, S: SeqAccess<'de>>(
+    entity_count: u32,
+    seq: &mut S,
+    batch: &mut ColumnBatchBuilder,
+    ds: &DropTracker,
+) -> Result<(), S::Error> {
+    seq.next_element_seed(DColumn {
+        entity_count,
+        batch,
+        ds,
+    })?
+    .ok_or_else(|| {
+        de::Error::invalid_value(
+            Unexpected::Other("end of components"),
+            &"a column of components",
+        )
+    })
+}
+
+struct DColumn<'a> {
+    entity_count: u32,
+    batch: &'a mut ColumnBatchBuilder,
+    ds: &'a DropTracker,
+}
+
+impl<'de> DeserializeSeed<'de> for DColumn<'_> {
+    type Value = ();
+
+    fn deserialize<De: Deserializer<'de>>(self, de: De) -> Result<(), De::Error> {
+        de.deserialize_tuple(self.entity_count as usize, self)
+    }
+}
+
+impl<'de> Visitor<'de> for DColumn<'_> {
+    type Value = ();
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "a column of {} D values", self.entity_count)
+    }
+
+    fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<(), S::Error> {
+        let mut writer = self.batch.writer::<D>().expect("D is in the batch type");
+        while let Some(d) = seq.next_element_seed(DSeed(self.ds))? {
+            if writer.push(d).is_err() {
+                return Err(de::Error::invalid_value(
+                    Unexpected::Other("extra component"),
+                    &self,
+                ));
+            }
+        }
+        if writer.fill() < self.entity_count {
+            return Err(de::Error::invalid_length(writer.fill() as usize, &self));
         }
         Ok(())
     }
@@ -197,9 +261,13 @@ fn column_satisfying_bytes<Q: Query>(world: &World) -> Vec<u8> {
     buf
 }
 
-fn column_world(bytes: &[u8]) -> Result<World, bincode::Error> {
+fn column_world(bytes: &[u8], ds: &DropTracker) -> Result<World, bincode::Error> {
     let mut de = bincode::Deserializer::with_reader(bytes, bincode::options());
-    column::deserialize(&mut ColumnDe::default(), &mut de)
+    let mut context = ColumnDe {
+        components: Vec::new(),
+        ds,
+    };
+    column::deserialize(&mut context, &mut de)
 }
 
 /// bincode-encode one value with the options used everywhere here, for
@@ -219,10 +287,10 @@ const WORLD_SIZE: u32 = 24;
 
 #[hegel::test(settings())]
 fn row_format_roundtrips(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, WORLD_SIZE));
-    let world = build_world(&history);
-    let restored = row_world(&row_bytes(&world)).expect("row deserialize");
+    let world = build_world(&history, &ds);
+    let restored = row_world(&row_bytes(&world), &ds).expect("row deserialize");
     assert_eq!(
         fingerprint(&world),
         fingerprint(&restored),
@@ -232,10 +300,10 @@ fn row_format_roundtrips(tc: hegel::TestCase) {
 
 #[hegel::test(settings())]
 fn column_format_roundtrips(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, WORLD_SIZE));
-    let world = build_world(&history);
-    let restored = column_world(&column_bytes(&world)).expect("column deserialize");
+    let world = build_world(&history, &ds);
+    let restored = column_world(&column_bytes(&world), &ds).expect("column deserialize");
     assert_eq!(
         fingerprint(&world),
         fingerprint(&restored),
@@ -247,10 +315,10 @@ fn column_format_roundtrips(tc: hegel::TestCase) {
 /// writes all of their components rather than only the ones `Q` mentions.
 #[hegel::test(settings())]
 fn row_serialize_satisfying_keeps_exactly_the_matching_entities(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, WORLD_SIZE));
-    let world = build_world(&history);
-    let restored = row_world(&row_satisfying_bytes::<&A>(&world)).expect("row deserialize");
+    let world = build_world(&history, &ds);
+    let restored = row_world(&row_satisfying_bytes::<&A>(&world), &ds).expect("row deserialize");
     let want: Fingerprint = fingerprint(&world)
         .into_iter()
         .filter(|(_, cs)| cs.a.is_some())
@@ -264,11 +332,11 @@ fn row_serialize_satisfying_keeps_exactly_the_matching_entities(tc: hegel::TestC
 
 #[hegel::test(settings())]
 fn column_serialize_satisfying_keeps_exactly_the_matching_entities(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, WORLD_SIZE));
-    let world = build_world(&history);
+    let world = build_world(&history, &ds);
     let restored =
-        column_world(&column_satisfying_bytes::<&A>(&world)).expect("column deserialize");
+        column_world(&column_satisfying_bytes::<&A>(&world), &ds).expect("column deserialize");
     let want: Fingerprint = fingerprint(&world)
         .into_iter()
         .filter(|(_, cs)| cs.a.is_some())
@@ -285,13 +353,13 @@ fn column_serialize_satisfying_keeps_exactly_the_matching_entities(tc: hegel::Te
 /// follows the full parse byte for byte until it runs out of input.
 #[hegel::test(settings())]
 fn row_truncated_input_is_rejected_without_leaking(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, WORLD_SIZE));
-    let world = build_world(&history);
+    let world = build_world(&history, &ds);
     let bytes = row_bytes(&world);
     assert_eq!(
         fingerprint(&world),
-        fingerprint(&row_world(&bytes).expect("row deserialize")),
+        fingerprint(&row_world(&bytes, &ds).expect("row deserialize")),
         "row round trip"
     );
     let cut = tc.draw(
@@ -299,14 +367,14 @@ fn row_truncated_input_is_rejected_without_leaking(tc: hegel::TestCase) {
             .min_value(0)
             .max_value(bytes.len() - 1),
     );
-    let baseline = d_live();
+    let baseline = ds.live();
     assert!(
-        row_world(&bytes[..cut]).is_err(),
+        row_world(&bytes[..cut], &ds).is_err(),
         "row prefix {cut}/{} parsed",
         bytes.len()
     );
     assert_eq!(
-        d_live(),
+        ds.live(),
         baseline,
         "row prefix {cut} leaked or double-dropped a component"
     );
@@ -318,13 +386,13 @@ fn row_truncated_input_is_rejected_without_leaking(tc: hegel::TestCase) {
 /// deserialize path.
 #[hegel::test(settings())]
 fn column_truncated_input_is_rejected_without_leaking(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, WORLD_SIZE));
-    let world = build_world(&history);
+    let world = build_world(&history, &ds);
     let bytes = column_bytes(&world);
     assert_eq!(
         fingerprint(&world),
-        fingerprint(&column_world(&bytes).expect("column deserialize")),
+        fingerprint(&column_world(&bytes, &ds).expect("column deserialize")),
         "column round trip"
     );
     let cut = tc.draw(
@@ -332,14 +400,14 @@ fn column_truncated_input_is_rejected_without_leaking(tc: hegel::TestCase) {
             .min_value(0)
             .max_value(bytes.len() - 1),
     );
-    let baseline = d_live();
+    let baseline = ds.live();
     assert!(
-        column_world(&bytes[..cut]).is_err(),
+        column_world(&bytes[..cut], &ds).is_err(),
         "column prefix {cut}/{} parsed",
         bytes.len()
     );
     assert_eq!(
-        d_live(),
+        ds.live(),
         baseline,
         "column prefix {cut} leaked or double-dropped a component"
     );
@@ -378,13 +446,13 @@ fn corrupt(bytes: &mut [u8], flips: &[(usize, u8)]) {
 #[cfg_attr(miri, ignore = "corrupted ids reach allocations Miri cannot afford")]
 #[hegel::test(settings())]
 fn row_corrupted_input_is_rejected_or_usable(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, WORLD_SIZE));
-    let world = build_world(&history);
+    let world = build_world(&history, &ds);
     let mut bytes = row_bytes(&world);
     let flips = tc.draw(corruptions(bytes.len()));
     corrupt(&mut bytes, &flips);
-    let outcome = catch_unwind(AssertUnwindSafe(|| row_world(&bytes)));
+    let outcome = catch_unwind(AssertUnwindSafe(|| row_world(&bytes, &ds)));
     match outcome {
         Ok(Ok(restored)) => drop(fingerprint(&restored)),
         Ok(Err(_)) => {}
@@ -400,13 +468,13 @@ fn row_corrupted_input_is_rejected_or_usable(tc: hegel::TestCase) {
 #[cfg_attr(miri, ignore = "corrupted counts reach allocations Miri cannot afford")]
 #[hegel::test(settings())]
 fn column_corrupted_input_is_rejected_or_usable(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, WORLD_SIZE));
-    let world = build_world(&history);
+    let world = build_world(&history, &ds);
     let mut bytes = column_bytes(&world);
     let flips = tc.draw(corruptions(bytes.len()));
     corrupt(&mut bytes, &flips);
-    let outcome = catch_unwind(AssertUnwindSafe(|| column_world(&bytes)));
+    let outcome = catch_unwind(AssertUnwindSafe(|| column_world(&bytes, &ds)));
     match outcome {
         Ok(Ok(restored)) => drop(fingerprint(&restored)),
         Ok(Err(_)) => {}
@@ -419,12 +487,13 @@ fn column_corrupted_input_is_rejected_or_usable(tc: hegel::TestCase) {
 /// outside the context's enum.
 #[test]
 fn row_rejects_streams_it_cannot_represent() {
+    let ds = DropTracker::new();
     let mut zero_generation = Vec::new();
     zero_generation.extend(encode(&1u64)); // one entity
     zero_generation.extend(encode(&0u64)); // entity bits: generation 0
     zero_generation.extend(encode(&0u64)); // no components
     assert!(
-        row_world(&zero_generation).is_err(),
+        row_world(&zero_generation, &ds).is_err(),
         "accepted a generation-0 entity"
     );
 
@@ -435,7 +504,7 @@ fn row_rejects_streams_it_cannot_represent() {
     unknown_component.extend(encode(&99u32)); // no such Id variant
     unknown_component.extend(encode(&0i32));
     assert!(
-        row_world(&unknown_component).is_err(),
+        row_world(&unknown_component, &ds).is_err(),
         "accepted an unknown component id"
     );
 }
@@ -445,6 +514,7 @@ fn row_rejects_streams_it_cannot_represent() {
 /// deduplicates the type), and an entity list shorter than `entity_count`.
 #[test]
 fn column_rejects_streams_it_cannot_represent() {
+    let ds = DropTracker::new();
     let mut duplicate_column = Vec::new();
     duplicate_column.extend(encode(&1u64)); // one archetype
     duplicate_column.extend(encode(&1u32)); // entity_count
@@ -455,7 +525,7 @@ fn column_rejects_streams_it_cannot_represent() {
     duplicate_column.extend(encode(&0i32)); // first A column
     duplicate_column.extend(encode(&1i32)); // second A column, no space left
     assert!(
-        column_world(&duplicate_column).is_err(),
+        column_world(&duplicate_column, &ds).is_err(),
         "accepted a duplicated component column"
     );
 
@@ -465,7 +535,7 @@ fn column_rejects_streams_it_cannot_represent() {
     short_entity_list.extend(encode(&0u32)); // component_count = 0
     short_entity_list.extend(encode(&(1u64 << 32))); // only one entity id
     assert!(
-        column_world(&short_entity_list).is_err(),
+        column_world(&short_entity_list, &ds).is_err(),
         "accepted a short entity list"
     );
 }
@@ -476,6 +546,7 @@ fn column_rejects_streams_it_cannot_represent() {
 /// fix for issue #449 this reached `Archetype::remove(u32::MAX)`.
 #[test]
 fn column_deserialize_tolerates_repeated_entity_ids() {
+    let ds = DropTracker::new();
     let bits = 1u64 << 32; // generation 1, id 0
     let mut bytes = Vec::new();
     bytes.extend(encode(&1u64)); // one archetype
@@ -487,7 +558,7 @@ fn column_deserialize_tolerates_repeated_entity_ids() {
     bytes.extend(encode(&7i32));
     bytes.extend(encode(&9i32));
 
-    let world = column_world(&bytes).expect("repeated ids are deduplicated, not rejected");
+    let world = column_world(&bytes, &ds).expect("repeated ids are deduplicated, not rejected");
     let e = Entity::from_bits(bits).unwrap();
     assert_eq!(
         world.len(),

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -1,0 +1,514 @@
+//! Round-trip and malformed-input properties for `hecs::serialize::{row, column}`.
+//!
+//! Both formats reinstate entities with `spawn_at`, so a round trip must
+//! preserve the exact `Entity` handles (id and generation) as well as the
+//! components. Malformed input is the other half: these are the only hecs entry
+//! points that take untrusted bytes, so the properties here assert that a
+//! stream that is not a valid serialization is rejected rather than accepted or
+//! panicked on, and that a rejected stream does not leak the components it had
+//! already parsed. `D` is drop-tracked and deserialized through its own
+//! constructor, which is what makes the leak half checkable.
+
+mod common;
+
+use std::any::TypeId;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use bincode::Options;
+use common::*;
+use hecs::serialize::{column, row};
+use hecs::{
+    Archetype, ColumnBatchBuilder, ColumnBatchType, Entity, EntityBuilder, EntityRef, Query, World,
+};
+use hegel::generators as gs;
+use serde::{Deserialize, Serialize};
+
+/// Wire identifiers for the component universe. The bincode encoding of these
+/// discriminants is `A = 0 .. D = 3`, so anything above 3 is an unknown-variant
+/// error on the way back in.
+#[derive(Clone, Copy, Serialize, Deserialize)]
+enum Id {
+    A,
+    B,
+    C,
+    D,
+}
+
+// ---- row format ----
+
+struct Row;
+
+impl row::SerializeContext for Row {
+    fn serialize_entity<S>(&mut self, entity: EntityRef<'_>, mut map: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::SerializeMap,
+    {
+        row::try_serialize::<A, _, _>(&entity, &Id::A, &mut map)?;
+        row::try_serialize::<B, _, _>(&entity, &Id::B, &mut map)?;
+        row::try_serialize::<C, _, _>(&entity, &Id::C, &mut map)?;
+        row::try_serialize::<D, _, _>(&entity, &Id::D, &mut map)?;
+        map.end()
+    }
+
+    /// Length-prefixed formats such as bincode need this.
+    fn component_count(&self, entity: EntityRef<'_>) -> Option<usize> {
+        Some(entity.len())
+    }
+}
+
+impl row::DeserializeContext for Row {
+    fn deserialize_entity<'de, M>(
+        &mut self,
+        mut map: M,
+        entity: &mut EntityBuilder,
+    ) -> Result<(), M::Error>
+    where
+        M: serde::de::MapAccess<'de>,
+    {
+        while let Some(key) = map.next_key()? {
+            match key {
+                Id::A => entity.add::<A>(map.next_value()?),
+                Id::B => entity.add::<B>(map.next_value()?),
+                Id::C => entity.add::<C>(map.next_value()?),
+                Id::D => entity.add::<D>(map.next_value()?),
+            };
+        }
+        Ok(())
+    }
+}
+
+fn row_bytes(world: &World) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let mut ser = bincode::Serializer::new(&mut buf, bincode::options());
+    row::serialize(world, &mut Row, &mut ser).expect("row serialize");
+    buf
+}
+
+fn row_satisfying_bytes<Q: Query>(world: &World) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let mut ser = bincode::Serializer::new(&mut buf, bincode::options());
+    row::serialize_satisfying::<Q, _, _>(world, &mut Row, &mut ser)
+        .expect("row serialize_satisfying");
+    buf
+}
+
+fn row_world(bytes: &[u8]) -> Result<World, bincode::Error> {
+    let mut de = bincode::Deserializer::with_reader(bytes, bincode::options());
+    row::deserialize(&mut Row, &mut de)
+}
+
+// ---- column format ----
+
+struct ColumnSer;
+
+impl column::SerializeContext for ColumnSer {
+    fn component_count(&self, archetype: &Archetype) -> usize {
+        archetype
+            .component_types()
+            .filter(|&t| {
+                t == TypeId::of::<A>()
+                    || t == TypeId::of::<B>()
+                    || t == TypeId::of::<C>()
+                    || t == TypeId::of::<D>()
+            })
+            .count()
+    }
+
+    fn serialize_component_ids<S: serde::ser::SerializeTuple>(
+        &mut self,
+        archetype: &Archetype,
+        mut out: S,
+    ) -> Result<S::Ok, S::Error> {
+        column::try_serialize_id::<A, _, _>(archetype, &Id::A, &mut out)?;
+        column::try_serialize_id::<B, _, _>(archetype, &Id::B, &mut out)?;
+        column::try_serialize_id::<C, _, _>(archetype, &Id::C, &mut out)?;
+        column::try_serialize_id::<D, _, _>(archetype, &Id::D, &mut out)?;
+        out.end()
+    }
+
+    fn serialize_components<S: serde::ser::SerializeTuple>(
+        &mut self,
+        archetype: &Archetype,
+        mut out: S,
+    ) -> Result<S::Ok, S::Error> {
+        column::try_serialize::<A, _>(archetype, &mut out)?;
+        column::try_serialize::<B, _>(archetype, &mut out)?;
+        column::try_serialize::<C, _>(archetype, &mut out)?;
+        column::try_serialize::<D, _>(archetype, &mut out)?;
+        out.end()
+    }
+}
+
+#[derive(Default)]
+struct ColumnDe {
+    components: Vec<Id>,
+}
+
+impl column::DeserializeContext for ColumnDe {
+    fn deserialize_component_ids<'de, S>(&mut self, mut seq: S) -> Result<ColumnBatchType, S::Error>
+    where
+        S: serde::de::SeqAccess<'de>,
+    {
+        self.components.clear();
+        let mut batch = ColumnBatchType::new();
+        while let Some(id) = seq.next_element()? {
+            match id {
+                Id::A => batch.add::<A>(),
+                Id::B => batch.add::<B>(),
+                Id::C => batch.add::<C>(),
+                Id::D => batch.add::<D>(),
+            };
+            self.components.push(id);
+        }
+        Ok(batch)
+    }
+
+    fn deserialize_components<'de, S>(
+        &mut self,
+        entity_count: u32,
+        mut seq: S,
+        batch: &mut ColumnBatchBuilder,
+    ) -> Result<(), S::Error>
+    where
+        S: serde::de::SeqAccess<'de>,
+    {
+        for id in &self.components {
+            match id {
+                Id::A => column::deserialize_column::<A, _>(entity_count, &mut seq, batch)?,
+                Id::B => column::deserialize_column::<B, _>(entity_count, &mut seq, batch)?,
+                Id::C => column::deserialize_column::<C, _>(entity_count, &mut seq, batch)?,
+                Id::D => column::deserialize_column::<D, _>(entity_count, &mut seq, batch)?,
+            }
+        }
+        Ok(())
+    }
+}
+
+fn column_bytes(world: &World) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let mut ser = bincode::Serializer::new(&mut buf, bincode::options());
+    column::serialize(world, &mut ColumnSer, &mut ser).expect("column serialize");
+    buf
+}
+
+fn column_satisfying_bytes<Q: Query>(world: &World) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let mut ser = bincode::Serializer::new(&mut buf, bincode::options());
+    column::serialize_satisfying::<Q, _, _>(world, &mut ColumnSer, &mut ser)
+        .expect("column serialize_satisfying");
+    buf
+}
+
+fn column_world(bytes: &[u8]) -> Result<World, bincode::Error> {
+    let mut de = bincode::Deserializer::with_reader(bytes, bincode::options());
+    column::deserialize(&mut ColumnDe::default(), &mut de)
+}
+
+/// bincode-encode one value with the options used everywhere here, for
+/// hand-writing malformed streams.
+fn encode<T: Serialize>(value: &T) -> Vec<u8> {
+    bincode::options().serialize(value).expect("encode")
+}
+
+/// Round trips want enough entities to spread over many archetypes. Under Miri
+/// the serde machinery is by far the slowest thing in this suite, so the bound
+/// there drops to the smallest size that still makes the handle-preservation
+/// claim non-trivial.
+#[cfg(miri)]
+const WORLD_SIZE: u32 = 3;
+#[cfg(not(miri))]
+const WORLD_SIZE: u32 = 24;
+
+/// A world whose entities cover arbitrary component subsets, with despawns
+/// interleaved so ids get recycled and generations advance — which is what
+/// makes handle preservation a non-trivial claim.
+fn arbitrary_world(tc: &hegel::TestCase, max_entities: u32) -> World {
+    let mut world = World::new();
+    let mut live: Vec<Entity> = Vec::new();
+    for _ in 0..tc.draw(gs::integers::<u32>().min_value(0).max_value(max_entities)) {
+        if !live.is_empty() && tc.draw(gs::weighted_booleans(0.25)) {
+            let i = tc.draw(
+                gs::integers::<usize>()
+                    .min_value(0)
+                    .max_value(live.len() - 1),
+            );
+            world
+                .despawn(live.swap_remove(i))
+                .expect("despawn of a live entity");
+        } else {
+            live.push(world.spawn(make_builder(tc.draw(specs())).build()));
+        }
+    }
+    world
+}
+
+#[hegel::test(settings())]
+fn row_format_roundtrips(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let world = arbitrary_world(&tc, WORLD_SIZE);
+    let restored = row_world(&row_bytes(&world)).expect("row deserialize");
+    assert_eq!(
+        fingerprint(&world),
+        fingerprint(&restored),
+        "row round trip"
+    );
+}
+
+#[hegel::test(settings())]
+fn column_format_roundtrips(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let world = arbitrary_world(&tc, WORLD_SIZE);
+    let restored = column_world(&column_bytes(&world)).expect("column deserialize");
+    assert_eq!(
+        fingerprint(&world),
+        fingerprint(&restored),
+        "column round trip"
+    );
+}
+
+/// `serialize_satisfying::<Q>` writes exactly the entities matching `Q`, and
+/// writes all of their components rather than only the ones `Q` mentions.
+#[hegel::test(settings())]
+fn row_serialize_satisfying_keeps_exactly_the_matching_entities(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let world = arbitrary_world(&tc, WORLD_SIZE);
+    let restored = row_world(&row_satisfying_bytes::<&A>(&world)).expect("row deserialize");
+    let want: Fingerprint = fingerprint(&world)
+        .into_iter()
+        .filter(|(_, s)| s.a.is_some())
+        .collect();
+    assert_eq!(
+        want,
+        fingerprint(&restored),
+        "row serialize_satisfying::<&A>"
+    );
+}
+
+#[hegel::test(settings())]
+fn column_serialize_satisfying_keeps_exactly_the_matching_entities(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let world = arbitrary_world(&tc, WORLD_SIZE);
+    let restored =
+        column_world(&column_satisfying_bytes::<&A>(&world)).expect("column deserialize");
+    let want: Fingerprint = fingerprint(&world)
+        .into_iter()
+        .filter(|(_, s)| s.a.is_some())
+        .collect();
+    assert_eq!(
+        want,
+        fingerprint(&restored),
+        "column serialize_satisfying::<&A>"
+    );
+}
+
+/// A strict prefix of a valid stream is rejected, and nothing the failed parse
+/// had already built survives. bincode parsing is deterministic, so a prefix
+/// follows the full parse byte for byte until it runs out of input.
+#[hegel::test(settings())]
+fn row_truncated_input_is_rejected_without_leaking(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let world = arbitrary_world(&tc, WORLD_SIZE);
+    let bytes = row_bytes(&world);
+    assert_eq!(
+        fingerprint(&world),
+        fingerprint(&row_world(&bytes).expect("row deserialize")),
+        "row round trip"
+    );
+    let cut = tc.draw(
+        gs::integers::<usize>()
+            .min_value(0)
+            .max_value(bytes.len() - 1),
+    );
+    let baseline = d_live();
+    assert!(
+        row_world(&bytes[..cut]).is_err(),
+        "row prefix {cut}/{} parsed",
+        bytes.len()
+    );
+    assert_eq!(
+        d_live(),
+        baseline,
+        "row prefix {cut} leaked or double-dropped a component"
+    );
+}
+
+/// The column counterpart. A failed column parse leaves the components it had
+/// already read in a `ColumnBatchBuilder` that is then dropped; that builder
+/// leaked them all (issue #450), so this is the regression witness for the
+/// deserialize path.
+#[hegel::test(settings())]
+fn column_truncated_input_is_rejected_without_leaking(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let world = arbitrary_world(&tc, WORLD_SIZE);
+    let bytes = column_bytes(&world);
+    assert_eq!(
+        fingerprint(&world),
+        fingerprint(&column_world(&bytes).expect("column deserialize")),
+        "column round trip"
+    );
+    let cut = tc.draw(
+        gs::integers::<usize>()
+            .min_value(0)
+            .max_value(bytes.len() - 1),
+    );
+    let baseline = d_live();
+    assert!(
+        column_world(&bytes[..cut]).is_err(),
+        "column prefix {cut}/{} parsed",
+        bytes.len()
+    );
+    assert_eq!(
+        d_live(),
+        baseline,
+        "column prefix {cut} leaked or double-dropped a component"
+    );
+}
+
+/// Flip the low two bits of a few drawn positions. This still reaches unknown
+/// enum discriminants, invalid entity bit patterns, colliding entity ids,
+/// bincode length-marker mutations and corrupted payloads, while bounding every
+/// count and id the parser can derive from the stream: both deserializers size
+/// allocations from untrusted integers before validating them (row grows the
+/// entity metadata table up to the deserialized id, column reserves from
+/// `entity_count`), so a full-byte overwrite can ask for tens of gigabytes.
+fn corrupt(tc: &hegel::TestCase, bytes: &mut [u8]) {
+    for _ in 0..tc.draw(gs::integers::<u32>().min_value(1).max_value(3)) {
+        let at = tc.draw(
+            gs::integers::<usize>()
+                .min_value(0)
+                .max_value(bytes.len() - 1),
+        );
+        let mask = tc.draw(gs::integers::<u8>().min_value(1).max_value(3));
+        bytes[at] ^= mask;
+    }
+}
+
+/// Corrupting a stream must produce either an error or a usable world — never a
+/// panic, and never a world with a duplicated handle. `Ok` is legitimate:
+/// flipping bits of a payload byte yields a different valid stream.
+///
+/// Not run under Miri: a corrupted entity id makes `spawn_at` grow the metadata
+/// table to that id, which is a few tens of megabytes at worst here but is far
+/// beyond what the interpreter can track in reasonable time.
+#[cfg_attr(miri, ignore = "corrupted ids reach allocations Miri cannot afford")]
+#[hegel::test(settings())]
+fn row_corrupted_input_is_rejected_or_usable(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let world = arbitrary_world(&tc, WORLD_SIZE);
+    let mut bytes = row_bytes(&world);
+    corrupt(&tc, &mut bytes);
+    let outcome = catch_unwind(AssertUnwindSafe(|| row_world(&bytes)));
+    match outcome {
+        Ok(Ok(restored)) => drop(fingerprint(&restored)),
+        Ok(Err(_)) => {}
+        Err(_) => panic!("row deserialize panicked on a corrupted stream"),
+    }
+}
+
+/// The column counterpart. Corrupting the entity-id region routinely produces
+/// colliding ids, which used to reach an out-of-bounds write in
+/// `spawn_column_batch_at` (issue #449), so this doubles as the regression
+/// witness for that fix. Not run under Miri, for the same reason as its row
+/// counterpart: `entity_count` drives a `reserve` before it is validated.
+#[cfg_attr(miri, ignore = "corrupted counts reach allocations Miri cannot afford")]
+#[hegel::test(settings())]
+fn column_corrupted_input_is_rejected_or_usable(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let world = arbitrary_world(&tc, WORLD_SIZE);
+    let mut bytes = column_bytes(&world);
+    corrupt(&tc, &mut bytes);
+    let outcome = catch_unwind(AssertUnwindSafe(|| column_world(&bytes)));
+    match outcome {
+        Ok(Ok(restored)) => drop(fingerprint(&restored)),
+        Ok(Err(_)) => {}
+        Err(_) => panic!("column deserialize panicked on a corrupted stream"),
+    }
+}
+
+/// Streams that are well-formed bincode but not valid hecs serializations must
+/// be rejected: an entity bit pattern with generation 0, and a component id
+/// outside the context's enum.
+#[test]
+fn row_rejects_streams_it_cannot_represent() {
+    let mut zero_generation = Vec::new();
+    zero_generation.extend(encode(&1u64)); // one entity
+    zero_generation.extend(encode(&0u64)); // entity bits: generation 0
+    zero_generation.extend(encode(&0u64)); // no components
+    assert!(
+        row_world(&zero_generation).is_err(),
+        "accepted a generation-0 entity"
+    );
+
+    let mut unknown_component = Vec::new();
+    unknown_component.extend(encode(&1u64)); // one entity
+    unknown_component.extend(encode(&(1u64 << 32))); // generation 1, id 0
+    unknown_component.extend(encode(&1u64)); // one component
+    unknown_component.extend(encode(&99u32)); // no such Id variant
+    unknown_component.extend(encode(&0i32));
+    assert!(
+        row_world(&unknown_component).is_err(),
+        "accepted an unknown component id"
+    );
+}
+
+/// The column counterparts: an archetype that declares the same component
+/// twice (the second column has nowhere to go, because `ColumnBatchType`
+/// deduplicates the type), and an entity list shorter than `entity_count`.
+#[test]
+fn column_rejects_streams_it_cannot_represent() {
+    let mut duplicate_column = Vec::new();
+    duplicate_column.extend(encode(&1u64)); // one archetype
+    duplicate_column.extend(encode(&1u32)); // entity_count
+    duplicate_column.extend(encode(&2u32)); // component_count
+    duplicate_column.extend(encode(&0u32)); // Id::A
+    duplicate_column.extend(encode(&0u32)); // Id::A again
+    duplicate_column.extend(encode(&(1u64 << 32))); // generation 1, id 0
+    duplicate_column.extend(encode(&0i32)); // first A column
+    duplicate_column.extend(encode(&1i32)); // second A column, no space left
+    assert!(
+        column_world(&duplicate_column).is_err(),
+        "accepted a duplicated component column"
+    );
+
+    let mut short_entity_list = Vec::new();
+    short_entity_list.extend(encode(&1u64)); // one archetype
+    short_entity_list.extend(encode(&2u32)); // entity_count = 2
+    short_entity_list.extend(encode(&0u32)); // component_count = 0
+    short_entity_list.extend(encode(&(1u64 << 32))); // only one entity id
+    assert!(
+        column_world(&short_entity_list).is_err(),
+        "accepted a short entity list"
+    );
+}
+
+/// A column archetype whose entity-id list repeats an id is accepted, with the
+/// last row for that id winning and the world left self-consistent — the same
+/// semantics `spawn_column_batch_at_redundant` in src/world.rs pins. Before the
+/// fix for issue #449 this reached `Archetype::remove(u32::MAX)`.
+#[test]
+fn column_deserialize_tolerates_repeated_entity_ids() {
+    let bits = 1u64 << 32; // generation 1, id 0
+    let mut bytes = Vec::new();
+    bytes.extend(encode(&1u64)); // one archetype
+    bytes.extend(encode(&2u32)); // entity_count = 2
+    bytes.extend(encode(&1u32)); // component_count = 1
+    bytes.extend(encode(&0u32)); // Id::A
+    bytes.extend(encode(&bits));
+    bytes.extend(encode(&bits)); // the same id twice
+    bytes.extend(encode(&7i32));
+    bytes.extend(encode(&9i32));
+
+    let world = column_world(&bytes).expect("repeated ids are deduplicated, not rejected");
+    let e = Entity::from_bits(bits).unwrap();
+    assert_eq!(
+        world.len(),
+        1,
+        "a repeated id produced more than one entity"
+    );
+    assert_eq!(
+        fingerprint(&world).get(&e).and_then(|s| s.a),
+        Some(9),
+        "the last row must win"
+    );
+    check_archetypes(&world, "deduplicated world");
+}

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -21,7 +21,7 @@ use hecs::{
 use hegel::generators as gs;
 use serde::{Deserialize, Serialize};
 
-/// Wire identifiers for the component universe. The bincode encoding of these
+/// Wire identifiers for the four component types. The bincode encoding of these
 /// discriminants is `A = 0 .. D = 3`, so anything above 3 is an unknown-variant
 /// error on the way back in.
 #[derive(Clone, Copy, Serialize, Deserialize)]
@@ -253,7 +253,7 @@ fn row_serialize_satisfying_keeps_exactly_the_matching_entities(tc: hegel::TestC
     let restored = row_world(&row_satisfying_bytes::<&A>(&world)).expect("row deserialize");
     let want: Fingerprint = fingerprint(&world)
         .into_iter()
-        .filter(|(_, s)| s.a.is_some())
+        .filter(|(_, cs)| cs.a.is_some())
         .collect();
     assert_eq!(
         want,
@@ -271,7 +271,7 @@ fn column_serialize_satisfying_keeps_exactly_the_matching_entities(tc: hegel::Te
         column_world(&column_satisfying_bytes::<&A>(&world)).expect("column deserialize");
     let want: Fingerprint = fingerprint(&world)
         .into_iter()
-        .filter(|(_, s)| s.a.is_some())
+        .filter(|(_, cs)| cs.a.is_some())
         .collect();
     assert_eq!(
         want,
@@ -495,7 +495,7 @@ fn column_deserialize_tolerates_repeated_entity_ids() {
         "a repeated id produced more than one entity"
     );
     assert_eq!(
-        fingerprint(&world).get(&e).and_then(|s| s.a),
+        fingerprint(&world).get(&e).and_then(|cs| cs.a),
         Some(9),
         "the last row must win"
     );

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -10,9 +10,8 @@
 //! constructor, which is what makes the leak half checkable.
 
 use std::any::TypeId;
-use std::panic::{catch_unwind, AssertUnwindSafe};
-
 use std::fmt;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use bincode::Options;
 use fixtures::*;
@@ -476,21 +475,25 @@ fn column_corrupted_input_is_rejected_or_usable(tc: hegel::TestCase) {
 #[test]
 fn row_rejects_streams_it_cannot_represent() {
     let ds = DropTracker::new();
-    let mut zero_generation = Vec::new();
-    zero_generation.extend(encode(&1u64)); // one entity
-    zero_generation.extend(encode(&0u64)); // entity bits: generation 0
-    zero_generation.extend(encode(&0u64)); // no components
+    let zero_generation = [
+        encode(&1u64), // one entity
+        encode(&0u64), // entity bits: generation 0
+        encode(&0u64), // no components
+    ]
+    .concat();
     assert!(
         RowFormat::world(&zero_generation, &ds).is_err(),
         "accepted a generation-0 entity"
     );
 
-    let mut unknown_component = Vec::new();
-    unknown_component.extend(encode(&1u64)); // one entity
-    unknown_component.extend(encode(&(1u64 << 32))); // generation 1, id 0
-    unknown_component.extend(encode(&1u64)); // one component
-    unknown_component.extend(encode(&99u32)); // no such Id variant
-    unknown_component.extend(encode(&0i32));
+    let unknown_component = [
+        encode(&1u64),         // one entity
+        encode(&(1u64 << 32)), // generation 1, id 0
+        encode(&1u64),         // one component
+        encode(&99u32),        // no such Id variant
+        encode(&0i32),
+    ]
+    .concat();
     assert!(
         RowFormat::world(&unknown_component, &ds).is_err(),
         "accepted an unknown component id"
@@ -503,25 +506,29 @@ fn row_rejects_streams_it_cannot_represent() {
 #[test]
 fn column_rejects_streams_it_cannot_represent() {
     let ds = DropTracker::new();
-    let mut duplicate_column = Vec::new();
-    duplicate_column.extend(encode(&1u64)); // one archetype
-    duplicate_column.extend(encode(&1u32)); // entity_count
-    duplicate_column.extend(encode(&2u32)); // component_count
-    duplicate_column.extend(encode(&0u32)); // Id::A
-    duplicate_column.extend(encode(&0u32)); // Id::A again
-    duplicate_column.extend(encode(&(1u64 << 32))); // generation 1, id 0
-    duplicate_column.extend(encode(&0i32)); // first A column
-    duplicate_column.extend(encode(&1i32)); // second A column, no space left
+    let duplicate_column = [
+        encode(&1u64),         // one archetype
+        encode(&1u32),         // entity_count
+        encode(&2u32),         // component_count
+        encode(&0u32),         // Id::A
+        encode(&0u32),         // Id::A again
+        encode(&(1u64 << 32)), // generation 1, id 0
+        encode(&0i32),         // first A column
+        encode(&1i32),         // second A column, no space left
+    ]
+    .concat();
     assert!(
         ColumnFormat::world(&duplicate_column, &ds).is_err(),
         "accepted a duplicated component column"
     );
 
-    let mut short_entity_list = Vec::new();
-    short_entity_list.extend(encode(&1u64)); // one archetype
-    short_entity_list.extend(encode(&2u32)); // entity_count = 2
-    short_entity_list.extend(encode(&0u32)); // component_count = 0
-    short_entity_list.extend(encode(&(1u64 << 32))); // only one entity id
+    let short_entity_list = [
+        encode(&1u64),         // one archetype
+        encode(&2u32),         // entity_count = 2
+        encode(&0u32),         // component_count = 0
+        encode(&(1u64 << 32)), // only one entity id
+    ]
+    .concat();
     assert!(
         ColumnFormat::world(&short_entity_list, &ds).is_err(),
         "accepted a short entity list"
@@ -536,15 +543,17 @@ fn column_rejects_streams_it_cannot_represent() {
 fn column_deserialize_tolerates_repeated_entity_ids() {
     let ds = DropTracker::new();
     let bits = 1u64 << 32; // generation 1, id 0
-    let mut bytes = Vec::new();
-    bytes.extend(encode(&1u64)); // one archetype
-    bytes.extend(encode(&2u32)); // entity_count = 2
-    bytes.extend(encode(&1u32)); // component_count = 1
-    bytes.extend(encode(&0u32)); // Id::A
-    bytes.extend(encode(&bits));
-    bytes.extend(encode(&bits)); // the same id twice
-    bytes.extend(encode(&7i32));
-    bytes.extend(encode(&9i32));
+    let bytes = [
+        encode(&1u64), // one archetype
+        encode(&2u32), // entity_count = 2
+        encode(&1u32), // component_count = 1
+        encode(&0u32), // Id::A
+        encode(&bits),
+        encode(&bits), // the same id twice
+        encode(&7i32),
+        encode(&9i32),
+    ]
+    .concat();
 
     let world =
         ColumnFormat::world(&bytes, &ds).expect("repeated ids are deduplicated, not rejected");

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -219,33 +219,11 @@ const WORLD_SIZE: u32 = 3;
 #[cfg(not(miri))]
 const WORLD_SIZE: u32 = 24;
 
-/// A world whose entities cover arbitrary component subsets, with despawns
-/// interleaved so ids get recycled and generations advance — which is what
-/// makes handle preservation a non-trivial claim.
-fn arbitrary_world(tc: &hegel::TestCase, max_entities: u32) -> World {
-    let mut world = World::new();
-    let mut live: Vec<Entity> = Vec::new();
-    for _ in 0..tc.draw(gs::integers::<u32>().min_value(0).max_value(max_entities)) {
-        if !live.is_empty() && tc.draw(gs::weighted_booleans(0.25)) {
-            let i = tc.draw(
-                gs::integers::<usize>()
-                    .min_value(0)
-                    .max_value(live.len() - 1),
-            );
-            world
-                .despawn(live.swap_remove(i))
-                .expect("despawn of a live entity");
-        } else {
-            live.push(world.spawn(make_builder(tc.draw(specs())).build()));
-        }
-    }
-    world
-}
-
 #[hegel::test(settings())]
 fn row_format_roundtrips(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let world = arbitrary_world(&tc, WORLD_SIZE);
+    let history = tc.draw(histories(0, WORLD_SIZE));
+    let world = build_world(&history);
     let restored = row_world(&row_bytes(&world)).expect("row deserialize");
     assert_eq!(
         fingerprint(&world),
@@ -257,7 +235,8 @@ fn row_format_roundtrips(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn column_format_roundtrips(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let world = arbitrary_world(&tc, WORLD_SIZE);
+    let history = tc.draw(histories(0, WORLD_SIZE));
+    let world = build_world(&history);
     let restored = column_world(&column_bytes(&world)).expect("column deserialize");
     assert_eq!(
         fingerprint(&world),
@@ -271,7 +250,8 @@ fn column_format_roundtrips(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn row_serialize_satisfying_keeps_exactly_the_matching_entities(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let world = arbitrary_world(&tc, WORLD_SIZE);
+    let history = tc.draw(histories(0, WORLD_SIZE));
+    let world = build_world(&history);
     let restored = row_world(&row_satisfying_bytes::<&A>(&world)).expect("row deserialize");
     let want: Fingerprint = fingerprint(&world)
         .into_iter()
@@ -287,7 +267,8 @@ fn row_serialize_satisfying_keeps_exactly_the_matching_entities(tc: hegel::TestC
 #[hegel::test(settings())]
 fn column_serialize_satisfying_keeps_exactly_the_matching_entities(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let world = arbitrary_world(&tc, WORLD_SIZE);
+    let history = tc.draw(histories(0, WORLD_SIZE));
+    let world = build_world(&history);
     let restored =
         column_world(&column_satisfying_bytes::<&A>(&world)).expect("column deserialize");
     let want: Fingerprint = fingerprint(&world)
@@ -307,7 +288,8 @@ fn column_serialize_satisfying_keeps_exactly_the_matching_entities(tc: hegel::Te
 #[hegel::test(settings())]
 fn row_truncated_input_is_rejected_without_leaking(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let world = arbitrary_world(&tc, WORLD_SIZE);
+    let history = tc.draw(histories(0, WORLD_SIZE));
+    let world = build_world(&history);
     let bytes = row_bytes(&world);
     assert_eq!(
         fingerprint(&world),
@@ -339,7 +321,8 @@ fn row_truncated_input_is_rejected_without_leaking(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn column_truncated_input_is_rejected_without_leaking(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let world = arbitrary_world(&tc, WORLD_SIZE);
+    let history = tc.draw(histories(0, WORLD_SIZE));
+    let world = build_world(&history);
     let bytes = column_bytes(&world);
     assert_eq!(
         fingerprint(&world),
@@ -364,21 +347,25 @@ fn column_truncated_input_is_rejected_without_leaking(tc: hegel::TestCase) {
     );
 }
 
-/// Flip the low two bits of a few drawn positions. This still reaches unknown
-/// enum discriminants, invalid entity bit patterns, colliding entity ids,
-/// bincode length-marker mutations and corrupted payloads, while bounding every
-/// count and id the parser can derive from the stream: both deserializers size
-/// allocations from untrusted integers before validating them (row grows the
-/// entity metadata table up to the deserialized id, column reserves from
-/// `entity_count`), so a full-byte overwrite can ask for tens of gigabytes.
-fn corrupt(tc: &hegel::TestCase, bytes: &mut [u8]) {
-    for _ in 0..tc.draw(gs::integers::<u32>().min_value(1).max_value(3)) {
-        let at = tc.draw(
-            gs::integers::<usize>()
-                .min_value(0)
-                .max_value(bytes.len() - 1),
-        );
-        let mask = tc.draw(gs::integers::<u8>().min_value(1).max_value(3));
+/// One to three `(position, mask)` pairs flipping the low two bits of a byte in
+/// a stream of `len` bytes. This still reaches unknown enum discriminants,
+/// invalid entity bit patterns, colliding entity ids, bincode length-marker
+/// mutations and corrupted payloads, while bounding every count and id the
+/// parser can derive from the stream: both deserializers size allocations from
+/// untrusted integers before validating them (row grows the entity metadata
+/// table up to the deserialized id, column reserves from `entity_count`), so a
+/// full-byte overwrite can ask for tens of gigabytes.
+fn corruptions(len: usize) -> impl gs::PrintableGenerator<Vec<(usize, u8)>> {
+    gs::vecs(hegel::tuples!(
+        gs::integers::<usize>().min_value(0).max_value(len - 1),
+        gs::integers::<u8>().min_value(1).max_value(3),
+    ))
+    .min_size(1)
+    .max_size(3)
+}
+
+fn corrupt(bytes: &mut [u8], flips: &[(usize, u8)]) {
+    for &(at, mask) in flips {
         bytes[at] ^= mask;
     }
 }
@@ -394,9 +381,11 @@ fn corrupt(tc: &hegel::TestCase, bytes: &mut [u8]) {
 #[hegel::test(settings())]
 fn row_corrupted_input_is_rejected_or_usable(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let world = arbitrary_world(&tc, WORLD_SIZE);
+    let history = tc.draw(histories(0, WORLD_SIZE));
+    let world = build_world(&history);
     let mut bytes = row_bytes(&world);
-    corrupt(&tc, &mut bytes);
+    let flips = tc.draw(corruptions(bytes.len()));
+    corrupt(&mut bytes, &flips);
     let outcome = catch_unwind(AssertUnwindSafe(|| row_world(&bytes)));
     match outcome {
         Ok(Ok(restored)) => drop(fingerprint(&restored)),
@@ -414,9 +403,11 @@ fn row_corrupted_input_is_rejected_or_usable(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn column_corrupted_input_is_rejected_or_usable(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let world = arbitrary_world(&tc, WORLD_SIZE);
+    let history = tc.draw(histories(0, WORLD_SIZE));
+    let world = build_world(&history);
     let mut bytes = column_bytes(&world);
-    corrupt(&tc, &mut bytes);
+    let flips = tc.draw(corruptions(bytes.len()));
+    corrupt(&mut bytes, &flips);
     let outcome = catch_unwind(AssertUnwindSafe(|| column_world(&bytes)));
     match outcome {
         Ok(Ok(restored)) => drop(fingerprint(&restored)),

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -80,26 +80,6 @@ impl row::DeserializeContext for RowDe<'_> {
     }
 }
 
-fn row_bytes(world: &World) -> Vec<u8> {
-    let mut buf = Vec::new();
-    let mut ser = bincode::Serializer::new(&mut buf, bincode::options());
-    row::serialize(world, &mut Row, &mut ser).expect("row serialize");
-    buf
-}
-
-fn row_satisfying_bytes<Q: Query>(world: &World) -> Vec<u8> {
-    let mut buf = Vec::new();
-    let mut ser = bincode::Serializer::new(&mut buf, bincode::options());
-    row::serialize_satisfying::<Q, _, _>(world, &mut Row, &mut ser)
-        .expect("row serialize_satisfying");
-    buf
-}
-
-fn row_world(bytes: &[u8], ds: &DropTracker) -> Result<World, bincode::Error> {
-    let mut de = bincode::Deserializer::with_reader(bytes, bincode::options());
-    row::deserialize(&mut RowDe(ds), &mut de)
-}
-
 // ---- column format ----
 
 struct ColumnSer;
@@ -246,28 +226,64 @@ impl<'de> Visitor<'de> for DColumn<'_> {
     }
 }
 
-fn column_bytes(world: &World) -> Vec<u8> {
+/// One of the two formats, behind the bincode plumbing every test shares.
+trait Format {
+    const NAME: &'static str;
+    fn bytes(world: &World) -> Vec<u8>;
+    fn satisfying_bytes<Q: Query>(world: &World) -> Vec<u8>;
+    fn world(bytes: &[u8], ds: &DropTracker) -> Result<World, bincode::Error>;
+}
+
+fn serialized(
+    write: impl FnOnce(
+        &mut bincode::Serializer<&mut Vec<u8>, bincode::DefaultOptions>,
+    ) -> bincode::Result<()>,
+) -> Vec<u8> {
     let mut buf = Vec::new();
-    let mut ser = bincode::Serializer::new(&mut buf, bincode::options());
-    column::serialize(world, &mut ColumnSer, &mut ser).expect("column serialize");
+    write(&mut bincode::Serializer::new(&mut buf, bincode::options())).expect("serialize");
     buf
 }
 
-fn column_satisfying_bytes<Q: Query>(world: &World) -> Vec<u8> {
-    let mut buf = Vec::new();
-    let mut ser = bincode::Serializer::new(&mut buf, bincode::options());
-    column::serialize_satisfying::<Q, _, _>(world, &mut ColumnSer, &mut ser)
-        .expect("column serialize_satisfying");
-    buf
+struct RowFormat;
+
+impl Format for RowFormat {
+    const NAME: &'static str = "row";
+
+    fn bytes(world: &World) -> Vec<u8> {
+        serialized(|ser| row::serialize(world, &mut Row, ser))
+    }
+
+    fn satisfying_bytes<Q: Query>(world: &World) -> Vec<u8> {
+        serialized(|ser| row::serialize_satisfying::<Q, _, _>(world, &mut Row, ser))
+    }
+
+    fn world(bytes: &[u8], ds: &DropTracker) -> Result<World, bincode::Error> {
+        let mut de = bincode::Deserializer::with_reader(bytes, bincode::options());
+        row::deserialize(&mut RowDe(ds), &mut de)
+    }
 }
 
-fn column_world(bytes: &[u8], ds: &DropTracker) -> Result<World, bincode::Error> {
-    let mut de = bincode::Deserializer::with_reader(bytes, bincode::options());
-    let mut context = ColumnDe {
-        components: Vec::new(),
-        ds,
-    };
-    column::deserialize(&mut context, &mut de)
+struct ColumnFormat;
+
+impl Format for ColumnFormat {
+    const NAME: &'static str = "column";
+
+    fn bytes(world: &World) -> Vec<u8> {
+        serialized(|ser| column::serialize(world, &mut ColumnSer, ser))
+    }
+
+    fn satisfying_bytes<Q: Query>(world: &World) -> Vec<u8> {
+        serialized(|ser| column::serialize_satisfying::<Q, _, _>(world, &mut ColumnSer, ser))
+    }
+
+    fn world(bytes: &[u8], ds: &DropTracker) -> Result<World, bincode::Error> {
+        let mut de = bincode::Deserializer::with_reader(bytes, bincode::options());
+        let mut context = ColumnDe {
+            components: Vec::new(),
+            ds,
+        };
+        column::deserialize(&mut context, &mut de)
+    }
 }
 
 /// bincode-encode one value with the options used everywhere here, for
@@ -282,132 +298,107 @@ fn encode<T: Serialize>(value: &T) -> Vec<u8> {
 /// claim non-trivial.
 const WORLD_SIZE: u32 = if cfg!(miri) { 3 } else { 24 };
 
+fn check_roundtrip<F: Format>(world: &World, ds: &DropTracker) {
+    let restored = F::world(&F::bytes(world), ds).expect("deserialize");
+    assert_eq!(
+        fingerprint(world),
+        fingerprint(&restored),
+        "{} round trip",
+        F::NAME
+    );
+}
+
 #[hegel::test(settings())]
 fn row_format_roundtrips(tc: hegel::TestCase) {
     let ds = DropTracker::new();
     let history = tc.draw(histories(0, WORLD_SIZE));
-    let world = build_world(&history, &ds);
-    let restored = row_world(&row_bytes(&world), &ds).expect("row deserialize");
-    assert_eq!(
-        fingerprint(&world),
-        fingerprint(&restored),
-        "row round trip"
-    );
+    check_roundtrip::<RowFormat>(&build_world(&history, &ds), &ds);
 }
 
 #[hegel::test(settings())]
 fn column_format_roundtrips(tc: hegel::TestCase) {
     let ds = DropTracker::new();
     let history = tc.draw(histories(0, WORLD_SIZE));
-    let world = build_world(&history, &ds);
-    let restored = column_world(&column_bytes(&world), &ds).expect("column deserialize");
-    assert_eq!(
-        fingerprint(&world),
-        fingerprint(&restored),
-        "column round trip"
-    );
+    check_roundtrip::<ColumnFormat>(&build_world(&history, &ds), &ds);
 }
 
 /// `serialize_satisfying::<Q>` writes exactly the entities matching `Q`, and
 /// writes all of their components rather than only the ones `Q` mentions.
-#[hegel::test(settings())]
-fn row_serialize_satisfying_keeps_exactly_the_matching_entities(tc: hegel::TestCase) {
-    let ds = DropTracker::new();
-    let history = tc.draw(histories(0, WORLD_SIZE));
-    let world = build_world(&history, &ds);
-    let restored = row_world(&row_satisfying_bytes::<&A>(&world), &ds).expect("row deserialize");
-    let want: Fingerprint = fingerprint(&world)
+fn check_satisfying<F: Format>(world: &World, ds: &DropTracker) {
+    let restored = F::world(&F::satisfying_bytes::<&A>(world), ds).expect("deserialize");
+    let want: Fingerprint = fingerprint(world)
         .into_iter()
         .filter(|(_, cs)| cs.a.is_some())
         .collect();
     assert_eq!(
         want,
         fingerprint(&restored),
-        "row serialize_satisfying::<&A>"
+        "{} serialize_satisfying::<&A>",
+        F::NAME
     );
+}
+
+#[hegel::test(settings())]
+fn row_serialize_satisfying_keeps_exactly_the_matching_entities(tc: hegel::TestCase) {
+    let ds = DropTracker::new();
+    let history = tc.draw(histories(0, WORLD_SIZE));
+    check_satisfying::<RowFormat>(&build_world(&history, &ds), &ds);
 }
 
 #[hegel::test(settings())]
 fn column_serialize_satisfying_keeps_exactly_the_matching_entities(tc: hegel::TestCase) {
     let ds = DropTracker::new();
     let history = tc.draw(histories(0, WORLD_SIZE));
-    let world = build_world(&history, &ds);
-    let restored =
-        column_world(&column_satisfying_bytes::<&A>(&world), &ds).expect("column deserialize");
-    let want: Fingerprint = fingerprint(&world)
-        .into_iter()
-        .filter(|(_, cs)| cs.a.is_some())
-        .collect();
-    assert_eq!(
-        want,
-        fingerprint(&restored),
-        "column serialize_satisfying::<&A>"
-    );
+    check_satisfying::<ColumnFormat>(&build_world(&history, &ds), &ds);
 }
 
 /// A strict prefix of a valid stream is rejected, and nothing the failed parse
 /// had already built survives. bincode parsing is deterministic, so a prefix
 /// follows the full parse byte for byte until it runs out of input.
+fn check_truncation<F: Format>(bytes: &[u8], cut: usize, ds: &DropTracker) {
+    F::world(bytes, ds).expect("the full stream parses");
+    let baseline = ds.live();
+    assert!(
+        F::world(&bytes[..cut], ds).is_err(),
+        "{} prefix {cut}/{} parsed",
+        F::NAME,
+        bytes.len()
+    );
+    assert_eq!(
+        ds.live(),
+        baseline,
+        "{} prefix {cut} leaked or double-dropped a component",
+        F::NAME
+    );
+}
+
 #[hegel::test(settings())]
 fn row_truncated_input_is_rejected_without_leaking(tc: hegel::TestCase) {
     let ds = DropTracker::new();
     let history = tc.draw(histories(0, WORLD_SIZE));
-    let world = build_world(&history, &ds);
-    let bytes = row_bytes(&world);
-    assert_eq!(
-        fingerprint(&world),
-        fingerprint(&row_world(&bytes, &ds).expect("row deserialize")),
-        "row round trip"
-    );
+    let bytes = RowFormat::bytes(&build_world(&history, &ds));
     let cut = tc.draw(
         gs::integers::<usize>()
             .min_value(0)
             .max_value(bytes.len() - 1),
     );
-    let baseline = ds.live();
-    assert!(
-        row_world(&bytes[..cut], &ds).is_err(),
-        "row prefix {cut}/{} parsed",
-        bytes.len()
-    );
-    assert_eq!(
-        ds.live(),
-        baseline,
-        "row prefix {cut} leaked or double-dropped a component"
-    );
+    check_truncation::<RowFormat>(&bytes, cut, &ds);
 }
 
-/// The column counterpart. A failed column parse leaves the components it had
-/// already read in a `ColumnBatchBuilder` that is then dropped; that builder
-/// leaked them all (issue #450), so this is the regression witness for the
-/// deserialize path.
+/// A failed column parse leaves the components it had already read in a
+/// `ColumnBatchBuilder` that is then dropped; that builder leaked them all
+/// (issue #450), so this is the regression witness for the deserialize path.
 #[hegel::test(settings())]
 fn column_truncated_input_is_rejected_without_leaking(tc: hegel::TestCase) {
     let ds = DropTracker::new();
     let history = tc.draw(histories(0, WORLD_SIZE));
-    let world = build_world(&history, &ds);
-    let bytes = column_bytes(&world);
-    assert_eq!(
-        fingerprint(&world),
-        fingerprint(&column_world(&bytes, &ds).expect("column deserialize")),
-        "column round trip"
-    );
+    let bytes = ColumnFormat::bytes(&build_world(&history, &ds));
     let cut = tc.draw(
         gs::integers::<usize>()
             .min_value(0)
             .max_value(bytes.len() - 1),
     );
-    let baseline = ds.live();
-    assert!(
-        column_world(&bytes[..cut], &ds).is_err(),
-        "column prefix {cut}/{} parsed",
-        bytes.len()
-    );
-    assert_eq!(
-        ds.live(),
-        baseline,
-        "column prefix {cut} leaked or double-dropped a component"
-    );
+    check_truncation::<ColumnFormat>(&bytes, cut, &ds);
 }
 
 /// One to three `(position, mask)` pairs flipping the low two bits of a byte in
@@ -436,7 +427,19 @@ fn corrupt(bytes: &mut [u8], flips: &[(usize, u8)]) {
 /// Corrupting a stream must produce either an error or a usable world — never a
 /// panic, and never a world with a duplicated handle. `Ok` is legitimate:
 /// flipping bits of a payload byte yields a different valid stream.
-///
+fn check_corruption<F: Format>(bytes: &[u8], ds: &DropTracker) {
+    match catch_unwind(AssertUnwindSafe(|| F::world(bytes, ds))) {
+        Ok(Ok(restored)) => {
+            // `fingerprint` panics on a handle iterated twice, `check_archetypes`
+            // on an id in two archetypes.
+            fingerprint(&restored);
+            check_archetypes(&restored, "corrupted stream");
+        }
+        Ok(Err(_)) => {}
+        Err(_) => panic!("{} deserialize panicked on a corrupted stream", F::NAME),
+    }
+}
+
 /// Not run under Miri: a corrupted entity id makes `spawn_at` grow the metadata
 /// table to that id, which is a few tens of megabytes at worst here but is far
 /// beyond what the interpreter can track in reasonable time.
@@ -445,38 +448,26 @@ fn corrupt(bytes: &mut [u8], flips: &[(usize, u8)]) {
 fn row_corrupted_input_is_rejected_or_usable(tc: hegel::TestCase) {
     let ds = DropTracker::new();
     let history = tc.draw(histories(0, WORLD_SIZE));
-    let world = build_world(&history, &ds);
-    let mut bytes = row_bytes(&world);
+    let mut bytes = RowFormat::bytes(&build_world(&history, &ds));
     let flips = tc.draw(corruptions(bytes.len()));
     corrupt(&mut bytes, &flips);
-    let outcome = catch_unwind(AssertUnwindSafe(|| row_world(&bytes, &ds)));
-    match outcome {
-        Ok(Ok(restored)) => drop(fingerprint(&restored)),
-        Ok(Err(_)) => {}
-        Err(_) => panic!("row deserialize panicked on a corrupted stream"),
-    }
+    check_corruption::<RowFormat>(&bytes, &ds);
 }
 
-/// The column counterpart. Corrupting the entity-id region routinely produces
-/// colliding ids, which used to reach an out-of-bounds write in
-/// `spawn_column_batch_at` (issue #449), so this doubles as the regression
-/// witness for that fix. Not run under Miri, for the same reason as its row
-/// counterpart: `entity_count` drives a `reserve` before it is validated.
+/// Corrupting the entity-id region routinely produces colliding ids, which
+/// used to reach an out-of-bounds write in `spawn_column_batch_at` (issue
+/// #449), so this doubles as the regression witness for that fix. Not run
+/// under Miri, for the same reason as its row counterpart: `entity_count`
+/// drives a `reserve` before it is validated.
 #[cfg_attr(miri, ignore = "corrupted counts reach allocations Miri cannot afford")]
 #[hegel::test(settings())]
 fn column_corrupted_input_is_rejected_or_usable(tc: hegel::TestCase) {
     let ds = DropTracker::new();
     let history = tc.draw(histories(0, WORLD_SIZE));
-    let world = build_world(&history, &ds);
-    let mut bytes = column_bytes(&world);
+    let mut bytes = ColumnFormat::bytes(&build_world(&history, &ds));
     let flips = tc.draw(corruptions(bytes.len()));
     corrupt(&mut bytes, &flips);
-    let outcome = catch_unwind(AssertUnwindSafe(|| column_world(&bytes, &ds)));
-    match outcome {
-        Ok(Ok(restored)) => drop(fingerprint(&restored)),
-        Ok(Err(_)) => {}
-        Err(_) => panic!("column deserialize panicked on a corrupted stream"),
-    }
+    check_corruption::<ColumnFormat>(&bytes, &ds);
 }
 
 /// Streams that are well-formed bincode but not valid hecs serializations must
@@ -490,7 +481,7 @@ fn row_rejects_streams_it_cannot_represent() {
     zero_generation.extend(encode(&0u64)); // entity bits: generation 0
     zero_generation.extend(encode(&0u64)); // no components
     assert!(
-        row_world(&zero_generation, &ds).is_err(),
+        RowFormat::world(&zero_generation, &ds).is_err(),
         "accepted a generation-0 entity"
     );
 
@@ -501,7 +492,7 @@ fn row_rejects_streams_it_cannot_represent() {
     unknown_component.extend(encode(&99u32)); // no such Id variant
     unknown_component.extend(encode(&0i32));
     assert!(
-        row_world(&unknown_component, &ds).is_err(),
+        RowFormat::world(&unknown_component, &ds).is_err(),
         "accepted an unknown component id"
     );
 }
@@ -522,7 +513,7 @@ fn column_rejects_streams_it_cannot_represent() {
     duplicate_column.extend(encode(&0i32)); // first A column
     duplicate_column.extend(encode(&1i32)); // second A column, no space left
     assert!(
-        column_world(&duplicate_column, &ds).is_err(),
+        ColumnFormat::world(&duplicate_column, &ds).is_err(),
         "accepted a duplicated component column"
     );
 
@@ -532,7 +523,7 @@ fn column_rejects_streams_it_cannot_represent() {
     short_entity_list.extend(encode(&0u32)); // component_count = 0
     short_entity_list.extend(encode(&(1u64 << 32))); // only one entity id
     assert!(
-        column_world(&short_entity_list, &ds).is_err(),
+        ColumnFormat::world(&short_entity_list, &ds).is_err(),
         "accepted a short entity list"
     );
 }
@@ -555,7 +546,8 @@ fn column_deserialize_tolerates_repeated_entity_ids() {
     bytes.extend(encode(&7i32));
     bytes.extend(encode(&9i32));
 
-    let world = column_world(&bytes, &ds).expect("repeated ids are deduplicated, not rejected");
+    let world =
+        ColumnFormat::world(&bytes, &ds).expect("repeated ids are deduplicated, not rejected");
     let e = Entity::from_bits(bits).unwrap();
     assert_eq!(
         world.len(),

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -9,13 +9,11 @@
 //! already parsed. `D` is drop-tracked and deserialized through its own
 //! constructor, which is what makes the leak half checkable.
 
-mod common;
-
 use std::any::TypeId;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use bincode::Options;
-use common::*;
+use fixtures::*;
 use hecs::serialize::{column, row};
 use hecs::{
     Archetype, ColumnBatchBuilder, ColumnBatchType, Entity, EntityBuilder, EntityRef, Query, World,

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -280,10 +280,7 @@ fn encode<T: Serialize>(value: &T) -> Vec<u8> {
 /// the serde machinery is by far the slowest thing in this suite, so the bound
 /// there drops to the smallest size that still makes the handle-preservation
 /// claim non-trivial.
-#[cfg(miri)]
-const WORLD_SIZE: u32 = 3;
-#[cfg(not(miri))]
-const WORLD_SIZE: u32 = 24;
+const WORLD_SIZE: u32 = if cfg!(miri) { 3 } else { 24 };
 
 #[hegel::test(settings())]
 fn row_format_roundtrips(tc: hegel::TestCase) {

--- a/tests/world_model.rs
+++ b/tests/world_model.rs
@@ -466,43 +466,48 @@ impl WorldModel {
         }
     }
 
-    /// A `View` reaches by handle exactly the entities a query iterates, and
-    /// writes through it are visible afterwards.
+    /// A `View` reaches by handle exactly the entities a query iterates, and a
+    /// write through it is visible afterwards.
     #[rule]
-    fn view_random_access(&mut self, tc: TestCase) {
+    fn view_get_mut(&mut self, tc: TestCase) {
+        let e = self.draw_handle(&tc);
+        let v = tc.draw(val());
+        let got = self.world.view_mut::<&mut B>().get_mut(e).map(|b| b.0 = v);
+        assert_eq!(
+            got.is_some(),
+            self.expect(e).is_some_and(|cs| cs.b.is_some()),
+            "view B-presence {e:?}"
+        );
+        if got.is_some() {
+            self.model.get_mut(&e).unwrap().b = Some(v);
+        }
+        self.check_entity(e, "view_get_mut");
+    }
+
+    /// `View::get_disjoint_mut` resolves two distinct handles at once, each as
+    /// `get_mut` would.
+    #[rule]
+    fn view_get_disjoint_mut(&mut self, tc: TestCase) {
         let e1 = self.draw_handle(&tc);
         let e2 = self.draw_handle(&tc);
+        // `get_disjoint_mut` documents a panic on repeated handles.
+        tc.assume(e1 != e2);
         let (v1, v2) = (tc.draw(val()), tc.draw(val()));
-        let (got1, got2);
-        if e1 == e2 {
-            let mut view = self.world.view_mut::<&mut B>();
-            got1 = view.get_mut(e1).map(|b| {
-                b.0 = v1;
-            });
-            got2 = None;
-        } else {
-            let mut view = self.world.view_mut::<&mut B>();
-            let [r1, r2] = view.get_disjoint_mut([e1, e2]);
-            got1 = r1.map(|b| b.0 = v1);
-            got2 = r2.map(|b| b.0 = v2);
-        }
-        assert_eq!(
-            got1.is_some(),
-            self.expect(e1).is_some_and(|cs| cs.b.is_some()),
-            "view B-presence {e1:?}"
-        );
-        if got1.is_some() {
-            self.model.get_mut(&e1).unwrap().b = Some(v1);
-        }
-        if e1 != e2 {
+        let mut view = self.world.view_mut::<&mut B>();
+        let [r1, r2] = view.get_disjoint_mut([e1, e2]);
+        let got1 = r1.map(|b| b.0 = v1).is_some();
+        let got2 = r2.map(|b| b.0 = v2).is_some();
+        drop(view);
+        for (e, v, got) in [(e1, v1, got1), (e2, v2, got2)] {
             assert_eq!(
-                got2.is_some(),
-                self.expect(e2).is_some_and(|cs| cs.b.is_some()),
-                "view B-presence {e2:?}"
+                got,
+                self.expect(e).is_some_and(|cs| cs.b.is_some()),
+                "view B-presence {e:?}"
             );
-            if got2.is_some() {
-                self.model.get_mut(&e2).unwrap().b = Some(v2);
+            if got {
+                self.model.get_mut(&e).unwrap().b = Some(v);
             }
+            self.check_entity(e, "view_get_disjoint_mut");
         }
     }
 

--- a/tests/world_model.rs
+++ b/tests/world_model.rs
@@ -517,24 +517,22 @@ impl WorldModel {
     #[rule]
     fn spawn_batch(&mut self, tc: TestCase) {
         self.flush_model();
-        let n = tc.draw(gs::integers::<u32>().min_value(0).max_value(5));
-        let v = tc.draw(val());
+        let payloads: Vec<(i32, i32)> = tc.draw(gs::vecs(hegel::tuples!(val(), val())).max_size(5));
         let handles: Vec<Entity> = self
             .world
-            .spawn_batch((0..n).map(|_| (A(v), B(v))))
+            .spawn_batch(payloads.iter().map(|&(a, b)| (A(a), B(b))))
             .collect();
         assert_eq!(
             handles.len(),
-            n as usize,
+            payloads.len(),
             "spawn_batch yielded the wrong count"
         );
-        let cs = Components {
-            a: Some(v),
-            b: Some(v),
-            c: false,
-            d: None,
-        };
-        for e in handles {
+        for (e, &(a, b)) in handles.into_iter().zip(&payloads) {
+            let cs = Components {
+                a: Some(a),
+                b: Some(b),
+                ..Components::default()
+            };
             assert!(
                 self.model.insert(e, cs).is_none(),
                 "spawn_batch reused {e:?}"

--- a/tests/world_model.rs
+++ b/tests/world_model.rs
@@ -75,6 +75,15 @@ impl WorldModel {
     }
 }
 
+/// Collect `(Entity, value)` pairs, failing on a repeated entity.
+fn unique<V>(pairs: impl IntoIterator<Item = (Entity, V)>, label: &str) -> HashMap<Entity, V> {
+    let mut got = HashMap::new();
+    for (e, v) in pairs {
+        assert!(got.insert(e, v).is_none(), "{label} yielded {e:?} twice");
+    }
+    got
+}
+
 // Driven by `world_matches_model` below.
 #[hegel::state_machine]
 impl WorldModel {
@@ -784,48 +793,49 @@ impl WorldModel {
         let model = &self.model;
         let world = &self.world;
 
-        let mut got = HashMap::new();
-        for (e, a) in world.query::<(Entity, &A)>().iter() {
-            assert!(
-                got.insert(e, a.0).is_none(),
-                "query::<&A> yielded {e:?} twice"
-            );
-        }
+        let got = unique(
+            world.query::<(Entity, &A)>().iter().map(|(e, a)| (e, a.0)),
+            "query::<&A>",
+        );
         let want: HashMap<Entity, i32> = model
             .iter()
             .filter_map(|(&e, cs)| cs.a.map(|v| (e, v)))
             .collect();
         assert_eq!(got, want, "query::<&A>");
 
-        let mut got = HashMap::new();
-        for (e, a, b) in world.query::<(Entity, &A, &B)>().iter() {
-            assert!(
-                got.insert(e, (a.0, b.0)).is_none(),
-                "query::<(&A,&B)> yielded {e:?} twice"
-            );
-        }
+        let got = unique(
+            world
+                .query::<(Entity, &A, &B)>()
+                .iter()
+                .map(|(e, a, b)| (e, (a.0, b.0))),
+            "query::<(&A,&B)>",
+        );
         let want: HashMap<Entity, (i32, i32)> = model
             .iter()
             .filter_map(|(&e, cs)| cs.a.zip(cs.b).map(|v| (e, v)))
             .collect();
         assert_eq!(got, want, "query::<(&A,&B)>");
 
-        let with: HashMap<Entity, i32> = world
-            .query::<With<(Entity, &A), &B>>()
-            .iter()
-            .map(|(e, a)| (e, a.0))
-            .collect();
+        let got = unique(
+            world
+                .query::<With<(Entity, &A), &B>>()
+                .iter()
+                .map(|(e, a)| (e, a.0)),
+            "query::<With<&A, &B>>",
+        );
         let want: HashMap<Entity, i32> = model
             .iter()
             .filter_map(|(&e, cs)| cs.b.and(cs.a).map(|v| (e, v)))
             .collect();
-        assert_eq!(with, want, "query::<With<&A, &B>>");
+        assert_eq!(got, want, "query::<With<&A, &B>>");
 
-        let without: HashMap<Entity, i32> = world
-            .query::<Without<(Entity, &A), &B>>()
-            .iter()
-            .map(|(e, a)| (e, a.0))
-            .collect();
+        let got = unique(
+            world
+                .query::<Without<(Entity, &A), &B>>()
+                .iter()
+                .map(|(e, a)| (e, a.0)),
+            "query::<Without<&A, &B>>",
+        );
         let want: HashMap<Entity, i32> = model
             .iter()
             .filter_map(|(&e, cs)| match (cs.a, cs.b) {
@@ -833,30 +843,34 @@ impl WorldModel {
                 _ => None,
             })
             .collect();
-        assert_eq!(without, want, "query::<Without<&A, &B>>");
+        assert_eq!(got, want, "query::<Without<&A, &B>>");
 
-        let or: HashMap<Entity, (Option<i32>, Option<i32>)> = world
-            .query::<(Entity, Or<&A, &B>)>()
-            .iter()
-            .map(|(e, ab)| (e, (ab.left().map(|a| a.0), ab.right().map(|b| b.0))))
-            .collect();
+        let got = unique(
+            world
+                .query::<(Entity, Or<&A, &B>)>()
+                .iter()
+                .map(|(e, ab)| (e, (ab.left().map(|a| a.0), ab.right().map(|b| b.0)))),
+            "query::<Or<&A, &B>>",
+        );
         let want: HashMap<Entity, (Option<i32>, Option<i32>)> = model
             .iter()
             .filter(|(_, cs)| cs.a.is_some() || cs.b.is_some())
             .map(|(&e, cs)| (e, (cs.a, cs.b)))
             .collect();
-        assert_eq!(or, want, "query::<Or<&A, &B>>");
+        assert_eq!(got, want, "query::<Or<&A, &B>>");
 
-        let opt: HashMap<Entity, Option<i32>> = world
-            .query::<(Entity, &A, Option<&B>)>()
-            .iter()
-            .map(|(e, _, b)| (e, b.map(|b| b.0)))
-            .collect();
+        let got = unique(
+            world
+                .query::<(Entity, &A, Option<&B>)>()
+                .iter()
+                .map(|(e, _, b)| (e, b.map(|b| b.0))),
+            "query::<(&A, Option<&B>)>",
+        );
         let want: HashMap<Entity, Option<i32>> = model
             .iter()
             .filter_map(|(&e, cs)| cs.a.map(|_| (e, cs.b)))
             .collect();
-        assert_eq!(opt, want, "query::<(&A, Option<&B>)>");
+        assert_eq!(got, want, "query::<(&A, Option<&B>)>");
     }
 
     /// Per-entity access agrees with the model for every live entity,

--- a/tests/world_model.rs
+++ b/tests/world_model.rs
@@ -78,6 +78,16 @@ fn unique<V>(pairs: impl IntoIterator<Item = (Entity, V)>, label: &str) -> HashM
     got
 }
 
+/// `query_one::<&A>(e)` on a live entity, against the `A` the model predicts
+/// once the query's filters are applied.
+fn check_query_one(got: Result<&A, QueryOneError>, want: Option<i32>, label: &str) {
+    match got {
+        Ok(a) => assert_eq!(Some(a.0), want, "{label}"),
+        Err(QueryOneError::Unsatisfied) => assert!(want.is_none(), "{label} unsatisfied"),
+        Err(QueryOneError::NoSuchEntity) => panic!("{label} on a live entity"),
+    }
+}
+
 // Driven by `world_matches_model` below.
 #[hegel::state_machine]
 impl WorldModel {
@@ -373,36 +383,18 @@ impl WorldModel {
         let (got1, got2);
         {
             let [r1, r2] = self.world.query_disjoint_mut::<&mut A, 2>([e1, e2]);
-            got1 = r1
-                .map(|a| {
-                    let old = a.0;
-                    a.0 = v1;
-                    old
-                })
-                .ok();
-            got2 = r2
-                .map(|a| {
-                    let old = a.0;
-                    a.0 = v2;
-                    old
-                })
-                .ok();
+            got1 = r1.map(|a| std::mem::replace(&mut a.0, v1)).ok();
+            got2 = r2.map(|a| std::mem::replace(&mut a.0, v2)).ok();
         }
-        assert_eq!(
-            got1,
-            self.expect(e1).and_then(|cs| cs.a),
-            "query_disjoint_mut {e1:?}"
-        );
-        assert_eq!(
-            got2,
-            self.expect(e2).and_then(|cs| cs.a),
-            "query_disjoint_mut {e2:?}"
-        );
-        if got1.is_some() {
-            self.model.get_mut(&e1).unwrap().a = Some(v1);
-        }
-        if got2.is_some() {
-            self.model.get_mut(&e2).unwrap().a = Some(v2);
+        for (e, v, got) in [(e1, v1, got1), (e2, v2, got2)] {
+            assert_eq!(
+                got,
+                self.expect(e).and_then(|cs| cs.a),
+                "query_disjoint_mut {e:?}"
+            );
+            if got.is_some() {
+                self.model.get_mut(&e).unwrap().a = Some(v);
+            }
         }
     }
 
@@ -808,46 +800,23 @@ impl WorldModel {
     #[invariant]
     fn per_entity_access_matches_model(&self, _: TestCase) {
         for (&e, cs) in &self.model {
-            match self.world.query_one::<&A>(e).get() {
-                Ok(a) => assert_eq!(Some(a.0), cs.a, "query_one::<&A> value for {e:?}"),
-                Err(QueryOneError::Unsatisfied) => {
-                    assert!(
-                        cs.a.is_none(),
-                        "query_one::<&A> unsatisfied but A modelled for {e:?}"
-                    )
-                }
-                Err(QueryOneError::NoSuchEntity) => panic!("query_one on live {e:?}"),
-            }
+            check_query_one(
+                self.world.query_one::<&A>(e).get(),
+                cs.a,
+                &format!("query_one::<&A> {e:?}"),
+            );
             // `with`/`without` filter the same query by another component's
             // presence without borrowing it.
-            match self.world.query_one::<&A>(e).with::<&B>().get() {
-                Ok(a) => assert_eq!(
-                    (Some(a.0), true),
-                    (cs.a, cs.b.is_some()),
-                    "with::<&B> {e:?}"
-                ),
-                Err(QueryOneError::Unsatisfied) => {
-                    assert!(
-                        cs.a.is_none() || cs.b.is_none(),
-                        "with::<&B> unsatisfied for {e:?}"
-                    )
-                }
-                Err(QueryOneError::NoSuchEntity) => panic!("with::<&B> on live {e:?}"),
-            }
-            match self.world.query_one::<&A>(e).without::<&B>().get() {
-                Ok(a) => assert_eq!(
-                    (Some(a.0), false),
-                    (cs.a, cs.b.is_some()),
-                    "without::<&B> {e:?}"
-                ),
-                Err(QueryOneError::Unsatisfied) => {
-                    assert!(
-                        cs.a.is_none() || cs.b.is_some(),
-                        "without::<&B> unsatisfied for {e:?}"
-                    )
-                }
-                Err(QueryOneError::NoSuchEntity) => panic!("without::<&B> on live {e:?}"),
-            }
+            check_query_one(
+                self.world.query_one::<&A>(e).with::<&B>().get(),
+                cs.a.filter(|_| cs.b.is_some()),
+                &format!("query_one::<&A>.with::<&B> {e:?}"),
+            );
+            check_query_one(
+                self.world.query_one::<&A>(e).without::<&B>().get(),
+                cs.a.filter(|_| cs.b.is_none()),
+                &format!("query_one::<&A>.without::<&B> {e:?}"),
+            );
             assert_eq!(
                 self.world.satisfies::<&A>(e),
                 cs.a.is_some(),

--- a/tests/world_model.rs
+++ b/tests/world_model.rs
@@ -1,0 +1,1013 @@
+//! Model-based property test for `World`: a drawn sequence of operations is
+//! applied to both a `World` and a `HashMap<Entity, Spec>` reference model, and
+//! the two must agree.
+//!
+//! Each rule asserts the postcondition it establishes (the operation's
+//! `Ok`/`Err` against modelled liveness, and the touched entity's resulting
+//! component set). The global oracles — full bidirectional equivalence, the
+//! archetype partition, the drop count, and the query surface — are invariants,
+//! which hegel samples between steps and runs in full on the initial and final
+//! state.
+//!
+//! The handle pool deliberately retains despawned handles, so operations
+//! against dead entities are common and their error paths are exercised.
+
+mod common;
+
+use std::collections::HashMap;
+
+use common::*;
+use hecs::{Entity, EntityBuilderClone, Or, PreparedQuery, QueryOneError, With, Without, World};
+use hegel::generators::{self as gs, Generator};
+use hegel::stateful::{pool, Pool};
+use hegel::TestCase;
+
+#[cfg(miri)]
+const STEPS: i64 = 8;
+#[cfg(not(miri))]
+const STEPS: i64 = 150;
+
+struct WorldModel {
+    world: World,
+    model: HashMap<Entity, Spec>,
+    /// Every handle ever handed out, including despawned ones.
+    handles: Pool<Entity>,
+    /// Handles from `reserve_entity`/`reserve_entities` awaiting a flush.
+    reserved: Vec<Entity>,
+    /// Handles whose entity was destroyed. `despawn` reuses the id but
+    /// advances the generation, so none of these may resolve again; `clear`
+    /// and `spawn_at` are the documented exceptions.
+    retired: Vec<Entity>,
+}
+
+impl WorldModel {
+    /// Mirror hecs's implicit flush: reserved handles become componentless
+    /// entities. Called by every rule that runs an operation documented to
+    /// flush (all variations of spawn, despawn, insert and remove).
+    fn flush_model(&mut self) {
+        for e in self.reserved.drain(..) {
+            self.model.insert(e, Spec::default());
+        }
+    }
+
+    fn draw_handle(&self, tc: &TestCase) -> Entity {
+        *tc.draw(self.handles.values_reusable().print_as_debug())
+    }
+
+    /// The component set the model predicts for `e`, or `None` if dead.
+    fn expect(&self, e: Entity) -> Option<Spec> {
+        self.model.get(&e).copied()
+    }
+
+    /// Everything observable about `e` right now.
+    fn observe(&self, e: Entity) -> Option<Spec> {
+        let eref = self.world.entity(e).ok()?;
+        Some(Spec {
+            a: eref.get::<&A>().map(|r| r.0),
+            b: eref.get::<&B>().map(|r| r.0),
+            c: eref.get::<&C>().is_some(),
+            d: eref.get::<&D>().map(|r| r.0),
+        })
+    }
+
+    fn check_entity(&self, e: Entity, label: &str) {
+        // An unflushed handle resolves to the empty archetype rather than to an
+        // entity, so there is nothing to compare against the model yet.
+        if self.reserved.contains(&e) {
+            return;
+        }
+        assert_eq!(self.observe(e), self.expect(e), "{label}: {e:?}");
+    }
+}
+
+#[hegel::state_machine]
+impl WorldModel {
+    /// `spawn` reports a fresh handle carrying exactly the bundle's components,
+    /// and `EntityBuilder`'s introspection agrees with what was added.
+    #[rule]
+    fn spawn(&mut self, tc: TestCase) {
+        self.flush_model();
+        let s = tc.draw(specs());
+        let mut builder = make_builder(s);
+        assert_eq!(builder.has::<A>(), s.a.is_some(), "builder.has::<A>");
+        assert_eq!(builder.has::<D>(), s.d.is_some(), "builder.has::<D>");
+        assert_eq!(builder.get::<&A>().map(|r| r.0), s.a, "builder.get::<&A>");
+        assert_eq!(
+            builder.component_types().count(),
+            s.component_count(),
+            "builder.component_types"
+        );
+        let e = self.world.spawn(builder.build());
+        assert!(
+            self.model.insert(e, s).is_none(),
+            "spawn reused a live handle {e:?}"
+        );
+        self.handles.add(e);
+        self.check_entity(e, "spawn");
+    }
+
+    /// `spawn_at` makes exactly `handle` live, destroying whatever entity
+    /// shared its id.
+    #[rule]
+    fn spawn_at(&mut self, tc: TestCase) {
+        self.flush_model();
+        let handle = self.draw_handle(&tc);
+        let s = tc.draw(specs());
+        let mut builder = make_builder(s);
+        self.world.spawn_at(handle, builder.build());
+        self.model.retain(|k, _| k.id() != handle.id());
+        self.model.insert(handle, s);
+        self.retired.retain(|r| r.id() != handle.id());
+        self.check_entity(handle, "spawn_at");
+        assert!(
+            self.world.contains(handle),
+            "spawn_at target is not contained"
+        );
+    }
+
+    /// `spawn_at` at an id past the end of the metadata table grows it and
+    /// leaves the intervening ids reusable. The offset is small to bound the
+    /// test's memory, not because hecs limits it.
+    #[rule]
+    fn spawn_at_fresh_id(&mut self, tc: TestCase) {
+        self.flush_model();
+        let max_id = self.model.keys().map(|e| e.id()).max().unwrap_or(0);
+        let offset = tc.draw(gs::integers::<u32>().min_value(1).max_value(8));
+        let generation = tc.draw(gs::integers::<u32>().min_value(1).max_value(3));
+        let bits = (u64::from(generation) << 32) | u64::from(max_id + offset);
+        let handle = Entity::from_bits(bits).expect("nonzero generation");
+        assert_eq!(
+            handle.to_bits().get(),
+            bits,
+            "to_bits is not the inverse of from_bits"
+        );
+        let s = tc.draw(specs());
+        let mut builder = make_builder(s);
+        self.world.spawn_at(handle, builder.build());
+        self.model.retain(|k, _| k.id() != handle.id());
+        self.model.insert(handle, s);
+        self.retired.retain(|r| r.id() != handle.id());
+        self.handles.add(handle);
+        self.check_entity(handle, "spawn_at_fresh_id");
+    }
+
+    /// `despawn` succeeds exactly for live handles and leaves the handle dead.
+    #[rule]
+    fn despawn(&mut self, tc: TestCase) {
+        self.flush_model();
+        let e = self.draw_handle(&tc);
+        let ok = self.world.despawn(e).is_ok();
+        assert_eq!(
+            ok,
+            self.model.remove(&e).is_some(),
+            "despawn disagreed for {e:?}"
+        );
+        if ok {
+            assert!(
+                !self.world.contains(e),
+                "despawned {e:?} is still contained"
+            );
+            self.retired.push(e);
+        }
+        self.check_entity(e, "despawn");
+    }
+
+    /// `insert_one` succeeds exactly for live handles, and overwrites any
+    /// existing component of that type.
+    #[rule]
+    fn insert_one(&mut self, tc: TestCase) {
+        self.flush_model();
+        let e = self.draw_handle(&tc);
+        let live = self.model.contains_key(&e);
+        let v = tc.draw(val());
+        let ok = match tc.draw(gs::integers::<u8>().min_value(0).max_value(3)) {
+            0 => {
+                let ok = self.world.insert_one(e, A(v)).is_ok();
+                if let Some(m) = self.model.get_mut(&e) {
+                    m.a = Some(v);
+                }
+                ok
+            }
+            1 => {
+                let ok = self.world.insert_one(e, B(v)).is_ok();
+                if let Some(m) = self.model.get_mut(&e) {
+                    m.b = Some(v);
+                }
+                ok
+            }
+            2 => {
+                let ok = self.world.insert_one(e, C).is_ok();
+                if let Some(m) = self.model.get_mut(&e) {
+                    m.c = true;
+                }
+                ok
+            }
+            // On a dead target the component is dropped rather than stored, so
+            // the drop count stays balanced either way.
+            _ => {
+                let ok = self.world.insert_one(e, D::new(v)).is_ok();
+                if let Some(m) = self.model.get_mut(&e) {
+                    m.d = Some(v);
+                }
+                ok
+            }
+        };
+        assert_eq!(ok, live, "insert_one disagreed for {e:?}");
+        self.check_entity(e, "insert_one");
+    }
+
+    /// `insert` of a multi-component bundle adds every member in one migration.
+    #[rule]
+    fn insert_bundle(&mut self, tc: TestCase) {
+        self.flush_model();
+        let e = self.draw_handle(&tc);
+        let live = self.model.contains_key(&e);
+        let s = tc.draw(specs());
+        let mut builder = make_builder(s);
+        let ok = self.world.insert(e, builder.build()).is_ok();
+        assert_eq!(ok, live, "insert bundle disagreed for {e:?}");
+        if let Some(m) = self.model.get_mut(&e) {
+            m.a = s.a.or(m.a);
+            m.b = s.b.or(m.b);
+            m.c |= s.c;
+            m.d = s.d.or(m.d);
+        }
+        self.check_entity(e, "insert_bundle");
+    }
+
+    /// `remove_one` succeeds exactly when the component was present, and
+    /// returns the value it removed.
+    #[rule]
+    fn remove_one(&mut self, tc: TestCase) {
+        self.flush_model();
+        let e = self.draw_handle(&tc);
+        let before = self.expect(e);
+        match tc.draw(gs::integers::<u8>().min_value(0).max_value(3)) {
+            0 => {
+                let got = self.world.remove_one::<A>(e).ok();
+                assert_eq!(
+                    got.map(|A(v)| v),
+                    before.and_then(|s| s.a),
+                    "remove_one::<A> {e:?}"
+                );
+                if let Some(m) = self.model.get_mut(&e) {
+                    m.a = None;
+                }
+            }
+            1 => {
+                let got = self.world.remove_one::<B>(e).ok();
+                assert_eq!(
+                    got.map(|B(v)| v),
+                    before.and_then(|s| s.b),
+                    "remove_one::<B> {e:?}"
+                );
+                if let Some(m) = self.model.get_mut(&e) {
+                    m.b = None;
+                }
+            }
+            2 => {
+                let ok = self.world.remove_one::<C>(e).is_ok();
+                assert_eq!(ok, before.is_some_and(|s| s.c), "remove_one::<C> {e:?}");
+                if let Some(m) = self.model.get_mut(&e) {
+                    m.c = false;
+                }
+            }
+            // The removed D is returned and dropped here, matching the model.
+            _ => {
+                let got = self.world.remove_one::<D>(e).ok();
+                assert_eq!(
+                    got.as_ref().map(|d| d.0),
+                    before.and_then(|s| s.d),
+                    "remove_one::<D> {e:?}"
+                );
+                if let Some(m) = self.model.get_mut(&e) {
+                    m.d = None;
+                }
+            }
+        }
+        self.check_entity(e, "remove_one");
+    }
+
+    /// `remove` of a bundle is all-or-nothing: if any member is missing it
+    /// returns `Err` and removes nothing.
+    #[rule]
+    fn remove_bundle(&mut self, tc: TestCase) {
+        self.flush_model();
+        let e = self.draw_handle(&tc);
+        let before = self.expect(e);
+        if tc.draw(gs::booleans()) {
+            let had = before.is_some_and(|s| s.a.is_some() && s.b.is_some());
+            assert_eq!(
+                self.world.remove::<(A, B)>(e).is_ok(),
+                had,
+                "remove::<(A,B)> {e:?}"
+            );
+            if had {
+                let m = self.model.get_mut(&e).unwrap();
+                m.a = None;
+                m.b = None;
+            }
+        } else {
+            let had = before.is_some_and(|s| s.c && s.d.is_some());
+            assert_eq!(
+                self.world.remove::<(C, D)>(e).is_ok(),
+                had,
+                "remove::<(C,D)> {e:?}"
+            );
+            if had {
+                let m = self.model.get_mut(&e).unwrap();
+                m.c = false;
+                m.d = None;
+            }
+        }
+        self.check_entity(e, "remove_bundle");
+    }
+
+    /// `exchange_one` needs the outgoing component present, returns it, and
+    /// leaves the incoming one in place.
+    #[rule]
+    fn exchange_one(&mut self, tc: TestCase) {
+        self.flush_model();
+        let e = self.draw_handle(&tc);
+        let before = self.expect(e);
+        let v = tc.draw(val());
+        if tc.draw(gs::booleans()) {
+            let got = self.world.exchange_one::<A, B>(e, B(v)).ok();
+            assert_eq!(
+                got.map(|A(x)| x),
+                before.and_then(|s| s.a),
+                "exchange A->B {e:?}"
+            );
+            if got.is_some() {
+                let m = self.model.get_mut(&e).unwrap();
+                m.a = None;
+                m.b = Some(v);
+            }
+        } else {
+            let got = self.world.exchange_one::<D, A>(e, A(v)).ok();
+            assert_eq!(
+                got.as_ref().map(|d| d.0),
+                before.and_then(|s| s.d),
+                "exchange D->A {e:?}"
+            );
+            if got.is_some() {
+                let m = self.model.get_mut(&e).unwrap();
+                m.d = None;
+                m.a = Some(v);
+            }
+        }
+        self.check_entity(e, "exchange_one");
+    }
+
+    /// A write through `get::<&mut T>` is visible to a subsequent read. This is
+    /// a read path, so it does not flush.
+    #[rule]
+    fn mutate_in_place(&mut self, tc: TestCase) {
+        let e = self.draw_handle(&tc);
+        let v = tc.draw(val());
+        match tc.draw(gs::integers::<u8>().min_value(0).max_value(2)) {
+            0 => {
+                if let Ok(mut a) = self.world.get::<&mut A>(e) {
+                    a.0 = v;
+                }
+                if let Some(m) = self.model.get_mut(&e).filter(|m| m.a.is_some()) {
+                    m.a = Some(v);
+                }
+            }
+            1 => {
+                if let Ok(mut b) = self.world.get::<&mut B>(e) {
+                    b.0 = v;
+                }
+                if let Some(m) = self.model.get_mut(&e).filter(|m| m.b.is_some()) {
+                    m.b = Some(v);
+                }
+            }
+            // Editing D's payload constructs and drops nothing.
+            _ => {
+                if let Ok(mut d) = self.world.get::<&mut D>(e) {
+                    d.0 = v;
+                }
+                if let Some(m) = self.model.get_mut(&e).filter(|m| m.d.is_some()) {
+                    m.d = Some(v);
+                }
+            }
+        }
+        self.check_entity(e, "mutate_in_place");
+    }
+
+    /// A `query_mut` sweep reaches every entity with an `A`, and nothing else.
+    #[rule]
+    fn sweep_query_mut(&mut self, tc: TestCase) {
+        let v = tc.draw(val());
+        let mut swept = 0usize;
+        for a in self.world.query_mut::<&mut A>() {
+            a.0 = v;
+            swept += 1;
+        }
+        let expected = self.model.values().filter(|m| m.a.is_some()).count();
+        assert_eq!(
+            swept, expected,
+            "query_mut::<&mut A> visited the wrong number of entities"
+        );
+        for m in self.model.values_mut() {
+            if m.a.is_some() {
+                m.a = Some(v);
+            }
+        }
+    }
+
+    /// Two distinct handles can be fetched concurrently, and each result
+    /// matches the model.
+    #[rule]
+    fn query_disjoint_mut(&mut self, tc: TestCase) {
+        let e1 = self.draw_handle(&tc);
+        let e2 = self.draw_handle(&tc);
+        // `query_disjoint_mut` documents a panic on repeated handles.
+        tc.assume(e1 != e2);
+        let (v1, v2) = (tc.draw(val()), tc.draw(val()));
+        let (got1, got2);
+        {
+            let [r1, r2] = self.world.query_disjoint_mut::<&mut A, 2>([e1, e2]);
+            got1 = r1
+                .map(|a| {
+                    let old = a.0;
+                    a.0 = v1;
+                    old
+                })
+                .ok();
+            got2 = r2
+                .map(|a| {
+                    let old = a.0;
+                    a.0 = v2;
+                    old
+                })
+                .ok();
+        }
+        assert_eq!(
+            got1,
+            self.expect(e1).and_then(|s| s.a),
+            "query_disjoint_mut {e1:?}"
+        );
+        assert_eq!(
+            got2,
+            self.expect(e2).and_then(|s| s.a),
+            "query_disjoint_mut {e2:?}"
+        );
+        if got1.is_some() {
+            self.model.get_mut(&e1).unwrap().a = Some(v1);
+        }
+        if got2.is_some() {
+            self.model.get_mut(&e2).unwrap().a = Some(v2);
+        }
+    }
+
+    /// A `View` reaches by handle exactly the entities a query iterates, and
+    /// writes through it are visible afterwards.
+    #[rule]
+    fn view_random_access(&mut self, tc: TestCase) {
+        let e1 = self.draw_handle(&tc);
+        let e2 = self.draw_handle(&tc);
+        let (v1, v2) = (tc.draw(val()), tc.draw(val()));
+        let (got1, got2);
+        if e1 == e2 {
+            let mut view = self.world.view_mut::<&mut B>();
+            got1 = view.get_mut(e1).map(|b| {
+                b.0 = v1;
+            });
+            got2 = None;
+        } else {
+            let mut view = self.world.view_mut::<&mut B>();
+            let [r1, r2] = view.get_disjoint_mut([e1, e2]);
+            got1 = r1.map(|b| b.0 = v1);
+            got2 = r2.map(|b| b.0 = v2);
+        }
+        assert_eq!(
+            got1.is_some(),
+            self.expect(e1).is_some_and(|s| s.b.is_some()),
+            "view B-presence {e1:?}"
+        );
+        if got1.is_some() {
+            self.model.get_mut(&e1).unwrap().b = Some(v1);
+        }
+        if e1 != e2 {
+            assert_eq!(
+                got2.is_some(),
+                self.expect(e2).is_some_and(|s| s.b.is_some()),
+                "view B-presence {e2:?}"
+            );
+            if got2.is_some() {
+                self.model.get_mut(&e2).unwrap().b = Some(v2);
+            }
+        }
+    }
+
+    /// `clear` empties the world. Entity values repeat afterwards, so pooled
+    /// handles may alias freshly spawned entities; the model is keyed by the
+    /// full handle, so that stays consistent.
+    #[rule]
+    fn clear(&mut self, _: TestCase) {
+        self.world.clear();
+        self.model.clear();
+        self.reserved.clear();
+        // `clear` documents that Entity values will repeat, so retired
+        // handles may legitimately become live again.
+        self.retired.clear();
+        assert_eq!(self.world.len(), 0, "clear left live entities");
+        assert_eq!(self.world.iter().count(), 0, "clear left iterable entities");
+    }
+
+    /// `spawn_batch` hands out one distinct handle per item, each carrying that
+    /// item's components.
+    #[rule]
+    fn spawn_batch(&mut self, tc: TestCase) {
+        self.flush_model();
+        let n = tc.draw(gs::integers::<u32>().min_value(0).max_value(5));
+        let v = tc.draw(val());
+        let handles: Vec<Entity> = self
+            .world
+            .spawn_batch((0..n).map(|_| (A(v), B(v))))
+            .collect();
+        assert_eq!(
+            handles.len(),
+            n as usize,
+            "spawn_batch yielded the wrong count"
+        );
+        let s = Spec {
+            a: Some(v),
+            b: Some(v),
+            c: false,
+            d: None,
+        };
+        for e in handles {
+            assert!(
+                self.model.insert(e, s).is_none(),
+                "spawn_batch reused {e:?}"
+            );
+            self.handles.add(e);
+            self.check_entity(e, "spawn_batch");
+        }
+    }
+
+    /// `reserve` is a capacity hint with no observable effect.
+    #[rule]
+    fn reserve_capacity(&mut self, tc: TestCase) {
+        self.world.flush();
+        self.flush_model();
+        let before = fingerprint(&self.world);
+        let n = tc.draw(gs::integers::<u32>().min_value(0).max_value(8));
+        self.world.reserve::<(A, B)>(n);
+        assert_eq!(
+            fingerprint(&self.world),
+            before,
+            "reserve changed observable state"
+        );
+    }
+
+    /// Reserved handles are `contains`-true immediately but stay out of `len`,
+    /// `iter` and every query until a flush.
+    #[rule]
+    fn reserve_entities(&mut self, tc: TestCase) {
+        let len_before = self.world.len();
+        let fresh: Vec<Entity> = if tc.draw(gs::booleans()) {
+            vec![self.world.reserve_entity()]
+        } else {
+            let n = tc.draw(gs::integers::<u32>().min_value(0).max_value(4));
+            self.world.reserve_entities(n).collect()
+        };
+        for &e in &fresh {
+            assert!(self.world.contains(e), "reserved {e:?} not contained");
+            self.reserved.push(e);
+            self.handles.add(e);
+        }
+        assert_eq!(
+            self.world.len(),
+            len_before,
+            "reserve_entity changed world.len()"
+        );
+    }
+
+    /// An explicit `flush` turns reserved handles into componentless entities.
+    #[rule]
+    fn flush(&mut self, _: TestCase) {
+        let expected = self.reserved.clone();
+        self.world.flush();
+        self.flush_model();
+        for e in expected {
+            assert_eq!(self.observe(e), Some(Spec::default()), "flushed {e:?}");
+        }
+    }
+
+    /// `take` removes the entity; dropping the `TakenEntity` drops its
+    /// components.
+    #[rule]
+    fn take_and_drop(&mut self, tc: TestCase) {
+        self.flush_model();
+        let e = self.draw_handle(&tc);
+        let ok = self.world.take(e).is_ok();
+        assert_eq!(
+            ok,
+            self.model.remove(&e).is_some(),
+            "take disagreed for {e:?}"
+        );
+        if ok {
+            self.retired.push(e);
+        }
+        self.check_entity(e, "take_and_drop");
+    }
+
+    /// Spawning a `TakenEntity` into another world moves its components across
+    /// unchanged.
+    #[rule]
+    fn take_and_migrate(&mut self, tc: TestCase) {
+        self.flush_model();
+        let e = self.draw_handle(&tc);
+        let expected = self.expect(e);
+        match self.world.take(e) {
+            Ok(taken) => {
+                let mut scratch = World::new();
+                let moved = scratch.spawn(taken);
+                assert_eq!(
+                    scratch.len(),
+                    1,
+                    "scratch world holds more than the moved entity"
+                );
+                let obs = Spec {
+                    a: scratch.get::<&A>(moved).ok().map(|r| r.0),
+                    b: scratch.get::<&B>(moved).ok().map(|r| r.0),
+                    c: scratch.get::<&C>(moved).is_ok(),
+                    d: scratch.get::<&D>(moved).ok().map(|r| r.0),
+                };
+                assert_eq!(Some(obs), expected, "migrated entity lost components");
+                self.model.remove(&e);
+                self.retired.push(e);
+            }
+            Err(_) => assert!(expected.is_none(), "take failed for live {e:?}"),
+        }
+    }
+
+    /// A `BuiltEntityClone` can be spawned repeatedly, producing entities with
+    /// identical components. `D` is not `Clone`, so this covers {A, B, C}.
+    #[rule]
+    fn spawn_clone_builder(&mut self, tc: TestCase) {
+        self.flush_model();
+        let s = Spec {
+            d: None,
+            ..tc.draw(specs())
+        };
+        let mut builder = EntityBuilderClone::new();
+        if let Some(v) = s.a {
+            builder.add(A(v));
+        }
+        if let Some(v) = s.b {
+            builder.add(B(v));
+        }
+        if s.c {
+            builder.add(C);
+        }
+        let built = builder.build();
+        for _ in 0..2 {
+            let e = self.world.spawn(&built);
+            assert!(
+                self.model.insert(e, s).is_none(),
+                "clone-builder spawn reused {e:?}"
+            );
+            self.handles.add(e);
+            self.check_entity(e, "spawn_clone_builder");
+        }
+    }
+
+    /// `find_entity_from_id` reconstructs the live handle for an id, so it must
+    /// return the handle the id came from.
+    #[rule]
+    fn find_entity_from_id(&mut self, tc: TestCase) {
+        self.world.flush();
+        self.flush_model();
+        let e = self.draw_handle(&tc);
+        // SAFETY: the model tracks liveness, and `find_entity_from_id`
+        // documents that the id must belong to a live entity.
+        tc.assume(self.model.contains_key(&e));
+        assert_eq!(
+            unsafe { self.world.find_entity_from_id(e.id()) },
+            e,
+            "find_entity_from_id"
+        );
+    }
+
+    // ---- global oracles ----
+
+    /// The world and the model describe the same entities with the same
+    /// components, in both directions.
+    #[invariant]
+    fn world_matches_model(&self, _: TestCase) {
+        assert_eq!(
+            self.world.len() as usize,
+            self.model.len(),
+            "world.len() != model.len()"
+        );
+        for (&e, s) in &self.model {
+            assert!(self.world.contains(e), "world is missing modelled {e:?}");
+            assert_eq!(self.observe(e), Some(*s), "components of {e:?}");
+        }
+        for eref in self.world.iter() {
+            assert!(
+                self.model.contains_key(&eref.entity()),
+                "world has unmodelled {:?}",
+                eref.entity()
+            );
+        }
+    }
+
+    #[invariant]
+    fn archetypes_partition_entities(&self, _: TestCase) {
+        check_archetypes(&self.world, "model world");
+    }
+
+    /// Exactly as many `D` values are alive as the model accounts for: a
+    /// component leaked or dropped twice by an archetype migration shows up
+    /// here.
+    #[invariant]
+    fn drops_balance(&self, _: TestCase) {
+        let expected = self.model.values().filter(|s| s.d.is_some()).count() as i64;
+        assert_eq!(d_live(), expected, "live D count != modelled D count");
+    }
+
+    /// A destroyed handle never resolves again: `despawn` reuses the id but
+    /// advances the generation, which is what makes a stale handle safe to
+    /// keep around.
+    #[invariant]
+    fn retired_handles_never_resolve(&self, _: TestCase) {
+        for &e in &self.retired {
+            assert!(!self.world.contains(e), "retired {e:?} became live again");
+            assert!(
+                self.world.entity(e).is_err(),
+                "retired {e:?} resolved to an EntityRef"
+            );
+            assert!(
+                matches!(
+                    self.world.query_one::<&A>(e).get(),
+                    Err(QueryOneError::NoSuchEntity)
+                ),
+                "query_one on retired {e:?} did not report NoSuchEntity"
+            );
+            assert!(
+                !self.model.contains_key(&e),
+                "retired {e:?} is still modelled"
+            );
+        }
+    }
+
+    /// No two live entities share an id.
+    #[invariant]
+    fn live_ids_are_unique(&self, _: TestCase) {
+        let mut ids = std::collections::HashSet::new();
+        for eref in self.world.iter() {
+            let e = eref.entity();
+            assert!(ids.insert(e.id()), "id {} is live twice", e.id());
+        }
+    }
+
+    /// Reserved handles exist but are invisible to iteration and queries.
+    #[invariant]
+    fn reserved_handles_are_not_live(&self, _: TestCase) {
+        for &e in &self.reserved {
+            assert!(self.world.contains(e), "reserved {e:?} not contained");
+            assert!(
+                !self.model.contains_key(&e),
+                "reserved {e:?} leaked into the model"
+            );
+            assert!(
+                self.world.iter().all(|eref| eref.entity() != e),
+                "reserved {e:?} appeared in iter()"
+            );
+        }
+    }
+
+    /// Every query shape yields exactly the entities and values the model
+    /// predicts, with no duplicates.
+    #[invariant]
+    fn query_shapes_match_model(&self, _: TestCase) {
+        let model = &self.model;
+        let world = &self.world;
+
+        let mut got = HashMap::new();
+        for (e, a) in world.query::<(Entity, &A)>().iter() {
+            assert!(
+                got.insert(e, a.0).is_none(),
+                "query::<&A> yielded {e:?} twice"
+            );
+        }
+        let want: HashMap<Entity, i32> = model
+            .iter()
+            .filter_map(|(&e, s)| s.a.map(|v| (e, v)))
+            .collect();
+        assert_eq!(got, want, "query::<&A>");
+
+        let mut got = HashMap::new();
+        for (e, a, b) in world.query::<(Entity, &A, &B)>().iter() {
+            assert!(
+                got.insert(e, (a.0, b.0)).is_none(),
+                "query::<(&A,&B)> yielded {e:?} twice"
+            );
+        }
+        let want: HashMap<Entity, (i32, i32)> = model
+            .iter()
+            .filter_map(|(&e, s)| s.a.zip(s.b).map(|v| (e, v)))
+            .collect();
+        assert_eq!(got, want, "query::<(&A,&B)>");
+
+        let with: HashMap<Entity, i32> = world
+            .query::<With<(Entity, &A), &B>>()
+            .iter()
+            .map(|(e, a)| (e, a.0))
+            .collect();
+        let want: HashMap<Entity, i32> = model
+            .iter()
+            .filter_map(|(&e, s)| s.b.and(s.a).map(|v| (e, v)))
+            .collect();
+        assert_eq!(with, want, "query::<With<&A, &B>>");
+
+        let without: HashMap<Entity, i32> = world
+            .query::<Without<(Entity, &A), &B>>()
+            .iter()
+            .map(|(e, a)| (e, a.0))
+            .collect();
+        let want: HashMap<Entity, i32> = model
+            .iter()
+            .filter_map(|(&e, s)| match (s.a, s.b) {
+                (Some(v), None) => Some((e, v)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(without, want, "query::<Without<&A, &B>>");
+
+        let or: HashMap<Entity, (Option<i32>, Option<i32>)> = world
+            .query::<(Entity, Or<&A, &B>)>()
+            .iter()
+            .map(|(e, ab)| (e, (ab.left().map(|a| a.0), ab.right().map(|b| b.0))))
+            .collect();
+        let want: HashMap<Entity, (Option<i32>, Option<i32>)> = model
+            .iter()
+            .filter(|(_, s)| s.a.is_some() || s.b.is_some())
+            .map(|(&e, s)| (e, (s.a, s.b)))
+            .collect();
+        assert_eq!(or, want, "query::<Or<&A, &B>>");
+
+        let opt: HashMap<Entity, Option<i32>> = world
+            .query::<(Entity, &A, Option<&B>)>()
+            .iter()
+            .map(|(e, _, b)| (e, b.map(|b| b.0)))
+            .collect();
+        let want: HashMap<Entity, Option<i32>> = model
+            .iter()
+            .filter_map(|(&e, s)| s.a.map(|_| (e, s.b)))
+            .collect();
+        assert_eq!(opt, want, "query::<(&A, Option<&B>)>");
+    }
+
+    /// Per-entity access agrees with the model for every live entity,
+    /// including the `Unsatisfied` and `NoSuchEntity` distinction.
+    #[invariant]
+    fn per_entity_access_matches_model(&self, _: TestCase) {
+        for (&e, s) in &self.model {
+            match self.world.query_one::<&A>(e).get() {
+                Ok(a) => assert_eq!(Some(a.0), s.a, "query_one::<&A> value for {e:?}"),
+                Err(QueryOneError::Unsatisfied) => {
+                    assert!(
+                        s.a.is_none(),
+                        "query_one::<&A> unsatisfied but A modelled for {e:?}"
+                    )
+                }
+                Err(QueryOneError::NoSuchEntity) => panic!("query_one on live {e:?}"),
+            }
+            // `with`/`without` filter the same query by another component's
+            // presence without borrowing it.
+            match self.world.query_one::<&A>(e).with::<&B>().get() {
+                Ok(a) => assert_eq!((Some(a.0), true), (s.a, s.b.is_some()), "with::<&B> {e:?}"),
+                Err(QueryOneError::Unsatisfied) => {
+                    assert!(
+                        s.a.is_none() || s.b.is_none(),
+                        "with::<&B> unsatisfied for {e:?}"
+                    )
+                }
+                Err(QueryOneError::NoSuchEntity) => panic!("with::<&B> on live {e:?}"),
+            }
+            match self.world.query_one::<&A>(e).without::<&B>().get() {
+                Ok(a) => assert_eq!(
+                    (Some(a.0), false),
+                    (s.a, s.b.is_some()),
+                    "without::<&B> {e:?}"
+                ),
+                Err(QueryOneError::Unsatisfied) => {
+                    assert!(
+                        s.a.is_none() || s.b.is_some(),
+                        "without::<&B> unsatisfied for {e:?}"
+                    )
+                }
+                Err(QueryOneError::NoSuchEntity) => panic!("without::<&B> on live {e:?}"),
+            }
+            assert_eq!(
+                self.world.satisfies::<&A>(e),
+                s.a.is_some(),
+                "satisfies::<&A> {e:?}"
+            );
+            assert_eq!(
+                self.world.satisfies::<(&A, &B)>(e),
+                s.a.is_some() && s.b.is_some(),
+                "satisfies::<(&A,&B)> {e:?}"
+            );
+
+            let eref = self.world.entity(e).expect("live modelled entity");
+            assert_eq!(eref.entity(), e, "EntityRef::entity");
+            assert_eq!(eref.has::<A>(), s.a.is_some(), "EntityRef::has::<A> {e:?}");
+            assert_eq!(eref.has::<C>(), s.c, "EntityRef::has::<C> {e:?}");
+            assert_eq!(eref.len(), s.component_count(), "EntityRef::len {e:?}");
+            assert_eq!(
+                eref.is_empty(),
+                s.component_count() == 0,
+                "EntityRef::is_empty {e:?}"
+            );
+            assert_eq!(
+                eref.component_types().count(),
+                s.component_count(),
+                "EntityRef::component_types {e:?}"
+            );
+        }
+
+        let view = self.world.view::<&A>();
+        for (&e, s) in &self.model {
+            assert_eq!(view.get(e).map(|a| a.0), s.a, "view.get {e:?}");
+            assert_eq!(view.contains(e), s.a.is_some(), "view.contains {e:?}");
+        }
+    }
+
+    /// A `PreparedQuery` caches archetype state across calls, so it must keep
+    /// agreeing with a freshly built query as archetypes come and go.
+    #[invariant]
+    fn prepared_query_matches_fresh_query(&mut self, _: TestCase) {
+        let fresh: HashMap<Entity, i32> = self
+            .world
+            .query::<(Entity, &A)>()
+            .iter()
+            .map(|(e, a)| (e, a.0))
+            .collect();
+        let mut pq = PreparedQuery::<(Entity, &A)>::new();
+        let prepared: HashMap<Entity, i32> = {
+            let mut borrow = pq.query(&self.world);
+            borrow.iter().map(|(e, a)| (e, a.0)).collect()
+        };
+        assert_eq!(
+            prepared, fresh,
+            "PreparedQuery disagreed with a fresh query"
+        );
+
+        let mut pv = PreparedQuery::<&A>::new();
+        let view = pv.view_mut(&mut self.world);
+        for (&e, v) in &fresh {
+            assert_eq!(
+                view.get(e).map(|a| a.0),
+                Some(*v),
+                "PreparedView::get {e:?}"
+            );
+        }
+    }
+
+    /// Batched iteration visits exactly the same entities as flat iteration.
+    #[invariant]
+    fn batched_iteration_matches_flat(&self, tc: TestCase) {
+        let flat: HashMap<Entity, i32> = self
+            .world
+            .query::<(Entity, &A)>()
+            .iter()
+            .map(|(e, a)| (e, a.0))
+            .collect();
+        // A zero batch size is documented to panic.
+        let size = tc.draw(gs::integers::<u32>().min_value(1).max_value(4));
+        let mut q = self.world.query::<(Entity, &A)>();
+        let mut got = HashMap::new();
+        for batch in q.iter_batched(size) {
+            for (e, a) in batch {
+                assert!(
+                    got.insert(e, a.0).is_none(),
+                    "iter_batched yielded {e:?} twice"
+                );
+            }
+        }
+        assert_eq!(
+            got, flat,
+            "iter_batched(={size}) disagreed with flat iteration"
+        );
+    }
+}
+
+#[hegel::test(settings().stateful_step_count(STEPS))]
+fn world_matches_model(tc: TestCase) {
+    assert_d_balanced_at_start();
+    let machine = WorldModel {
+        world: World::new(),
+        model: HashMap::new(),
+        handles: pool(&tc),
+        reserved: Vec::new(),
+        retired: Vec::new(),
+    };
+    hegel::stateful::run(machine, tc);
+}

--- a/tests/world_model.rs
+++ b/tests/world_model.rs
@@ -652,10 +652,7 @@ impl WorldModel {
     #[rule]
     fn spawn_clone_builder(&mut self, tc: TestCase) {
         self.flush_model();
-        let s = Spec {
-            d: None,
-            ..tc.draw(specs())
-        };
+        let s = tc.draw(specs_without_d());
         let mut builder = EntityBuilderClone::new();
         if let Some(v) = s.a {
             builder.add(A(v));

--- a/tests/world_model.rs
+++ b/tests/world_model.rs
@@ -36,6 +36,7 @@ struct WorldModel {
     /// advances the generation, so none of these may resolve again; `clear`
     /// and `spawn_at` are the documented exceptions.
     retired: Vec<Entity>,
+    ds: DropTracker,
 }
 
 impl WorldModel {
@@ -64,7 +65,7 @@ impl WorldModel {
             a: eref.get::<&A>().map(|r| r.0),
             b: eref.get::<&B>().map(|r| r.0),
             c: eref.get::<&C>().is_some(),
-            d: eref.get::<&D>().map(|r| r.0),
+            d: eref.get::<&D>().map(|r| r.value),
         })
     }
 
@@ -88,7 +89,7 @@ impl WorldModel {
     fn spawn(&mut self, tc: TestCase) {
         self.flush_model();
         let cs = tc.draw(components());
-        let mut builder = cs.builder();
+        let mut builder = cs.builder(&self.ds);
         assert_eq!(builder.has::<A>(), cs.a.is_some(), "builder.has::<A>");
         assert_eq!(builder.has::<D>(), cs.d.is_some(), "builder.has::<D>");
         assert_eq!(builder.get::<&A>().map(|r| r.0), cs.a, "builder.get::<&A>");
@@ -113,7 +114,7 @@ impl WorldModel {
         self.flush_model();
         let handle = self.draw_handle(&tc);
         let cs = tc.draw(components());
-        let mut builder = cs.builder();
+        let mut builder = cs.builder(&self.ds);
         self.world.spawn_at(handle, builder.build());
         self.model.retain(|k, _| k.id() != handle.id());
         self.model.insert(handle, cs);
@@ -142,7 +143,7 @@ impl WorldModel {
             "to_bits is not the inverse of from_bits"
         );
         let cs = tc.draw(components());
-        let mut builder = cs.builder();
+        let mut builder = cs.builder(&self.ds);
         self.world.spawn_at(handle, builder.build());
         self.model.retain(|k, _| k.id() != handle.id());
         self.model.insert(handle, cs);
@@ -205,7 +206,7 @@ impl WorldModel {
             // On a dead target the component is dropped rather than stored, so
             // the drop count stays balanced either way.
             _ => {
-                let ok = self.world.insert_one(e, D::new(v)).is_ok();
+                let ok = self.world.insert_one(e, D::new(v, &self.ds)).is_ok();
                 if let Some(m) = self.model.get_mut(&e) {
                     m.d = Some(v);
                 }
@@ -223,7 +224,7 @@ impl WorldModel {
         let e = self.draw_handle(&tc);
         let live = self.model.contains_key(&e);
         let cs = tc.draw(components());
-        let mut builder = cs.builder();
+        let mut builder = cs.builder(&self.ds);
         let ok = self.world.insert(e, builder.build()).is_ok();
         assert_eq!(ok, live, "insert bundle disagreed for {e:?}");
         if let Some(m) = self.model.get_mut(&e) {
@@ -276,7 +277,7 @@ impl WorldModel {
             _ => {
                 let got = self.world.remove_one::<D>(e).ok();
                 assert_eq!(
-                    got.as_ref().map(|d| d.0),
+                    got.as_ref().map(|d| d.value),
                     before.and_then(|cs| cs.d),
                     "remove_one::<D> {e:?}"
                 );
@@ -346,7 +347,7 @@ impl WorldModel {
         } else {
             let got = self.world.exchange_one::<D, A>(e, A(v)).ok();
             assert_eq!(
-                got.as_ref().map(|d| d.0),
+                got.as_ref().map(|d| d.value),
                 before.and_then(|cs| cs.d),
                 "exchange D->A {e:?}"
             );
@@ -385,7 +386,7 @@ impl WorldModel {
             // Editing D's payload constructs and drops nothing.
             _ => {
                 if let Ok(mut d) = self.world.get::<&mut D>(e) {
-                    d.0 = v;
+                    d.value = v;
                 }
                 if let Some(m) = self.model.get_mut(&e).filter(|m| m.d.is_some()) {
                     m.d = Some(v);
@@ -639,7 +640,7 @@ impl WorldModel {
                     a: scratch.get::<&A>(moved).ok().map(|r| r.0),
                     b: scratch.get::<&B>(moved).ok().map(|r| r.0),
                     c: scratch.get::<&C>(moved).is_ok(),
-                    d: scratch.get::<&D>(moved).ok().map(|r| r.0),
+                    d: scratch.get::<&D>(moved).ok().map(|r| r.value),
                 };
                 assert_eq!(Some(obs), expected, "migrated entity lost components");
                 self.model.remove(&e);
@@ -728,8 +729,8 @@ impl WorldModel {
     /// here.
     #[invariant]
     fn drops_balance(&self, _: TestCase) {
-        let expected = self.model.values().filter(|cs| cs.d.is_some()).count() as i64;
-        assert_eq!(d_live(), expected, "live D count != modelled D count");
+        let expected = self.model.values().filter(|cs| cs.d.is_some()).count();
+        assert_eq!(self.ds.live(), expected, "live D count != modelled D count");
     }
 
     /// A destroyed handle never resolves again: `despawn` reuses the id but
@@ -1006,13 +1007,13 @@ impl WorldModel {
 
 #[hegel::test(settings().stateful_step_count(STEPS))]
 fn world_matches_model(tc: TestCase) {
-    assert_d_balanced_at_start();
     let machine = WorldModel {
         world: World::new(),
         model: HashMap::new(),
         handles: pool(&tc),
         reserved: Vec::new(),
         retired: Vec::new(),
+        ds: DropTracker::new(),
     };
     hegel::stateful::run(machine, tc);
 }

--- a/tests/world_model.rs
+++ b/tests/world_model.rs
@@ -345,7 +345,8 @@ impl WorldModel {
         };
         assert_eq!(got, had, "get::<&mut {kind:?}> disagreed for {e:?}");
         if had {
-            *self.model.get_mut(&e).unwrap() = self.model[&e].with(kind, v);
+            let m = self.model.get_mut(&e).unwrap();
+            *m = m.with(kind, v);
         }
         self.check_entity(e, "mutate_in_place");
     }
@@ -422,7 +423,8 @@ impl WorldModel {
     fn view_get_disjoint_mut(&mut self, tc: TestCase) {
         let e1 = self.draw_handle(&tc);
         let e2 = self.draw_handle(&tc);
-        // `get_disjoint_mut` documents a panic on repeated handles.
+        // Like `query_disjoint_mut`, `get_disjoint_mut` panics on repeated
+        // handles.
         tc.assume(e1 != e2);
         let (v1, v2) = (tc.draw(val()), tc.draw(val()));
         let mut view = self.world.view_mut::<&mut B>();

--- a/tests/world_model.rs
+++ b/tests/world_model.rs
@@ -12,11 +12,9 @@
 //! The handle pool deliberately retains despawned handles, so operations
 //! against dead entities are common and their error paths are exercised.
 
-mod common;
-
 use std::collections::HashMap;
 
-use common::*;
+use fixtures::*;
 use hecs::{Entity, EntityBuilderClone, Or, PreparedQuery, QueryOneError, With, Without, World};
 use hegel::generators::{self as gs, Generator};
 use hegel::stateful::{pool, Pool};

--- a/tests/world_model.rs
+++ b/tests/world_model.rs
@@ -5,9 +5,8 @@
 //! Each rule asserts the postcondition it establishes (the operation's
 //! `Ok`/`Err` against modelled liveness, and the touched entity's resulting
 //! component set). The global oracles — full bidirectional equivalence, the
-//! archetype partition, the drop count, and the query surface — are invariants,
-//! which hegel runs in full on the initial and final state and, after each
-//! step, each with probability `1 / STEPS`, so about once more per case.
+//! archetype partition, the drop count, and the query surface — are
+//! invariants.
 //!
 //! The handle pool deliberately retains despawned handles, so operations
 //! against dead entities are common and their error paths are exercised.
@@ -76,8 +75,7 @@ impl WorldModel {
     }
 }
 
-// Each case applies up to `STEPS` rules, chosen at random, to the machine
-// built in `world_matches_model` below.
+// Driven by `world_matches_model` below.
 #[hegel::state_machine]
 impl WorldModel {
     /// `spawn` reports a fresh handle carrying exactly the bundle's components,

--- a/tests/world_model.rs
+++ b/tests/world_model.rs
@@ -184,39 +184,14 @@ impl WorldModel {
         self.flush_model();
         let e = self.draw_handle(&tc);
         let live = self.model.contains_key(&e);
+        let kind = tc.draw(kinds());
         let v = tc.draw(val());
-        let ok = match tc.draw(gs::integers::<u8>().min_value(0).max_value(3)) {
-            0 => {
-                let ok = self.world.insert_one(e, A(v)).is_ok();
-                if let Some(m) = self.model.get_mut(&e) {
-                    m.a = Some(v);
-                }
-                ok
-            }
-            1 => {
-                let ok = self.world.insert_one(e, B(v)).is_ok();
-                if let Some(m) = self.model.get_mut(&e) {
-                    m.b = Some(v);
-                }
-                ok
-            }
-            2 => {
-                let ok = self.world.insert_one(e, C).is_ok();
-                if let Some(m) = self.model.get_mut(&e) {
-                    m.c = true;
-                }
-                ok
-            }
-            // On a dead target the component is dropped rather than stored, so
-            // the drop count stays balanced either way.
-            _ => {
-                let ok = self.world.insert_one(e, D::new(v, &self.ds)).is_ok();
-                if let Some(m) = self.model.get_mut(&e) {
-                    m.d = Some(v);
-                }
-                ok
-            }
-        };
+        // On a dead target the component is dropped rather than stored, so
+        // the drop count stays balanced either way.
+        let ok = kind.insert_one(&mut self.world, e, v, &self.ds).is_ok();
+        if let Some(m) = self.model.get_mut(&e) {
+            *m = m.with(kind, v);
+        }
         assert_eq!(ok, live, "insert_one disagreed for {e:?}");
         self.check_entity(e, "insert_one");
     }
@@ -247,48 +222,32 @@ impl WorldModel {
         self.flush_model();
         let e = self.draw_handle(&tc);
         let before = self.expect(e);
-        match tc.draw(gs::integers::<u8>().min_value(0).max_value(3)) {
-            0 => {
-                let got = self.world.remove_one::<A>(e).ok();
-                assert_eq!(
-                    got.map(|A(v)| v),
-                    before.and_then(|cs| cs.a),
-                    "remove_one::<A> {e:?}"
-                );
-                if let Some(m) = self.model.get_mut(&e) {
-                    m.a = None;
-                }
-            }
-            1 => {
-                let got = self.world.remove_one::<B>(e).ok();
-                assert_eq!(
-                    got.map(|B(v)| v),
-                    before.and_then(|cs| cs.b),
-                    "remove_one::<B> {e:?}"
-                );
-                if let Some(m) = self.model.get_mut(&e) {
-                    m.b = None;
-                }
-            }
-            2 => {
-                let ok = self.world.remove_one::<C>(e).is_ok();
-                assert_eq!(ok, before.is_some_and(|cs| cs.c), "remove_one::<C> {e:?}");
-                if let Some(m) = self.model.get_mut(&e) {
-                    m.c = false;
-                }
-            }
+        let kind = tc.draw(kinds());
+        match kind {
+            Kind::A => assert_eq!(
+                self.world.remove_one::<A>(e).ok().map(|A(v)| v),
+                before.and_then(|cs| cs.a),
+                "remove_one::<A> {e:?}"
+            ),
+            Kind::B => assert_eq!(
+                self.world.remove_one::<B>(e).ok().map(|B(v)| v),
+                before.and_then(|cs| cs.b),
+                "remove_one::<B> {e:?}"
+            ),
+            Kind::C => assert_eq!(
+                self.world.remove_one::<C>(e).is_ok(),
+                before.is_some_and(|cs| cs.c),
+                "remove_one::<C> {e:?}"
+            ),
             // The removed D is returned and dropped here, matching the model.
-            _ => {
-                let got = self.world.remove_one::<D>(e).ok();
-                assert_eq!(
-                    got.as_ref().map(|d| d.value),
-                    before.and_then(|cs| cs.d),
-                    "remove_one::<D> {e:?}"
-                );
-                if let Some(m) = self.model.get_mut(&e) {
-                    m.d = None;
-                }
-            }
+            Kind::D => assert_eq!(
+                self.world.remove_one::<D>(e).ok().map(|d| d.value),
+                before.and_then(|cs| cs.d),
+                "remove_one::<D> {e:?}"
+            ),
+        }
+        if let Some(m) = self.model.get_mut(&e) {
+            *m = m.without(kind);
         }
         self.check_entity(e, "remove_one");
     }
@@ -364,38 +323,25 @@ impl WorldModel {
         self.check_entity(e, "exchange_one");
     }
 
-    /// A write through `get::<&mut T>` is visible to a subsequent read. This is
-    /// a read path, so it does not flush.
+    /// `get::<&mut T>` resolves exactly the components the model holds, and a
+    /// write through it is visible to a subsequent read. This is a read path,
+    /// so it does not flush.
     #[rule]
     fn mutate_in_place(&mut self, tc: TestCase) {
         let e = self.draw_handle(&tc);
+        let kind = tc.draw(kinds());
         let v = tc.draw(val());
-        match tc.draw(gs::integers::<u8>().min_value(0).max_value(2)) {
-            0 => {
-                if let Ok(mut a) = self.world.get::<&mut A>(e) {
-                    a.0 = v;
-                }
-                if let Some(m) = self.model.get_mut(&e).filter(|m| m.a.is_some()) {
-                    m.a = Some(v);
-                }
-            }
-            1 => {
-                if let Ok(mut b) = self.world.get::<&mut B>(e) {
-                    b.0 = v;
-                }
-                if let Some(m) = self.model.get_mut(&e).filter(|m| m.b.is_some()) {
-                    m.b = Some(v);
-                }
-            }
+        let had = self.model.get(&e).is_some_and(|m| m.has(kind));
+        let got = match kind {
+            Kind::A => self.world.get::<&mut A>(e).map(|mut a| a.0 = v).is_ok(),
+            Kind::B => self.world.get::<&mut B>(e).map(|mut b| b.0 = v).is_ok(),
+            Kind::C => self.world.get::<&mut C>(e).is_ok(),
             // Editing D's payload constructs and drops nothing.
-            _ => {
-                if let Ok(mut d) = self.world.get::<&mut D>(e) {
-                    d.value = v;
-                }
-                if let Some(m) = self.model.get_mut(&e).filter(|m| m.d.is_some()) {
-                    m.d = Some(v);
-                }
-            }
+            Kind::D => self.world.get::<&mut D>(e).map(|mut d| d.value = v).is_ok(),
+        };
+        assert_eq!(got, had, "get::<&mut {kind:?}> disagreed for {e:?}");
+        if had {
+            *self.model.get_mut(&e).unwrap() = self.model[&e].with(kind, v);
         }
         self.check_entity(e, "mutate_in_place");
     }

--- a/tests/world_model.rs
+++ b/tests/world_model.rs
@@ -20,10 +20,7 @@ use hegel::generators::{self as gs, Generator};
 use hegel::stateful::{pool, Pool};
 use hegel::TestCase;
 
-#[cfg(miri)]
-const STEPS: i64 = 8;
-#[cfg(not(miri))]
-const STEPS: i64 = 150;
+const STEPS: i64 = if cfg!(miri) { 8 } else { 150 };
 
 struct WorldModel {
     world: World,

--- a/tests/world_model.rs
+++ b/tests/world_model.rs
@@ -6,8 +6,8 @@
 //! `Ok`/`Err` against modelled liveness, and the touched entity's resulting
 //! component set). The global oracles — full bidirectional equivalence, the
 //! archetype partition, the drop count, and the query surface — are invariants,
-//! which hegel samples between steps and runs in full on the initial and final
-//! state.
+//! which hegel runs in full on the initial and final state and, after each
+//! step, each with probability `1 / STEPS`, so about once more per case.
 //!
 //! The handle pool deliberately retains despawned handles, so operations
 //! against dead entities are common and their error paths are exercised.
@@ -80,6 +80,8 @@ impl WorldModel {
     }
 }
 
+// Each case applies up to `STEPS` rules, chosen at random, to the machine
+// built in `world_matches_model` below.
 #[hegel::state_machine]
 impl WorldModel {
     /// `spawn` reports a fresh handle carrying exactly the bundle's components,

--- a/tests/world_model.rs
+++ b/tests/world_model.rs
@@ -14,7 +14,7 @@
 use std::collections::HashMap;
 
 use fixtures::*;
-use hecs::{Entity, EntityBuilderClone, Or, PreparedQuery, QueryOneError, With, Without, World};
+use hecs::{Entity, Or, PreparedQuery, QueryOneError, With, Without, World};
 use hegel::generators::{self as gs, Generator};
 use hegel::stateful::{pool, Pool};
 use hegel::TestCase;
@@ -56,13 +56,7 @@ impl WorldModel {
 
     /// Everything observable about `e` right now.
     fn observe(&self, e: Entity) -> Option<Components> {
-        let eref = self.world.entity(e).ok()?;
-        Some(Components {
-            a: eref.get::<&A>().map(|r| r.0),
-            b: eref.get::<&B>().map(|r| r.0),
-            c: eref.get::<&C>().is_some(),
-            d: eref.get::<&D>().map(|r| r.value),
-        })
+        self.world.entity(e).ok().map(Components::observed)
     }
 
     fn check_entity(&self, e: Entity, label: &str) {
@@ -589,12 +583,7 @@ impl WorldModel {
                     1,
                     "scratch world holds more than the moved entity"
                 );
-                let obs = Components {
-                    a: scratch.get::<&A>(moved).ok().map(|r| r.0),
-                    b: scratch.get::<&B>(moved).ok().map(|r| r.0),
-                    c: scratch.get::<&C>(moved).is_ok(),
-                    d: scratch.get::<&D>(moved).ok().map(|r| r.value),
-                };
+                let obs = Components::observed(scratch.entity(moved).unwrap());
                 assert_eq!(Some(obs), expected, "migrated entity lost components");
                 self.model.remove(&e);
                 self.retired.push(e);
@@ -609,17 +598,7 @@ impl WorldModel {
     fn spawn_clone_builder(&mut self, tc: TestCase) {
         self.flush_model();
         let cs = tc.draw(components_without_d());
-        let mut builder = EntityBuilderClone::new();
-        if let Some(v) = cs.a {
-            builder.add(A(v));
-        }
-        if let Some(v) = cs.b {
-            builder.add(B(v));
-        }
-        if cs.c {
-            builder.add(C);
-        }
-        let built = builder.build();
+        let built = cs.clone_builder().build();
         for _ in 0..2 {
             let e = self.world.spawn(&built);
             assert!(

--- a/tests/world_model.rs
+++ b/tests/world_model.rs
@@ -1,6 +1,6 @@
 //! Model-based property test for `World`: a drawn sequence of operations is
-//! applied to both a `World` and a `HashMap<Entity, Spec>` reference model, and
-//! the two must agree.
+//! applied to both a `World` and a `HashMap<Entity, Components>` reference
+//! model, and the two must agree.
 //!
 //! Each rule asserts the postcondition it establishes (the operation's
 //! `Ok`/`Err` against modelled liveness, and the touched entity's resulting
@@ -27,7 +27,7 @@ const STEPS: i64 = 150;
 
 struct WorldModel {
     world: World,
-    model: HashMap<Entity, Spec>,
+    model: HashMap<Entity, Components>,
     /// Every handle ever handed out, including despawned ones.
     handles: Pool<Entity>,
     /// Handles from `reserve_entity`/`reserve_entities` awaiting a flush.
@@ -44,7 +44,7 @@ impl WorldModel {
     /// flush (all variations of spawn, despawn, insert and remove).
     fn flush_model(&mut self) {
         for e in self.reserved.drain(..) {
-            self.model.insert(e, Spec::default());
+            self.model.insert(e, Components::default());
         }
     }
 
@@ -53,14 +53,14 @@ impl WorldModel {
     }
 
     /// The component set the model predicts for `e`, or `None` if dead.
-    fn expect(&self, e: Entity) -> Option<Spec> {
+    fn expect(&self, e: Entity) -> Option<Components> {
         self.model.get(&e).copied()
     }
 
     /// Everything observable about `e` right now.
-    fn observe(&self, e: Entity) -> Option<Spec> {
+    fn observe(&self, e: Entity) -> Option<Components> {
         let eref = self.world.entity(e).ok()?;
-        Some(Spec {
+        Some(Components {
             a: eref.get::<&A>().map(|r| r.0),
             b: eref.get::<&B>().map(|r| r.0),
             c: eref.get::<&C>().is_some(),
@@ -87,19 +87,19 @@ impl WorldModel {
     #[rule]
     fn spawn(&mut self, tc: TestCase) {
         self.flush_model();
-        let s = tc.draw(specs());
-        let mut builder = make_builder(s);
-        assert_eq!(builder.has::<A>(), s.a.is_some(), "builder.has::<A>");
-        assert_eq!(builder.has::<D>(), s.d.is_some(), "builder.has::<D>");
-        assert_eq!(builder.get::<&A>().map(|r| r.0), s.a, "builder.get::<&A>");
+        let cs = tc.draw(components());
+        let mut builder = cs.builder();
+        assert_eq!(builder.has::<A>(), cs.a.is_some(), "builder.has::<A>");
+        assert_eq!(builder.has::<D>(), cs.d.is_some(), "builder.has::<D>");
+        assert_eq!(builder.get::<&A>().map(|r| r.0), cs.a, "builder.get::<&A>");
         assert_eq!(
             builder.component_types().count(),
-            s.component_count(),
+            cs.component_count(),
             "builder.component_types"
         );
         let e = self.world.spawn(builder.build());
         assert!(
-            self.model.insert(e, s).is_none(),
+            self.model.insert(e, cs).is_none(),
             "spawn reused a live handle {e:?}"
         );
         self.handles.add(e);
@@ -112,11 +112,11 @@ impl WorldModel {
     fn spawn_at(&mut self, tc: TestCase) {
         self.flush_model();
         let handle = self.draw_handle(&tc);
-        let s = tc.draw(specs());
-        let mut builder = make_builder(s);
+        let cs = tc.draw(components());
+        let mut builder = cs.builder();
         self.world.spawn_at(handle, builder.build());
         self.model.retain(|k, _| k.id() != handle.id());
-        self.model.insert(handle, s);
+        self.model.insert(handle, cs);
         self.retired.retain(|r| r.id() != handle.id());
         self.check_entity(handle, "spawn_at");
         assert!(
@@ -141,11 +141,11 @@ impl WorldModel {
             bits,
             "to_bits is not the inverse of from_bits"
         );
-        let s = tc.draw(specs());
-        let mut builder = make_builder(s);
+        let cs = tc.draw(components());
+        let mut builder = cs.builder();
         self.world.spawn_at(handle, builder.build());
         self.model.retain(|k, _| k.id() != handle.id());
-        self.model.insert(handle, s);
+        self.model.insert(handle, cs);
         self.retired.retain(|r| r.id() != handle.id());
         self.handles.add(handle);
         self.check_entity(handle, "spawn_at_fresh_id");
@@ -222,15 +222,15 @@ impl WorldModel {
         self.flush_model();
         let e = self.draw_handle(&tc);
         let live = self.model.contains_key(&e);
-        let s = tc.draw(specs());
-        let mut builder = make_builder(s);
+        let cs = tc.draw(components());
+        let mut builder = cs.builder();
         let ok = self.world.insert(e, builder.build()).is_ok();
         assert_eq!(ok, live, "insert bundle disagreed for {e:?}");
         if let Some(m) = self.model.get_mut(&e) {
-            m.a = s.a.or(m.a);
-            m.b = s.b.or(m.b);
-            m.c |= s.c;
-            m.d = s.d.or(m.d);
+            m.a = cs.a.or(m.a);
+            m.b = cs.b.or(m.b);
+            m.c |= cs.c;
+            m.d = cs.d.or(m.d);
         }
         self.check_entity(e, "insert_bundle");
     }
@@ -247,7 +247,7 @@ impl WorldModel {
                 let got = self.world.remove_one::<A>(e).ok();
                 assert_eq!(
                     got.map(|A(v)| v),
-                    before.and_then(|s| s.a),
+                    before.and_then(|cs| cs.a),
                     "remove_one::<A> {e:?}"
                 );
                 if let Some(m) = self.model.get_mut(&e) {
@@ -258,7 +258,7 @@ impl WorldModel {
                 let got = self.world.remove_one::<B>(e).ok();
                 assert_eq!(
                     got.map(|B(v)| v),
-                    before.and_then(|s| s.b),
+                    before.and_then(|cs| cs.b),
                     "remove_one::<B> {e:?}"
                 );
                 if let Some(m) = self.model.get_mut(&e) {
@@ -267,7 +267,7 @@ impl WorldModel {
             }
             2 => {
                 let ok = self.world.remove_one::<C>(e).is_ok();
-                assert_eq!(ok, before.is_some_and(|s| s.c), "remove_one::<C> {e:?}");
+                assert_eq!(ok, before.is_some_and(|cs| cs.c), "remove_one::<C> {e:?}");
                 if let Some(m) = self.model.get_mut(&e) {
                     m.c = false;
                 }
@@ -277,7 +277,7 @@ impl WorldModel {
                 let got = self.world.remove_one::<D>(e).ok();
                 assert_eq!(
                     got.as_ref().map(|d| d.0),
-                    before.and_then(|s| s.d),
+                    before.and_then(|cs| cs.d),
                     "remove_one::<D> {e:?}"
                 );
                 if let Some(m) = self.model.get_mut(&e) {
@@ -296,7 +296,7 @@ impl WorldModel {
         let e = self.draw_handle(&tc);
         let before = self.expect(e);
         if tc.draw(gs::booleans()) {
-            let had = before.is_some_and(|s| s.a.is_some() && s.b.is_some());
+            let had = before.is_some_and(|cs| cs.a.is_some() && cs.b.is_some());
             assert_eq!(
                 self.world.remove::<(A, B)>(e).is_ok(),
                 had,
@@ -308,7 +308,7 @@ impl WorldModel {
                 m.b = None;
             }
         } else {
-            let had = before.is_some_and(|s| s.c && s.d.is_some());
+            let had = before.is_some_and(|cs| cs.c && cs.d.is_some());
             assert_eq!(
                 self.world.remove::<(C, D)>(e).is_ok(),
                 had,
@@ -335,7 +335,7 @@ impl WorldModel {
             let got = self.world.exchange_one::<A, B>(e, B(v)).ok();
             assert_eq!(
                 got.map(|A(x)| x),
-                before.and_then(|s| s.a),
+                before.and_then(|cs| cs.a),
                 "exchange A->B {e:?}"
             );
             if got.is_some() {
@@ -347,7 +347,7 @@ impl WorldModel {
             let got = self.world.exchange_one::<D, A>(e, A(v)).ok();
             assert_eq!(
                 got.as_ref().map(|d| d.0),
-                before.and_then(|s| s.d),
+                before.and_then(|cs| cs.d),
                 "exchange D->A {e:?}"
             );
             if got.is_some() {
@@ -445,12 +445,12 @@ impl WorldModel {
         }
         assert_eq!(
             got1,
-            self.expect(e1).and_then(|s| s.a),
+            self.expect(e1).and_then(|cs| cs.a),
             "query_disjoint_mut {e1:?}"
         );
         assert_eq!(
             got2,
-            self.expect(e2).and_then(|s| s.a),
+            self.expect(e2).and_then(|cs| cs.a),
             "query_disjoint_mut {e2:?}"
         );
         if got1.is_some() {
@@ -483,7 +483,7 @@ impl WorldModel {
         }
         assert_eq!(
             got1.is_some(),
-            self.expect(e1).is_some_and(|s| s.b.is_some()),
+            self.expect(e1).is_some_and(|cs| cs.b.is_some()),
             "view B-presence {e1:?}"
         );
         if got1.is_some() {
@@ -492,7 +492,7 @@ impl WorldModel {
         if e1 != e2 {
             assert_eq!(
                 got2.is_some(),
-                self.expect(e2).is_some_and(|s| s.b.is_some()),
+                self.expect(e2).is_some_and(|cs| cs.b.is_some()),
                 "view B-presence {e2:?}"
             );
             if got2.is_some() {
@@ -532,7 +532,7 @@ impl WorldModel {
             n as usize,
             "spawn_batch yielded the wrong count"
         );
-        let s = Spec {
+        let cs = Components {
             a: Some(v),
             b: Some(v),
             c: false,
@@ -540,7 +540,7 @@ impl WorldModel {
         };
         for e in handles {
             assert!(
-                self.model.insert(e, s).is_none(),
+                self.model.insert(e, cs).is_none(),
                 "spawn_batch reused {e:?}"
             );
             self.handles.add(e);
@@ -593,7 +593,11 @@ impl WorldModel {
         self.world.flush();
         self.flush_model();
         for e in expected {
-            assert_eq!(self.observe(e), Some(Spec::default()), "flushed {e:?}");
+            assert_eq!(
+                self.observe(e),
+                Some(Components::default()),
+                "flushed {e:?}"
+            );
         }
     }
 
@@ -631,7 +635,7 @@ impl WorldModel {
                     1,
                     "scratch world holds more than the moved entity"
                 );
-                let obs = Spec {
+                let obs = Components {
                     a: scratch.get::<&A>(moved).ok().map(|r| r.0),
                     b: scratch.get::<&B>(moved).ok().map(|r| r.0),
                     c: scratch.get::<&C>(moved).is_ok(),
@@ -650,22 +654,22 @@ impl WorldModel {
     #[rule]
     fn spawn_clone_builder(&mut self, tc: TestCase) {
         self.flush_model();
-        let s = tc.draw(specs_without_d());
+        let cs = tc.draw(components_without_d());
         let mut builder = EntityBuilderClone::new();
-        if let Some(v) = s.a {
+        if let Some(v) = cs.a {
             builder.add(A(v));
         }
-        if let Some(v) = s.b {
+        if let Some(v) = cs.b {
             builder.add(B(v));
         }
-        if s.c {
+        if cs.c {
             builder.add(C);
         }
         let built = builder.build();
         for _ in 0..2 {
             let e = self.world.spawn(&built);
             assert!(
-                self.model.insert(e, s).is_none(),
+                self.model.insert(e, cs).is_none(),
                 "clone-builder spawn reused {e:?}"
             );
             self.handles.add(e);
@@ -701,9 +705,9 @@ impl WorldModel {
             self.model.len(),
             "world.len() != model.len()"
         );
-        for (&e, s) in &self.model {
+        for (&e, cs) in &self.model {
             assert!(self.world.contains(e), "world is missing modelled {e:?}");
-            assert_eq!(self.observe(e), Some(*s), "components of {e:?}");
+            assert_eq!(self.observe(e), Some(*cs), "components of {e:?}");
         }
         for eref in self.world.iter() {
             assert!(
@@ -724,7 +728,7 @@ impl WorldModel {
     /// here.
     #[invariant]
     fn drops_balance(&self, _: TestCase) {
-        let expected = self.model.values().filter(|s| s.d.is_some()).count() as i64;
+        let expected = self.model.values().filter(|cs| cs.d.is_some()).count() as i64;
         assert_eq!(d_live(), expected, "live D count != modelled D count");
     }
 
@@ -795,7 +799,7 @@ impl WorldModel {
         }
         let want: HashMap<Entity, i32> = model
             .iter()
-            .filter_map(|(&e, s)| s.a.map(|v| (e, v)))
+            .filter_map(|(&e, cs)| cs.a.map(|v| (e, v)))
             .collect();
         assert_eq!(got, want, "query::<&A>");
 
@@ -808,7 +812,7 @@ impl WorldModel {
         }
         let want: HashMap<Entity, (i32, i32)> = model
             .iter()
-            .filter_map(|(&e, s)| s.a.zip(s.b).map(|v| (e, v)))
+            .filter_map(|(&e, cs)| cs.a.zip(cs.b).map(|v| (e, v)))
             .collect();
         assert_eq!(got, want, "query::<(&A,&B)>");
 
@@ -819,7 +823,7 @@ impl WorldModel {
             .collect();
         let want: HashMap<Entity, i32> = model
             .iter()
-            .filter_map(|(&e, s)| s.b.and(s.a).map(|v| (e, v)))
+            .filter_map(|(&e, cs)| cs.b.and(cs.a).map(|v| (e, v)))
             .collect();
         assert_eq!(with, want, "query::<With<&A, &B>>");
 
@@ -830,7 +834,7 @@ impl WorldModel {
             .collect();
         let want: HashMap<Entity, i32> = model
             .iter()
-            .filter_map(|(&e, s)| match (s.a, s.b) {
+            .filter_map(|(&e, cs)| match (cs.a, cs.b) {
                 (Some(v), None) => Some((e, v)),
                 _ => None,
             })
@@ -844,8 +848,8 @@ impl WorldModel {
             .collect();
         let want: HashMap<Entity, (Option<i32>, Option<i32>)> = model
             .iter()
-            .filter(|(_, s)| s.a.is_some() || s.b.is_some())
-            .map(|(&e, s)| (e, (s.a, s.b)))
+            .filter(|(_, cs)| cs.a.is_some() || cs.b.is_some())
+            .map(|(&e, cs)| (e, (cs.a, cs.b)))
             .collect();
         assert_eq!(or, want, "query::<Or<&A, &B>>");
 
@@ -856,7 +860,7 @@ impl WorldModel {
             .collect();
         let want: HashMap<Entity, Option<i32>> = model
             .iter()
-            .filter_map(|(&e, s)| s.a.map(|_| (e, s.b)))
+            .filter_map(|(&e, cs)| cs.a.map(|_| (e, cs.b)))
             .collect();
         assert_eq!(opt, want, "query::<(&A, Option<&B>)>");
     }
@@ -865,12 +869,12 @@ impl WorldModel {
     /// including the `Unsatisfied` and `NoSuchEntity` distinction.
     #[invariant]
     fn per_entity_access_matches_model(&self, _: TestCase) {
-        for (&e, s) in &self.model {
+        for (&e, cs) in &self.model {
             match self.world.query_one::<&A>(e).get() {
-                Ok(a) => assert_eq!(Some(a.0), s.a, "query_one::<&A> value for {e:?}"),
+                Ok(a) => assert_eq!(Some(a.0), cs.a, "query_one::<&A> value for {e:?}"),
                 Err(QueryOneError::Unsatisfied) => {
                     assert!(
-                        s.a.is_none(),
+                        cs.a.is_none(),
                         "query_one::<&A> unsatisfied but A modelled for {e:?}"
                     )
                 }
@@ -879,10 +883,14 @@ impl WorldModel {
             // `with`/`without` filter the same query by another component's
             // presence without borrowing it.
             match self.world.query_one::<&A>(e).with::<&B>().get() {
-                Ok(a) => assert_eq!((Some(a.0), true), (s.a, s.b.is_some()), "with::<&B> {e:?}"),
+                Ok(a) => assert_eq!(
+                    (Some(a.0), true),
+                    (cs.a, cs.b.is_some()),
+                    "with::<&B> {e:?}"
+                ),
                 Err(QueryOneError::Unsatisfied) => {
                     assert!(
-                        s.a.is_none() || s.b.is_none(),
+                        cs.a.is_none() || cs.b.is_none(),
                         "with::<&B> unsatisfied for {e:?}"
                     )
                 }
@@ -891,12 +899,12 @@ impl WorldModel {
             match self.world.query_one::<&A>(e).without::<&B>().get() {
                 Ok(a) => assert_eq!(
                     (Some(a.0), false),
-                    (s.a, s.b.is_some()),
+                    (cs.a, cs.b.is_some()),
                     "without::<&B> {e:?}"
                 ),
                 Err(QueryOneError::Unsatisfied) => {
                     assert!(
-                        s.a.is_none() || s.b.is_some(),
+                        cs.a.is_none() || cs.b.is_some(),
                         "without::<&B> unsatisfied for {e:?}"
                     )
                 }
@@ -904,36 +912,36 @@ impl WorldModel {
             }
             assert_eq!(
                 self.world.satisfies::<&A>(e),
-                s.a.is_some(),
+                cs.a.is_some(),
                 "satisfies::<&A> {e:?}"
             );
             assert_eq!(
                 self.world.satisfies::<(&A, &B)>(e),
-                s.a.is_some() && s.b.is_some(),
+                cs.a.is_some() && cs.b.is_some(),
                 "satisfies::<(&A,&B)> {e:?}"
             );
 
             let eref = self.world.entity(e).expect("live modelled entity");
             assert_eq!(eref.entity(), e, "EntityRef::entity");
-            assert_eq!(eref.has::<A>(), s.a.is_some(), "EntityRef::has::<A> {e:?}");
-            assert_eq!(eref.has::<C>(), s.c, "EntityRef::has::<C> {e:?}");
-            assert_eq!(eref.len(), s.component_count(), "EntityRef::len {e:?}");
+            assert_eq!(eref.has::<A>(), cs.a.is_some(), "EntityRef::has::<A> {e:?}");
+            assert_eq!(eref.has::<C>(), cs.c, "EntityRef::has::<C> {e:?}");
+            assert_eq!(eref.len(), cs.component_count(), "EntityRef::len {e:?}");
             assert_eq!(
                 eref.is_empty(),
-                s.component_count() == 0,
+                cs.component_count() == 0,
                 "EntityRef::is_empty {e:?}"
             );
             assert_eq!(
                 eref.component_types().count(),
-                s.component_count(),
+                cs.component_count(),
                 "EntityRef::component_types {e:?}"
             );
         }
 
         let view = self.world.view::<&A>();
-        for (&e, s) in &self.model {
-            assert_eq!(view.get(e).map(|a| a.0), s.a, "view.get {e:?}");
-            assert_eq!(view.contains(e), s.a.is_some(), "view.contains {e:?}");
+        for (&e, cs) in &self.model {
+            assert_eq!(view.get(e).map(|a| a.0), cs.a, "view.get {e:?}");
+            assert_eq!(view.contains(e), cs.a.is_some(), "view.contains {e:?}");
         }
     }
 

--- a/tests/world_relations.rs
+++ b/tests/world_relations.rs
@@ -6,9 +6,7 @@
 //! observational fingerprint. `D` is drop-tracked throughout, so a relation
 //! that holds observationally but leaks a component still fails.
 
-mod common;
-
-use common::*;
+use fixtures::*;
 use hecs::{Entity, World};
 use hegel::generators as gs;
 

--- a/tests/world_relations.rs
+++ b/tests/world_relations.rs
@@ -24,14 +24,10 @@ fn operations_on_distinct_entities_commute(tc: hegel::TestCase) {
     let x = tc.draw(ops());
     let y = tc.draw(ops());
 
-    let (rx0, ry0, rx1, ry1);
-    {
-        let (first, second) = worlds.split_at_mut(1);
-        rx0 = apply(&mut first[0], e1, x, &ds);
-        ry0 = apply(&mut first[0], e2, y, &ds);
-        ry1 = apply(&mut second[0], e2, y, &ds);
-        rx1 = apply(&mut second[0], e1, x, &ds);
-    }
+    let rx0 = apply(&mut worlds[0], e1, x, &ds);
+    let ry0 = apply(&mut worlds[0], e2, y, &ds);
+    let ry1 = apply(&mut worlds[1], e2, y, &ds);
+    let rx1 = apply(&mut worlds[1], e1, x, &ds);
     assert_eq!(
         rx0, rx1,
         "result of {x:?} on {e1:?} depended on the order of {y:?} on {e2:?}"

--- a/tests/world_relations.rs
+++ b/tests/world_relations.rs
@@ -16,7 +16,7 @@ use hegel::generators as gs;
 enum Op {
     InsertOne(u8, i32),
     RemoveOne(u8),
-    InsertBundle(Spec),
+    InsertBundle(Components),
     RemoveAB,
     RemoveCD,
     Despawn,
@@ -34,7 +34,7 @@ fn ops(tc: &hegel::TestCase) -> Op {
     tc.draw(hegel::one_of!(
         hegel::compose!(|tc| { Op::InsertOne(tc.draw(which()), tc.draw(val())) }),
         hegel::compose!(|tc| { Op::RemoveOne(tc.draw(which())) }),
-        hegel::compose!(|tc| { Op::InsertBundle(tc.draw(specs())) }),
+        hegel::compose!(|tc| { Op::InsertBundle(tc.draw(components())) }),
         gs::just(Op::RemoveAB),
         gs::just(Op::RemoveCD),
         gs::just(Op::Despawn),
@@ -60,7 +60,7 @@ fn apply(world: &mut World, e: Entity, op: Op) -> bool {
             2 => world.remove_one::<C>(e).is_ok(),
             _ => world.remove_one::<D>(e).is_ok(),
         },
-        Op::InsertBundle(s) => world.insert(e, make_builder(s).build()).is_ok(),
+        Op::InsertBundle(cs) => world.insert(e, cs.builder().build()).is_ok(),
         Op::RemoveAB => world.remove::<(A, B)>(e).is_ok(),
         Op::RemoveCD => world.remove::<(C, D)>(e).is_ok(),
         Op::Despawn => world.despawn(e).is_ok(),
@@ -85,8 +85,8 @@ fn operations_on_distinct_entities_commute(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
     let history = tc.draw(histories(1, MAX_ENTITIES));
     let (mut worlds, pool) = build_twins(&history, 2);
-    let e1 = tc.draw(pick(&pool));
-    let e2 = tc.draw(pick(&pool));
+    let e1 = tc.draw(handle_from(&pool));
+    let e2 = tc.draw(handle_from(&pool));
     tc.assume(e1 != e2);
     let x = tc.draw(ops());
     let y = tc.draw(ops());
@@ -131,7 +131,7 @@ fn insert_then_remove_leaves_the_component_absent(tc: hegel::TestCase) {
     let history = tc.draw(histories(1, MAX_ENTITIES));
     let (mut worlds, pool) = build_twins(&history, 1);
     let world = &mut worlds[0];
-    let e = tc.draw(pick(&pool));
+    let e = tc.draw(handle_from(&pool));
     let before = fingerprint(world);
     let live = before.contains_key(&e);
     let v = tc.draw(val());
@@ -204,7 +204,7 @@ fn exchange_roundtrip_restores_the_world(tc: hegel::TestCase) {
     let history = tc.draw(histories(1, MAX_ENTITIES));
     let (mut worlds, pool) = build_twins(&history, 1);
     let world = &mut worlds[0];
-    let e = tc.draw(pick(&pool));
+    let e = tc.draw(handle_from(&pool));
     let before = fingerprint(world);
     let had_a = before.get(&e).and_then(|o| o.a);
     let x = tc.draw(val());
@@ -309,9 +309,9 @@ fn cleared_world_behaves_like_a_fresh_one(tc: hegel::TestCase) {
         let kind = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
         match kind {
             0 | 1 => {
-                let s = tc.draw(specs());
-                let in_cleared = cleared.spawn(make_builder(s).build());
-                let in_fresh = fresh.spawn(make_builder(s).build());
+                let cs = tc.draw(components());
+                let in_cleared = cleared.spawn(cs.builder().build());
+                let in_fresh = fresh.spawn(cs.builder().build());
                 assert_eq!(
                     in_cleared, in_fresh,
                     "cleared world allocated a different handle"
@@ -320,7 +320,7 @@ fn cleared_world_behaves_like_a_fresh_one(tc: hegel::TestCase) {
             }
             2 => {
                 if !pool.is_empty() {
-                    let e = tc.draw(pick(&pool));
+                    let e = tc.draw(handle_from(&pool));
                     assert_eq!(
                         cleared.despawn(e).is_ok(),
                         fresh.despawn(e).is_ok(),
@@ -330,7 +330,7 @@ fn cleared_world_behaves_like_a_fresh_one(tc: hegel::TestCase) {
             }
             _ => {
                 if !pool.is_empty() {
-                    let e = tc.draw(pick(&pool));
+                    let e = tc.draw(handle_from(&pool));
                     let v = tc.draw(val());
                     assert_eq!(
                         cleared.insert_one(e, A(v)).is_ok(),
@@ -356,7 +356,7 @@ fn insert_order_on_one_entity_is_unobservable(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
     let history = tc.draw(histories(1, MAX_ENTITIES));
     let (mut worlds, pool) = build_twins(&history, 2);
-    let e = tc.draw(pick(&pool));
+    let e = tc.draw(handle_from(&pool));
     let c1 = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
     let c2 = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
     tc.assume(c1 != c2);
@@ -426,7 +426,7 @@ fn replaying_a_saved_freelist_reproduces_allocation(tc: hegel::TestCase) {
             );
             pool.push(in_source);
         } else if !pool.is_empty() {
-            let e = tc.draw(pick(&pool));
+            let e = tc.draw(handle_from(&pool));
             assert_eq!(
                 source.despawn(e).is_ok(),
                 replica.despawn(e).is_ok(),

--- a/tests/world_relations.rs
+++ b/tests/world_relations.rs
@@ -129,10 +129,9 @@ fn operations_on_distinct_entities_commute(tc: hegel::TestCase) {
 fn insert_then_remove_leaves_the_component_absent(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
     let history = tc.draw(histories(1, MAX_ENTITIES));
-    let (mut worlds, pool) = build_twins(&history, 1);
-    let world = &mut worlds[0];
+    let (mut world, pool) = build_world_with_handles(&history);
     let e = tc.draw(handle_from(&pool));
-    let before = fingerprint(world);
+    let before = fingerprint(&world);
     let live = before.contains_key(&e);
     let v = tc.draw(val());
     let which = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
@@ -183,13 +182,13 @@ fn insert_then_remove_leaves_the_component_absent(tc: hegel::TestCase) {
         }
     }
     assert_eq!(
-        fingerprint(world),
+        fingerprint(&world),
         expected,
         "insert then remove left a residue on {e:?}"
     );
     assert_eq!(
         d_live(),
-        total_d(&worlds),
+        d_in(&world),
         "drop imbalance after insert then remove"
     );
 }
@@ -202,10 +201,9 @@ fn insert_then_remove_leaves_the_component_absent(tc: hegel::TestCase) {
 fn exchange_roundtrip_restores_the_world(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
     let history = tc.draw(histories(1, MAX_ENTITIES));
-    let (mut worlds, pool) = build_twins(&history, 1);
-    let world = &mut worlds[0];
+    let (mut world, pool) = build_world_with_handles(&history);
     let e = tc.draw(handle_from(&pool));
-    let before = fingerprint(world);
+    let before = fingerprint(&world);
     let had_a = before.get(&e).and_then(|o| o.a);
     let x = tc.draw(val());
 
@@ -223,7 +221,7 @@ fn exchange_roundtrip_restores_the_world(tc: hegel::TestCase) {
             let mut expected = before;
             expected.get_mut(&e).unwrap().b = None;
             assert_eq!(
-                fingerprint(world),
+                fingerprint(&world),
                 expected,
                 "exchange roundtrip residue on {e:?}"
             );
@@ -234,7 +232,7 @@ fn exchange_roundtrip_restores_the_world(tc: hegel::TestCase) {
                 "exchange_one::<A, B> failed but {e:?} has an A"
             );
             assert_eq!(
-                fingerprint(world),
+                fingerprint(&world),
                 before,
                 "a failed exchange mutated the world"
             );
@@ -242,7 +240,7 @@ fn exchange_roundtrip_restores_the_world(tc: hegel::TestCase) {
     }
     assert_eq!(
         d_live(),
-        total_d(&worlds),
+        d_in(&world),
         "drop imbalance after exchange roundtrip"
     );
 }

--- a/tests/world_relations.rs
+++ b/tests/world_relations.rs
@@ -85,9 +85,10 @@ fn apply(world: &mut World, e: Entity, op: Op) -> bool {
 #[hegel::test(settings())]
 fn operations_on_distinct_entities_commute(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let (mut worlds, pool) = build_twins(&tc, 2, MAX_ENTITIES);
-    let Some(e1) = pick(&tc, &pool) else { return };
-    let e2 = pick(&tc, &pool).unwrap();
+    let history = tc.draw(histories(1, MAX_ENTITIES));
+    let (mut worlds, pool) = build_twins(&history, 2);
+    let e1 = tc.draw(pick(&pool));
+    let e2 = tc.draw(pick(&pool));
     tc.assume(e1 != e2);
     let x = tc.draw(ops());
     let y = tc.draw(ops());
@@ -129,9 +130,10 @@ fn operations_on_distinct_entities_commute(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn insert_then_remove_leaves_the_component_absent(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let (mut worlds, pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let history = tc.draw(histories(1, MAX_ENTITIES));
+    let (mut worlds, pool) = build_twins(&history, 1);
     let world = &mut worlds[0];
-    let Some(e) = pick(&tc, &pool) else { return };
+    let e = tc.draw(pick(&pool));
     let before = fingerprint(world);
     let live = before.contains_key(&e);
     let v = tc.draw(val());
@@ -201,9 +203,10 @@ fn insert_then_remove_leaves_the_component_absent(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn exchange_roundtrip_restores_the_world(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let (mut worlds, pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let history = tc.draw(histories(1, MAX_ENTITIES));
+    let (mut worlds, pool) = build_twins(&history, 1);
     let world = &mut worlds[0];
-    let Some(e) = pick(&tc, &pool) else { return };
+    let e = tc.draw(pick(&pool));
     let before = fingerprint(world);
     let had_a = before.get(&e).and_then(|o| o.a);
     let x = tc.draw(val());
@@ -253,9 +256,10 @@ fn exchange_roundtrip_restores_the_world(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn spawn_batch_matches_individual_spawns(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let (mut worlds, _pool) = build_twins(&tc, 2, MAX_ENTITIES);
-    let n = tc.draw(gs::integers::<usize>().min_value(0).max_value(5));
-    let rows: Vec<(i32, i32)> = (0..n).map(|_| (tc.draw(val()), tc.draw(val()))).collect();
+    let history = tc.draw(histories(0, MAX_ENTITIES));
+    let (mut worlds, _pool) = build_twins(&history, 2);
+    let rows: Vec<(i32, i32)> = tc.draw(gs::vecs(hegel::tuples!(val(), val())).max_size(5));
+    let n = rows.len();
     let consumed = tc.draw(gs::integers::<usize>().min_value(0).max_value(n));
 
     let batched: Vec<Entity> = {
@@ -290,8 +294,8 @@ fn spawn_batch_matches_individual_spawns(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn cleared_world_behaves_like_a_fresh_one(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let (mut worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
-    let mut cleared = worlds.pop().unwrap();
+    let history = tc.draw(histories(0, MAX_ENTITIES));
+    let mut cleared = build_world(&history);
     cleared.clear();
     assert_eq!(cleared.len(), 0, "clear left live entities");
     assert_eq!(d_live(), 0, "clear did not drop every component");
@@ -304,7 +308,8 @@ fn cleared_world_behaves_like_a_fresh_one(tc: hegel::TestCase) {
             .max_value(MAX_ENTITIES * 2),
     );
     for _ in 0..steps {
-        match tc.draw(gs::integers::<u8>().min_value(0).max_value(3)) {
+        let kind = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
+        match kind {
             0 | 1 => {
                 let s = tc.draw(specs());
                 let in_cleared = cleared.spawn(make_builder(s).build());
@@ -316,7 +321,8 @@ fn cleared_world_behaves_like_a_fresh_one(tc: hegel::TestCase) {
                 pool.push(in_cleared);
             }
             2 => {
-                if let Some(e) = pick(&tc, &pool) {
+                if !pool.is_empty() {
+                    let e = tc.draw(pick(&pool));
                     assert_eq!(
                         cleared.despawn(e).is_ok(),
                         fresh.despawn(e).is_ok(),
@@ -325,7 +331,8 @@ fn cleared_world_behaves_like_a_fresh_one(tc: hegel::TestCase) {
                 }
             }
             _ => {
-                if let Some(e) = pick(&tc, &pool) {
+                if !pool.is_empty() {
+                    let e = tc.draw(pick(&pool));
                     let v = tc.draw(val());
                     assert_eq!(
                         cleared.insert_one(e, A(v)).is_ok(),
@@ -349,13 +356,14 @@ fn cleared_world_behaves_like_a_fresh_one(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn insert_order_on_one_entity_is_unobservable(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let (mut worlds, pool) = build_twins(&tc, 2, MAX_ENTITIES);
-    let Some(e) = pick(&tc, &pool) else { return };
-    let which = gs::integers::<u8>().min_value(0).max_value(3);
-    let c1 = tc.draw(which);
+    let history = tc.draw(histories(1, MAX_ENTITIES));
+    let (mut worlds, pool) = build_twins(&history, 2);
+    let e = tc.draw(pick(&pool));
+    let c1 = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
     let c2 = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
     tc.assume(c1 != c2);
-    let (v1, v2) = (tc.draw(val()), tc.draw(val()));
+    let v1 = tc.draw(val());
+    let v2 = tc.draw(val());
 
     let insert = |w: &mut World, which: u8, v: i32| apply(w, e, Op::InsertOne(which, v));
     let first1 = insert(&mut worlds[0], c1, v1);
@@ -389,8 +397,8 @@ fn insert_order_on_one_entity_is_unobservable(tc: hegel::TestCase) {
 #[hegel::test(settings())]
 fn replaying_a_saved_freelist_reproduces_allocation(tc: hegel::TestCase) {
     assert_d_balanced_at_start();
-    let (mut worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
-    let mut source = worlds.pop().unwrap();
+    let history = tc.draw(histories(0, MAX_ENTITIES));
+    let mut source = build_world(&history);
 
     let mut replica = World::new();
     for eref in source.iter() {
@@ -410,7 +418,8 @@ fn replaying_a_saved_freelist_reproduces_allocation(tc: hegel::TestCase) {
             .max_value(MAX_ENTITIES * 2),
     );
     for _ in 0..steps {
-        if tc.draw(gs::weighted_booleans(0.7)) {
+        let spawn = tc.draw(gs::weighted_booleans(0.7));
+        if spawn {
             let in_source = source.spawn(());
             let in_replica = replica.spawn(());
             assert_eq!(
@@ -418,7 +427,8 @@ fn replaying_a_saved_freelist_reproduces_allocation(tc: hegel::TestCase) {
                 "replica allocated a different handle"
             );
             pool.push(in_source);
-        } else if let Some(e) = pick(&tc, &pool) {
+        } else if !pool.is_empty() {
+            let e = tc.draw(pick(&pool));
             assert_eq!(
                 source.despawn(e).is_ok(),
                 replica.despawn(e).is_ok(),

--- a/tests/world_relations.rs
+++ b/tests/world_relations.rs
@@ -14,8 +14,8 @@ use hegel::generators as gs;
 /// order is observable through the handles they return, so they do not commute.
 #[derive(Clone, Copy, Debug, hegel::PrettyPrintable)]
 enum Op {
-    InsertOne(u8, i32),
-    RemoveOne(u8),
+    InsertOne(Kind, i32),
+    RemoveOne(Kind),
     InsertBundle(Components),
     RemoveAB,
     RemoveCD,
@@ -28,12 +28,9 @@ enum Op {
 
 #[hegel::composite]
 fn ops(tc: &hegel::TestCase) -> Op {
-    fn which() -> impl hegel::generators::PrintableGenerator<u8> {
-        gs::integers::<u8>().min_value(0).max_value(3)
-    }
     tc.draw(hegel::one_of!(
-        hegel::compose!(|tc| { Op::InsertOne(tc.draw(which()), tc.draw(val())) }),
-        hegel::compose!(|tc| { Op::RemoveOne(tc.draw(which())) }),
+        hegel::compose!(|tc| { Op::InsertOne(tc.draw(kinds()), tc.draw(val())) }),
+        hegel::compose!(|tc| { Op::RemoveOne(tc.draw(kinds())) }),
         hegel::compose!(|tc| { Op::InsertBundle(tc.draw(components())) }),
         gs::just(Op::RemoveAB),
         gs::just(Op::RemoveCD),
@@ -48,18 +45,8 @@ fn ops(tc: &hegel::TestCase) -> Op {
 /// Apply `op` to `e` and report whether it succeeded.
 fn apply(world: &mut World, e: Entity, op: Op, ds: &DropTracker) -> bool {
     match op {
-        Op::InsertOne(which, v) => match which {
-            0 => world.insert_one(e, A(v)).is_ok(),
-            1 => world.insert_one(e, B(v)).is_ok(),
-            2 => world.insert_one(e, C).is_ok(),
-            _ => world.insert_one(e, D::new(v, ds)).is_ok(),
-        },
-        Op::RemoveOne(which) => match which {
-            0 => world.remove_one::<A>(e).is_ok(),
-            1 => world.remove_one::<B>(e).is_ok(),
-            2 => world.remove_one::<C>(e).is_ok(),
-            _ => world.remove_one::<D>(e).is_ok(),
-        },
+        Op::InsertOne(kind, v) => kind.insert_one(world, e, v, ds).is_ok(),
+        Op::RemoveOne(kind) => kind.remove_one(world, e).is_ok(),
         Op::InsertBundle(cs) => world.insert(e, cs.builder(ds).build()).is_ok(),
         Op::RemoveAB => world.remove::<(A, B)>(e).is_ok(),
         Op::RemoveCD => world.remove::<(C, D)>(e).is_ok(),
@@ -134,10 +121,10 @@ fn insert_then_remove_leaves_the_component_absent(tc: hegel::TestCase) {
     let before = fingerprint(&world);
     let live = before.contains_key(&e);
     let v = tc.draw(val());
-    let which = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
+    let kind = tc.draw(kinds());
 
-    let inserted = match which {
-        0 => {
+    let inserted = match kind {
+        Kind::A => {
             let ins = world.insert_one(e, A(v)).is_ok();
             assert_eq!(
                 world.remove_one::<A>(e).ok(),
@@ -146,7 +133,7 @@ fn insert_then_remove_leaves_the_component_absent(tc: hegel::TestCase) {
             );
             ins
         }
-        1 => {
+        Kind::B => {
             let ins = world.insert_one(e, B(v)).is_ok();
             assert_eq!(
                 world.remove_one::<B>(e).ok(),
@@ -155,12 +142,12 @@ fn insert_then_remove_leaves_the_component_absent(tc: hegel::TestCase) {
             );
             ins
         }
-        2 => {
+        Kind::C => {
             let ins = world.insert_one(e, C).is_ok();
             assert_eq!(world.remove_one::<C>(e).is_ok(), ins, "removed C");
             ins
         }
-        _ => {
+        Kind::D => {
             let ins = world.insert_one(e, D::new(v, &ds)).is_ok();
             let got = world.remove_one::<D>(e).ok();
             assert_eq!(got.as_ref().map(|d| d.value), ins.then_some(v), "removed D");
@@ -174,12 +161,7 @@ fn insert_then_remove_leaves_the_component_absent(tc: hegel::TestCase) {
 
     let mut expected = before;
     if let Some(obs) = expected.get_mut(&e) {
-        match which {
-            0 => obs.a = None,
-            1 => obs.b = None,
-            2 => obs.c = false,
-            _ => obs.d = None,
-        }
+        *obs = obs.without(kind);
     }
     assert_eq!(
         fingerprint(&world),
@@ -355,29 +337,29 @@ fn insert_order_on_one_entity_is_unobservable(tc: hegel::TestCase) {
     let history = tc.draw(histories(1, MAX_ENTITIES));
     let (mut worlds, pool) = build_twins(&history, 2, &ds);
     let e = tc.draw(handle_from(&pool));
-    let c1 = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
-    let c2 = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
+    let c1 = tc.draw(kinds());
+    let c2 = tc.draw(kinds());
     tc.assume(c1 != c2);
     let v1 = tc.draw(val());
     let v2 = tc.draw(val());
 
-    let insert = |w: &mut World, which: u8, v: i32| apply(w, e, Op::InsertOne(which, v), &ds);
+    let insert = |w: &mut World, k: Kind, v: i32| k.insert_one(w, e, v, &ds).is_ok();
     let first1 = insert(&mut worlds[0], c1, v1);
     let first2 = insert(&mut worlds[0], c2, v2);
     let second2 = insert(&mut worlds[1], c2, v2);
     let second1 = insert(&mut worlds[1], c1, v1);
     assert_eq!(
         first1, second1,
-        "insert of component {c1} was order-dependent on {e:?}"
+        "insert of {c1:?} was order-dependent on {e:?}"
     );
     assert_eq!(
         first2, second2,
-        "insert of component {c2} was order-dependent on {e:?}"
+        "insert of {c2:?} was order-dependent on {e:?}"
     );
     assert_eq!(
         fingerprint(&worlds[0]),
         fingerprint(&worlds[1]),
-        "insert order of components {c1} and {c2} was observable on {e:?}"
+        "insert order of {c1:?} and {c2:?} was observable on {e:?}"
     );
     assert_eq!(
         ds.live(),

--- a/tests/world_relations.rs
+++ b/tests/world_relations.rs
@@ -207,6 +207,26 @@ fn spawn_batch_matches_individual_spawns(tc: hegel::TestCase) {
     check_archetypes(&worlds[0], "batch");
 }
 
+/// One step run against both the cleared and the fresh world.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, hegel::PrettyPrintable)]
+enum Probe {
+    Spawn(Components),
+    Despawn,
+    InsertA(i32),
+}
+
+/// Half the probes spawn, so the other half soon have entities to act on.
+#[hegel::composite]
+fn probes(tc: &hegel::TestCase) -> Probe {
+    if tc.draw(gs::booleans()) {
+        return Probe::Spawn(tc.draw(components()));
+    }
+    tc.draw(hegel::one_of!(
+        gs::just(Probe::Despawn),
+        hegel::compose!(|tc| { Probe::InsertA(tc.draw(val())) }),
+    ))
+}
+
 /// After `clear`, a world is indistinguishable from `World::new()` under any
 /// subsequent operations — including handing out the same `Entity` values,
 /// which `clear` documents ("clears metadata so that `Entity` values will
@@ -228,10 +248,9 @@ fn cleared_world_behaves_like_a_fresh_one(tc: hegel::TestCase) {
             .max_value(MAX_ENTITIES * 2),
     );
     for _ in 0..steps {
-        let kind = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
-        match kind {
-            0 | 1 => {
-                let cs = tc.draw(components());
+        let probe = tc.draw(probes());
+        match probe {
+            Probe::Spawn(cs) => {
                 let in_cleared = cleared.spawn(cs.builder(&ds).build());
                 let in_fresh = fresh.spawn(cs.builder(&ds).build());
                 assert_eq!(
@@ -240,27 +259,23 @@ fn cleared_world_behaves_like_a_fresh_one(tc: hegel::TestCase) {
                 );
                 pool.push(in_cleared);
             }
-            2 => {
-                if !pool.is_empty() {
-                    let e = tc.draw(handle_from(&pool));
-                    assert_eq!(
-                        cleared.despawn(e).is_ok(),
-                        fresh.despawn(e).is_ok(),
-                        "despawn of {e:?} disagreed"
-                    );
-                }
+            Probe::Despawn if !pool.is_empty() => {
+                let e = tc.draw(handle_from(&pool));
+                assert_eq!(
+                    cleared.despawn(e).is_ok(),
+                    fresh.despawn(e).is_ok(),
+                    "despawn of {e:?} disagreed"
+                );
             }
-            _ => {
-                if !pool.is_empty() {
-                    let e = tc.draw(handle_from(&pool));
-                    let v = tc.draw(val());
-                    assert_eq!(
-                        cleared.insert_one(e, A(v)).is_ok(),
-                        fresh.insert_one(e, A(v)).is_ok(),
-                        "insert_one on {e:?} disagreed"
-                    );
-                }
+            Probe::InsertA(v) if !pool.is_empty() => {
+                let e = tc.draw(handle_from(&pool));
+                assert_eq!(
+                    cleared.insert_one(e, A(v)).is_ok(),
+                    fresh.insert_one(e, A(v)).is_ok(),
+                    "insert_one on {e:?} disagreed"
+                );
             }
+            Probe::Despawn | Probe::InsertA(_) => {}
         }
         assert_eq!(
             fingerprint(&cleared),

--- a/tests/world_relations.rs
+++ b/tests/world_relations.rs
@@ -14,7 +14,7 @@ use hegel::generators as gs;
 
 /// A single-entity operation. Spawning operations are excluded: allocation
 /// order is observable through the handles they return, so they do not commute.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, hegel::PrettyPrintable)]
 enum Op {
     InsertOne(u8, i32),
     RemoveOne(u8),
@@ -27,8 +27,6 @@ enum Op {
     ExchangeAToB(i32),
     ExchangeDToA(i32),
 }
-
-hegel::pretty_print_as_debug!(Op);
 
 #[hegel::composite]
 fn ops(tc: &hegel::TestCase) -> Op {

--- a/tests/world_relations.rs
+++ b/tests/world_relations.rs
@@ -46,13 +46,13 @@ fn ops(tc: &hegel::TestCase) -> Op {
 }
 
 /// Apply `op` to `e` and report whether it succeeded.
-fn apply(world: &mut World, e: Entity, op: Op) -> bool {
+fn apply(world: &mut World, e: Entity, op: Op, ds: &DropTracker) -> bool {
     match op {
         Op::InsertOne(which, v) => match which {
             0 => world.insert_one(e, A(v)).is_ok(),
             1 => world.insert_one(e, B(v)).is_ok(),
             2 => world.insert_one(e, C).is_ok(),
-            _ => world.insert_one(e, D::new(v)).is_ok(),
+            _ => world.insert_one(e, D::new(v, ds)).is_ok(),
         },
         Op::RemoveOne(which) => match which {
             0 => world.remove_one::<A>(e).is_ok(),
@@ -60,7 +60,7 @@ fn apply(world: &mut World, e: Entity, op: Op) -> bool {
             2 => world.remove_one::<C>(e).is_ok(),
             _ => world.remove_one::<D>(e).is_ok(),
         },
-        Op::InsertBundle(cs) => world.insert(e, cs.builder().build()).is_ok(),
+        Op::InsertBundle(cs) => world.insert(e, cs.builder(ds).build()).is_ok(),
         Op::RemoveAB => world.remove::<(A, B)>(e).is_ok(),
         Op::RemoveCD => world.remove::<(C, D)>(e).is_ok(),
         Op::Despawn => world.despawn(e).is_ok(),
@@ -82,9 +82,9 @@ fn apply(world: &mut World, e: Entity, op: Op) -> bool {
 /// of hecs storing each entity's components independently of every other's.
 #[hegel::test(settings())]
 fn operations_on_distinct_entities_commute(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(1, MAX_ENTITIES));
-    let (mut worlds, pool) = build_twins(&history, 2);
+    let (mut worlds, pool) = build_twins(&history, 2, &ds);
     let e1 = tc.draw(handle_from(&pool));
     let e2 = tc.draw(handle_from(&pool));
     tc.assume(e1 != e2);
@@ -94,10 +94,10 @@ fn operations_on_distinct_entities_commute(tc: hegel::TestCase) {
     let (rx0, ry0, rx1, ry1);
     {
         let (first, second) = worlds.split_at_mut(1);
-        rx0 = apply(&mut first[0], e1, x);
-        ry0 = apply(&mut first[0], e2, y);
-        ry1 = apply(&mut second[0], e2, y);
-        rx1 = apply(&mut second[0], e1, x);
+        rx0 = apply(&mut first[0], e1, x, &ds);
+        ry0 = apply(&mut first[0], e2, y, &ds);
+        ry1 = apply(&mut second[0], e2, y, &ds);
+        rx1 = apply(&mut second[0], e1, x, &ds);
     }
     assert_eq!(
         rx0, rx1,
@@ -113,7 +113,7 @@ fn operations_on_distinct_entities_commute(tc: hegel::TestCase) {
         "[{x:?} on {e1:?}; {y:?} on {e2:?}] and the reverse order left different worlds"
     );
     assert_eq!(
-        d_live(),
+        ds.live(),
         total_d(&worlds),
         "drop imbalance after commuting operations"
     );
@@ -127,9 +127,9 @@ fn operations_on_distinct_entities_commute(tc: hegel::TestCase) {
 /// replaced", which is what makes the residue exactly "T absent".
 #[hegel::test(settings())]
 fn insert_then_remove_leaves_the_component_absent(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(1, MAX_ENTITIES));
-    let (mut world, pool) = build_world_with_handles(&history);
+    let (mut world, pool) = build_world_with_handles(&history, &ds);
     let e = tc.draw(handle_from(&pool));
     let before = fingerprint(&world);
     let live = before.contains_key(&e);
@@ -161,9 +161,9 @@ fn insert_then_remove_leaves_the_component_absent(tc: hegel::TestCase) {
             ins
         }
         _ => {
-            let ins = world.insert_one(e, D::new(v)).is_ok();
+            let ins = world.insert_one(e, D::new(v, &ds)).is_ok();
             let got = world.remove_one::<D>(e).ok();
-            assert_eq!(got.as_ref().map(|d| d.0), ins.then_some(v), "removed D");
+            assert_eq!(got.as_ref().map(|d| d.value), ins.then_some(v), "removed D");
             ins
         }
     };
@@ -187,7 +187,7 @@ fn insert_then_remove_leaves_the_component_absent(tc: hegel::TestCase) {
         "insert then remove left a residue on {e:?}"
     );
     assert_eq!(
-        d_live(),
+        ds.live(),
         d_in(&world),
         "drop imbalance after insert then remove"
     );
@@ -199,9 +199,9 @@ fn insert_then_remove_leaves_the_component_absent(tc: hegel::TestCase) {
 /// second.
 #[hegel::test(settings())]
 fn exchange_roundtrip_restores_the_world(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(1, MAX_ENTITIES));
-    let (mut world, pool) = build_world_with_handles(&history);
+    let (mut world, pool) = build_world_with_handles(&history, &ds);
     let e = tc.draw(handle_from(&pool));
     let before = fingerprint(&world);
     let had_a = before.get(&e).and_then(|o| o.a);
@@ -239,7 +239,7 @@ fn exchange_roundtrip_restores_the_world(tc: hegel::TestCase) {
         }
     }
     assert_eq!(
-        d_live(),
+        ds.live(),
         d_in(&world),
         "drop imbalance after exchange roundtrip"
     );
@@ -251,9 +251,9 @@ fn exchange_roundtrip_restores_the_world(tc: hegel::TestCase) {
 /// it.
 #[hegel::test(settings())]
 fn spawn_batch_matches_individual_spawns(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let (mut worlds, _pool) = build_twins(&history, 2);
+    let (mut worlds, _pool) = build_twins(&history, 2, &ds);
     let rows: Vec<(i32, i32)> = tc.draw(gs::vecs(hegel::tuples!(val(), val())).max_size(5));
     let n = rows.len();
     let consumed = tc.draw(gs::integers::<usize>().min_value(0).max_value(n));
@@ -289,12 +289,12 @@ fn spawn_batch_matches_individual_spawns(tc: hegel::TestCase) {
 /// repeat").
 #[hegel::test(settings())]
 fn cleared_world_behaves_like_a_fresh_one(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let mut cleared = build_world(&history);
+    let mut cleared = build_world(&history, &ds);
     cleared.clear();
     assert_eq!(cleared.len(), 0, "clear left live entities");
-    assert_eq!(d_live(), 0, "clear did not drop every component");
+    assert_eq!(ds.live(), 0, "clear did not drop every component");
 
     let mut fresh = World::new();
     let mut pool: Vec<Entity> = Vec::new();
@@ -308,8 +308,8 @@ fn cleared_world_behaves_like_a_fresh_one(tc: hegel::TestCase) {
         match kind {
             0 | 1 => {
                 let cs = tc.draw(components());
-                let in_cleared = cleared.spawn(cs.builder().build());
-                let in_fresh = fresh.spawn(cs.builder().build());
+                let in_cleared = cleared.spawn(cs.builder(&ds).build());
+                let in_fresh = fresh.spawn(cs.builder(&ds).build());
                 assert_eq!(
                     in_cleared, in_fresh,
                     "cleared world allocated a different handle"
@@ -351,9 +351,9 @@ fn cleared_world_behaves_like_a_fresh_one(tc: hegel::TestCase) {
 /// though the two orders route through different intermediate archetypes.
 #[hegel::test(settings())]
 fn insert_order_on_one_entity_is_unobservable(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(1, MAX_ENTITIES));
-    let (mut worlds, pool) = build_twins(&history, 2);
+    let (mut worlds, pool) = build_twins(&history, 2, &ds);
     let e = tc.draw(handle_from(&pool));
     let c1 = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
     let c2 = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
@@ -361,7 +361,7 @@ fn insert_order_on_one_entity_is_unobservable(tc: hegel::TestCase) {
     let v1 = tc.draw(val());
     let v2 = tc.draw(val());
 
-    let insert = |w: &mut World, which: u8, v: i32| apply(w, e, Op::InsertOne(which, v));
+    let insert = |w: &mut World, which: u8, v: i32| apply(w, e, Op::InsertOne(which, v), &ds);
     let first1 = insert(&mut worlds[0], c1, v1);
     let first2 = insert(&mut worlds[0], c2, v2);
     let second2 = insert(&mut worlds[1], c2, v2);
@@ -380,7 +380,7 @@ fn insert_order_on_one_entity_is_unobservable(tc: hegel::TestCase) {
         "insert order of components {c1} and {c2} was observable on {e:?}"
     );
     assert_eq!(
-        d_live(),
+        ds.live(),
         total_d(&worlds),
         "drop imbalance after ordered inserts"
     );
@@ -392,9 +392,9 @@ fn insert_order_on_one_entity_is_unobservable(tc: hegel::TestCase) {
 /// generalization of the `deterministic_ids` test in src/world.rs.
 #[hegel::test(settings())]
 fn replaying_a_saved_freelist_reproduces_allocation(tc: hegel::TestCase) {
-    assert_d_balanced_at_start();
+    let ds = DropTracker::new();
     let history = tc.draw(histories(0, MAX_ENTITIES));
-    let mut source = build_world(&history);
+    let mut source = build_world(&history, &ds);
 
     let mut replica = World::new();
     for eref in source.iter() {

--- a/tests/world_relations.rs
+++ b/tests/world_relations.rs
@@ -1,0 +1,436 @@
+//! Metamorphic properties for `World`: relations between two executions that
+//! must hold by hecs's documented semantics, checked without a reference model.
+//!
+//! `World` is not `Clone`, so "two executions from the same state" is set up
+//! with twin worlds replayed from one drawn history, and compared through the
+//! observational fingerprint. `D` is drop-tracked throughout, so a relation
+//! that holds observationally but leaks a component still fails.
+
+mod common;
+
+use common::*;
+use hecs::{Entity, World};
+use hegel::generators as gs;
+
+/// A single-entity operation. Spawning operations are excluded: allocation
+/// order is observable through the handles they return, so they do not commute.
+#[derive(Clone, Copy, Debug)]
+enum Op {
+    InsertOne(u8, i32),
+    RemoveOne(u8),
+    InsertBundle(Spec),
+    RemoveAB,
+    RemoveCD,
+    Despawn,
+    Take,
+    MutateA(i32),
+    ExchangeAToB(i32),
+    ExchangeDToA(i32),
+}
+
+hegel::pretty_print_as_debug!(Op);
+
+#[hegel::composite]
+fn ops(tc: &hegel::TestCase) -> Op {
+    fn which() -> impl hegel::generators::PrintableGenerator<u8> {
+        gs::integers::<u8>().min_value(0).max_value(3)
+    }
+    tc.draw(hegel::one_of!(
+        hegel::compose!(|tc| { Op::InsertOne(tc.draw(which()), tc.draw(val())) }),
+        hegel::compose!(|tc| { Op::RemoveOne(tc.draw(which())) }),
+        hegel::compose!(|tc| { Op::InsertBundle(tc.draw(specs())) }),
+        gs::just(Op::RemoveAB),
+        gs::just(Op::RemoveCD),
+        gs::just(Op::Despawn),
+        gs::just(Op::Take),
+        hegel::compose!(|tc| { Op::MutateA(tc.draw(val())) }),
+        hegel::compose!(|tc| { Op::ExchangeAToB(tc.draw(val())) }),
+        hegel::compose!(|tc| { Op::ExchangeDToA(tc.draw(val())) }),
+    ))
+}
+
+/// Apply `op` to `e` and report whether it succeeded.
+fn apply(world: &mut World, e: Entity, op: Op) -> bool {
+    match op {
+        Op::InsertOne(which, v) => match which {
+            0 => world.insert_one(e, A(v)).is_ok(),
+            1 => world.insert_one(e, B(v)).is_ok(),
+            2 => world.insert_one(e, C).is_ok(),
+            _ => world.insert_one(e, D::new(v)).is_ok(),
+        },
+        Op::RemoveOne(which) => match which {
+            0 => world.remove_one::<A>(e).is_ok(),
+            1 => world.remove_one::<B>(e).is_ok(),
+            2 => world.remove_one::<C>(e).is_ok(),
+            _ => world.remove_one::<D>(e).is_ok(),
+        },
+        Op::InsertBundle(s) => world.insert(e, make_builder(s).build()).is_ok(),
+        Op::RemoveAB => world.remove::<(A, B)>(e).is_ok(),
+        Op::RemoveCD => world.remove::<(C, D)>(e).is_ok(),
+        Op::Despawn => world.despawn(e).is_ok(),
+        Op::Take => world.take(e).is_ok(),
+        Op::MutateA(v) => match world.get::<&mut A>(e) {
+            Ok(mut a) => {
+                a.0 = v;
+                true
+            }
+            Err(_) => false,
+        },
+        Op::ExchangeAToB(v) => world.exchange_one::<A, B>(e, B(v)).is_ok(),
+        Op::ExchangeDToA(v) => world.exchange_one::<D, A>(e, A(v)).is_ok(),
+    }
+}
+
+/// Operations on two different entities commute: neither their results nor the
+/// resulting world depend on the order they run in. This is the observable form
+/// of hecs storing each entity's components independently of every other's.
+#[hegel::test(settings())]
+fn operations_on_distinct_entities_commute(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let (mut worlds, pool) = build_twins(&tc, 2, MAX_ENTITIES);
+    let Some(e1) = pick(&tc, &pool) else { return };
+    let e2 = pick(&tc, &pool).unwrap();
+    tc.assume(e1 != e2);
+    let x = tc.draw(ops());
+    let y = tc.draw(ops());
+
+    let (rx0, ry0, rx1, ry1);
+    {
+        let (first, second) = worlds.split_at_mut(1);
+        rx0 = apply(&mut first[0], e1, x);
+        ry0 = apply(&mut first[0], e2, y);
+        ry1 = apply(&mut second[0], e2, y);
+        rx1 = apply(&mut second[0], e1, x);
+    }
+    assert_eq!(
+        rx0, rx1,
+        "result of {x:?} on {e1:?} depended on the order of {y:?} on {e2:?}"
+    );
+    assert_eq!(
+        ry0, ry1,
+        "result of {y:?} on {e2:?} depended on the order of {x:?} on {e1:?}"
+    );
+    assert_eq!(
+        fingerprint(&worlds[0]),
+        fingerprint(&worlds[1]),
+        "[{x:?} on {e1:?}; {y:?} on {e2:?}] and the reverse order left different worlds"
+    );
+    assert_eq!(
+        d_live(),
+        total_d(&worlds),
+        "drop imbalance after commuting operations"
+    );
+    check_archetypes(&worlds[0], "x-then-y");
+    check_archetypes(&worlds[1], "y-then-x");
+}
+
+/// `insert_one::<T>` followed by `remove_one::<T>` leaves the world as it was
+/// except that `T` is gone from that entity, and returns the value just
+/// inserted. `insert_one` documents that an existing component "is dropped and
+/// replaced", which is what makes the residue exactly "T absent".
+#[hegel::test(settings())]
+fn insert_then_remove_leaves_the_component_absent(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let (mut worlds, pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let world = &mut worlds[0];
+    let Some(e) = pick(&tc, &pool) else { return };
+    let before = fingerprint(world);
+    let live = before.contains_key(&e);
+    let v = tc.draw(val());
+    let which = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
+
+    let inserted = match which {
+        0 => {
+            let ins = world.insert_one(e, A(v)).is_ok();
+            assert_eq!(
+                world.remove_one::<A>(e).ok(),
+                ins.then_some(A(v)),
+                "removed A"
+            );
+            ins
+        }
+        1 => {
+            let ins = world.insert_one(e, B(v)).is_ok();
+            assert_eq!(
+                world.remove_one::<B>(e).ok(),
+                ins.then_some(B(v)),
+                "removed B"
+            );
+            ins
+        }
+        2 => {
+            let ins = world.insert_one(e, C).is_ok();
+            assert_eq!(world.remove_one::<C>(e).is_ok(), ins, "removed C");
+            ins
+        }
+        _ => {
+            let ins = world.insert_one(e, D::new(v)).is_ok();
+            let got = world.remove_one::<D>(e).ok();
+            assert_eq!(got.as_ref().map(|d| d.0), ins.then_some(v), "removed D");
+            ins
+        }
+    };
+    assert_eq!(
+        inserted, live,
+        "insert_one succeeded on a dead handle {e:?}"
+    );
+
+    let mut expected = before;
+    if let Some(obs) = expected.get_mut(&e) {
+        match which {
+            0 => obs.a = None,
+            1 => obs.b = None,
+            2 => obs.c = false,
+            _ => obs.d = None,
+        }
+    }
+    assert_eq!(
+        fingerprint(world),
+        expected,
+        "insert then remove left a residue on {e:?}"
+    );
+    assert_eq!(
+        d_live(),
+        total_d(&worlds),
+        "drop imbalance after insert then remove"
+    );
+}
+
+/// `exchange_one::<A, B>` returns the old `A` and installs the new `B`, so
+/// exchanging back with the returned value restores the world — except that any
+/// pre-existing `B` was overwritten by the first exchange and then taken by the
+/// second.
+#[hegel::test(settings())]
+fn exchange_roundtrip_restores_the_world(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let (mut worlds, pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let world = &mut worlds[0];
+    let Some(e) = pick(&tc, &pool) else { return };
+    let before = fingerprint(world);
+    let had_a = before.get(&e).and_then(|o| o.a);
+    let x = tc.draw(val());
+
+    match world.exchange_one::<A, B>(e, B(x)) {
+        Ok(old_a) => {
+            assert_eq!(
+                Some(old_a.0),
+                had_a,
+                "exchange returned the wrong old A for {e:?}"
+            );
+            let back = world
+                .exchange_one::<B, A>(e, A(old_a.0))
+                .expect("B was just inserted, so the reverse exchange must succeed");
+            assert_eq!(back.0, x, "reverse exchange returned the wrong B for {e:?}");
+            let mut expected = before;
+            expected.get_mut(&e).unwrap().b = None;
+            assert_eq!(
+                fingerprint(world),
+                expected,
+                "exchange roundtrip residue on {e:?}"
+            );
+        }
+        Err(_) => {
+            assert!(
+                had_a.is_none(),
+                "exchange_one::<A, B> failed but {e:?} has an A"
+            );
+            assert_eq!(
+                fingerprint(world),
+                before,
+                "a failed exchange mutated the world"
+            );
+        }
+    }
+    assert_eq!(
+        d_live(),
+        total_d(&worlds),
+        "drop imbalance after exchange roundtrip"
+    );
+}
+
+/// `spawn_batch` is indistinguishable from spawning the same bundles one at a
+/// time, including the handles it hands out. Dropping the iterator early must
+/// still spawn the remainder: `SpawnBatchIter`'s `Drop` is documented to drain
+/// it.
+#[hegel::test(settings())]
+fn spawn_batch_matches_individual_spawns(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let (mut worlds, _pool) = build_twins(&tc, 2, MAX_ENTITIES);
+    let n = tc.draw(gs::integers::<usize>().min_value(0).max_value(5));
+    let rows: Vec<(i32, i32)> = (0..n).map(|_| (tc.draw(val()), tc.draw(val()))).collect();
+    let consumed = tc.draw(gs::integers::<usize>().min_value(0).max_value(n));
+
+    let batched: Vec<Entity> = {
+        let mut iter = worlds[0].spawn_batch(rows.iter().map(|&(a, b)| (A(a), B(b))));
+        assert_eq!(iter.len(), n, "SpawnBatchIter::len");
+        let taken: Vec<Entity> = iter.by_ref().take(consumed).collect();
+        taken
+        // dropping `iter` here spawns whatever was not consumed
+    };
+    let individually: Vec<Entity> = rows
+        .iter()
+        .map(|&(a, b)| worlds[1].spawn((A(a), B(b))))
+        .collect();
+
+    assert_eq!(
+        batched,
+        individually[..consumed],
+        "spawn_batch handed out different handles than individual spawns"
+    );
+    assert_eq!(
+        fingerprint(&worlds[0]),
+        fingerprint(&worlds[1]),
+        "spawn_batch of {n} rows with {consumed} consumed differs from individual spawns"
+    );
+    check_archetypes(&worlds[0], "batch");
+}
+
+/// After `clear`, a world is indistinguishable from `World::new()` under any
+/// subsequent operations — including handing out the same `Entity` values,
+/// which `clear` documents ("clears metadata so that `Entity` values will
+/// repeat").
+#[hegel::test(settings())]
+fn cleared_world_behaves_like_a_fresh_one(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let (mut worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let mut cleared = worlds.pop().unwrap();
+    cleared.clear();
+    assert_eq!(cleared.len(), 0, "clear left live entities");
+    assert_eq!(d_live(), 0, "clear did not drop every component");
+
+    let mut fresh = World::new();
+    let mut pool: Vec<Entity> = Vec::new();
+    let steps = tc.draw(
+        gs::integers::<u32>()
+            .min_value(0)
+            .max_value(MAX_ENTITIES * 2),
+    );
+    for _ in 0..steps {
+        match tc.draw(gs::integers::<u8>().min_value(0).max_value(3)) {
+            0 | 1 => {
+                let s = tc.draw(specs());
+                let in_cleared = cleared.spawn(make_builder(s).build());
+                let in_fresh = fresh.spawn(make_builder(s).build());
+                assert_eq!(
+                    in_cleared, in_fresh,
+                    "cleared world allocated a different handle"
+                );
+                pool.push(in_cleared);
+            }
+            2 => {
+                if let Some(e) = pick(&tc, &pool) {
+                    assert_eq!(
+                        cleared.despawn(e).is_ok(),
+                        fresh.despawn(e).is_ok(),
+                        "despawn of {e:?} disagreed"
+                    );
+                }
+            }
+            _ => {
+                if let Some(e) = pick(&tc, &pool) {
+                    let v = tc.draw(val());
+                    assert_eq!(
+                        cleared.insert_one(e, A(v)).is_ok(),
+                        fresh.insert_one(e, A(v)).is_ok(),
+                        "insert_one on {e:?} disagreed"
+                    );
+                }
+            }
+        }
+        assert_eq!(
+            fingerprint(&cleared),
+            fingerprint(&fresh),
+            "cleared world diverged from a fresh one"
+        );
+    }
+    check_archetypes(&cleared, "cleared");
+}
+
+/// Inserting two different components on one entity is order-independent, even
+/// though the two orders route through different intermediate archetypes.
+#[hegel::test(settings())]
+fn insert_order_on_one_entity_is_unobservable(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let (mut worlds, pool) = build_twins(&tc, 2, MAX_ENTITIES);
+    let Some(e) = pick(&tc, &pool) else { return };
+    let which = gs::integers::<u8>().min_value(0).max_value(3);
+    let c1 = tc.draw(which);
+    let c2 = tc.draw(gs::integers::<u8>().min_value(0).max_value(3));
+    tc.assume(c1 != c2);
+    let (v1, v2) = (tc.draw(val()), tc.draw(val()));
+
+    let insert = |w: &mut World, which: u8, v: i32| apply(w, e, Op::InsertOne(which, v));
+    let first1 = insert(&mut worlds[0], c1, v1);
+    let first2 = insert(&mut worlds[0], c2, v2);
+    let second2 = insert(&mut worlds[1], c2, v2);
+    let second1 = insert(&mut worlds[1], c1, v1);
+    assert_eq!(
+        first1, second1,
+        "insert of component {c1} was order-dependent on {e:?}"
+    );
+    assert_eq!(
+        first2, second2,
+        "insert of component {c2} was order-dependent on {e:?}"
+    );
+    assert_eq!(
+        fingerprint(&worlds[0]),
+        fingerprint(&worlds[1]),
+        "insert order of components {c1} and {c2} was observable on {e:?}"
+    );
+    assert_eq!(
+        d_live(),
+        total_d(&worlds),
+        "drop imbalance after ordered inserts"
+    );
+}
+
+/// A world reconstructed with `spawn_at` over the same live entities and then
+/// given the original's `freelist` allocates handles identically from then on.
+/// That is exactly what `World::freelist` documents it is for, and it is the
+/// generalization of the `deterministic_ids` test in src/world.rs.
+#[hegel::test(settings())]
+fn replaying_a_saved_freelist_reproduces_allocation(tc: hegel::TestCase) {
+    assert_d_balanced_at_start();
+    let (mut worlds, _pool) = build_twins(&tc, 1, MAX_ENTITIES);
+    let mut source = worlds.pop().unwrap();
+
+    let mut replica = World::new();
+    for eref in source.iter() {
+        replica.spawn_at(eref.entity(), ());
+    }
+    replica.set_freelist(&source.freelist().collect::<Vec<_>>());
+    assert_eq!(
+        replica.len(),
+        source.len(),
+        "replica has a different number of entities"
+    );
+
+    let mut pool: Vec<Entity> = Vec::new();
+    let steps = tc.draw(
+        gs::integers::<u32>()
+            .min_value(0)
+            .max_value(MAX_ENTITIES * 2),
+    );
+    for _ in 0..steps {
+        if tc.draw(gs::weighted_booleans(0.7)) {
+            let in_source = source.spawn(());
+            let in_replica = replica.spawn(());
+            assert_eq!(
+                in_source, in_replica,
+                "replica allocated a different handle"
+            );
+            pool.push(in_source);
+        } else if let Some(e) = pick(&tc, &pool) {
+            assert_eq!(
+                source.despawn(e).is_ok(),
+                replica.despawn(e).is_ok(),
+                "despawn of {e:?} disagreed between the world and its replica"
+            );
+        }
+    }
+    assert_eq!(
+        source.freelist().collect::<Vec<_>>(),
+        replica.freelist().collect::<Vec<_>>(),
+        "freelists diverged"
+    );
+}

--- a/tests/world_relations.rs
+++ b/tests/world_relations.rs
@@ -283,29 +283,33 @@ fn insert_order_on_one_entity_is_unobservable(tc: hegel::TestCase) {
     let history = tc.draw(histories(1, MAX_ENTITIES));
     let (mut worlds, pool) = build_twins(&history, 2, &ds);
     let e = tc.draw(handle_from(&pool));
-    let c1 = tc.draw(kinds());
-    let c2 = tc.draw(kinds());
-    tc.assume(c1 != c2);
+    let pair = tc.draw(
+        gs::samples(&KINDS[..])
+            .without_replacement()
+            .min_size(2)
+            .max_size(2),
+    );
+    let (k1, k2) = (pair[0], pair[1]);
     let v1 = tc.draw(val());
     let v2 = tc.draw(val());
 
     let insert = |w: &mut World, k: Kind, v: i32| k.insert_one(w, e, v, &ds).is_ok();
-    let first1 = insert(&mut worlds[0], c1, v1);
-    let first2 = insert(&mut worlds[0], c2, v2);
-    let second2 = insert(&mut worlds[1], c2, v2);
-    let second1 = insert(&mut worlds[1], c1, v1);
+    let first1 = insert(&mut worlds[0], k1, v1);
+    let first2 = insert(&mut worlds[0], k2, v2);
+    let second2 = insert(&mut worlds[1], k2, v2);
+    let second1 = insert(&mut worlds[1], k1, v1);
     assert_eq!(
         first1, second1,
-        "insert of {c1:?} was order-dependent on {e:?}"
+        "insert of {k1:?} was order-dependent on {e:?}"
     );
     assert_eq!(
         first2, second2,
-        "insert of {c2:?} was order-dependent on {e:?}"
+        "insert of {k2:?} was order-dependent on {e:?}"
     );
     assert_eq!(
         fingerprint(&worlds[0]),
         fingerprint(&worlds[1]),
-        "insert order of {c1:?} and {c2:?} was observable on {e:?}"
+        "insert order of {k1:?} and {k2:?} was observable on {e:?}"
     );
     assert_eq!(
         ds.live(),

--- a/tests/world_relations.rs
+++ b/tests/world_relations.rs
@@ -10,60 +10,6 @@ use fixtures::*;
 use hecs::{Entity, World};
 use hegel::generators as gs;
 
-/// A single-entity operation. Spawning operations are excluded: allocation
-/// order is observable through the handles they return, so they do not commute.
-#[derive(Clone, Copy, Debug, hegel::PrettyPrintable)]
-enum Op {
-    InsertOne(Kind, i32),
-    RemoveOne(Kind),
-    InsertBundle(Components),
-    RemoveAB,
-    RemoveCD,
-    Despawn,
-    Take,
-    MutateA(i32),
-    ExchangeAToB(i32),
-    ExchangeDToA(i32),
-}
-
-#[hegel::composite]
-fn ops(tc: &hegel::TestCase) -> Op {
-    tc.draw(hegel::one_of!(
-        hegel::compose!(|tc| { Op::InsertOne(tc.draw(kinds()), tc.draw(val())) }),
-        hegel::compose!(|tc| { Op::RemoveOne(tc.draw(kinds())) }),
-        hegel::compose!(|tc| { Op::InsertBundle(tc.draw(components())) }),
-        gs::just(Op::RemoveAB),
-        gs::just(Op::RemoveCD),
-        gs::just(Op::Despawn),
-        gs::just(Op::Take),
-        hegel::compose!(|tc| { Op::MutateA(tc.draw(val())) }),
-        hegel::compose!(|tc| { Op::ExchangeAToB(tc.draw(val())) }),
-        hegel::compose!(|tc| { Op::ExchangeDToA(tc.draw(val())) }),
-    ))
-}
-
-/// Apply `op` to `e` and report whether it succeeded.
-fn apply(world: &mut World, e: Entity, op: Op, ds: &DropTracker) -> bool {
-    match op {
-        Op::InsertOne(kind, v) => kind.insert_one(world, e, v, ds).is_ok(),
-        Op::RemoveOne(kind) => kind.remove_one(world, e).is_ok(),
-        Op::InsertBundle(cs) => world.insert(e, cs.builder(ds).build()).is_ok(),
-        Op::RemoveAB => world.remove::<(A, B)>(e).is_ok(),
-        Op::RemoveCD => world.remove::<(C, D)>(e).is_ok(),
-        Op::Despawn => world.despawn(e).is_ok(),
-        Op::Take => world.take(e).is_ok(),
-        Op::MutateA(v) => match world.get::<&mut A>(e) {
-            Ok(mut a) => {
-                a.0 = v;
-                true
-            }
-            Err(_) => false,
-        },
-        Op::ExchangeAToB(v) => world.exchange_one::<A, B>(e, B(v)).is_ok(),
-        Op::ExchangeDToA(v) => world.exchange_one::<D, A>(e, A(v)).is_ok(),
-    }
-}
-
 /// Operations on two different entities commute: neither their results nor the
 /// resulting world depend on the order they run in. This is the observable form
 /// of hecs storing each entity's components independently of every other's.


### PR DESCRIPTION
Following up on #450, where you said you'd be happy to review these for inclusion. Claude Code wrote the tests and this description. Please read this as an offer of code rather than an imposition: if it is more than you want to own, or the wrong shape for the repo, say so and no offence will be taken.

Three tests are `#[ignore]`d, one each for #459, #460 and #461, which came out of this suite. The inputs that trigger those three are guarded rather than left to fail, with a comment saying why, so the suite stays clean under `cargo miri test --all-features --lib --tests`.
