### PR TITLE
Fix double-drop when a component's Drop panics

### DIFF
--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -66,15 +66,20 @@ impl Archetype {
     }
 
     pub(crate) fn clear(&mut self) {
+        // Take the length before running any destructor. `Drop for Archetype`
+        // calls this function, so if a component's `Drop` unwinds and the
+        // length is still set, every component is destroyed a second time.
+        // Components not reached before the unwind are leaked instead.
+        let len = self.len;
+        self.len = 0;
         for (ty, data) in self.types.iter().zip(&*self.data) {
-            for index in 0..self.len {
+            for index in 0..len {
                 unsafe {
                     let removed = data.storage.as_ptr().add(index as usize * ty.layout.size());
                     (ty.drop)(removed);
                 }
             }
         }
-        self.len = 0;
     }
 
     /// Whether this archetype contains `T` components

--- a/src/command_buffer.rs
+++ b/src/command_buffer.rs
@@ -143,10 +143,33 @@ impl CommandBuffer {
 
     /// Run recorded commands on `world`, clearing the command buffer
     pub fn run_on(&mut self, world: &mut World) {
-        for i in 0..self.cmds.len() {
-            match mem::replace(&mut self.cmds[i], Cmd::Despawn(Entity::DANGLING)) {
+        // Components handed to `world` must not be destroyed by `clear`, so the
+        // count of consumed components is committed as the loop goes. Without
+        // this a panicking command leaves them owned twice.
+        struct Reset<'a> {
+            buffer: &'a mut CommandBuffer,
+            consumed: usize,
+        }
+
+        impl Drop for Reset<'_> {
+            fn drop(&mut self) {
+                // Already moved into the world: forget them here.
+                self.buffer.components.drain(..self.consumed);
+                // Still owned by the buffer: destroy them normally.
+                self.buffer.clear();
+            }
+        }
+
+        let mut state = Reset {
+            buffer: self,
+            consumed: 0,
+        };
+
+        for i in 0..state.buffer.cmds.len() {
+            match mem::replace(&mut state.buffer.cmds[i], Cmd::Despawn(Entity::DANGLING)) {
                 Cmd::SpawnOrInsert(entity) => {
-                    let components = self.build(entity.components);
+                    let end = entity.components.end;
+                    let components = state.buffer.build(entity.components);
                     match entity.entity {
                         Some(entity) => {
                             // If `entity` no longer exists, quietly drop the components.
@@ -156,6 +179,7 @@ impl CommandBuffer {
                             world.spawn(components);
                         }
                     }
+                    state.consumed = end;
                 }
                 Cmd::Remove(remove) => {
                     (remove.remove)(world, remove.entity);
@@ -168,10 +192,6 @@ impl CommandBuffer {
                 }
             }
         }
-        // Wipe out component references so `clear` doesn't try to double-free
-        self.components.clear();
-
-        self.clear();
     }
 
     fn build(&mut self, components: Range<usize>) -> RecordedEntity<'_> {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -788,6 +788,43 @@ fn clear() {
 }
 
 #[test]
+fn clear_does_not_double_drop_when_a_destructor_panics() {
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    static DROPS: AtomicUsize = AtomicUsize::new(0);
+    static ARMED: AtomicBool = AtomicBool::new(true);
+
+    struct Bomb(usize);
+
+    impl Drop for Bomb {
+        fn drop(&mut self) {
+            DROPS.fetch_add(1, Ordering::SeqCst);
+            // Fire once. A second panic while unwinding would abort.
+            if self.0 == 2 && ARMED.swap(false, Ordering::SeqCst) {
+                panic!("boom");
+            }
+        }
+    }
+
+    let mut world = World::new();
+    for i in 0..4 {
+        world.spawn((Bomb(i),));
+    }
+
+    let unwound = catch_unwind(AssertUnwindSafe(|| world.clear()));
+    assert!(unwound.is_err());
+
+    drop(world);
+
+    assert_eq!(
+        DROPS.load(Ordering::SeqCst),
+        3,
+        "components destroyed before the unwind must not be destroyed again"
+    );
+}
+
+#[test]
 fn remove_missing() {
     let mut world = World::new();
     let e = world.spawn(("abc", 123));

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -825,6 +825,44 @@ fn clear_does_not_double_drop_when_a_destructor_panics() {
 }
 
 #[test]
+fn command_buffer_does_not_double_drop_when_a_command_panics() {
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static DROPS: AtomicUsize = AtomicUsize::new(0);
+
+    struct Tracked;
+
+    impl Drop for Tracked {
+        fn drop(&mut self) {
+            DROPS.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let mut world = World::new();
+    let mut buffer = CommandBuffer::new();
+
+    // Handed to the world by the first command.
+    buffer.spawn((Tracked,));
+    // Unwinds before run_on can wipe the component list.
+    buffer.queue(|_| panic!("boom"));
+    // Never reached; still owned by the buffer.
+    buffer.spawn((Tracked,));
+
+    let unwound = catch_unwind(AssertUnwindSafe(|| buffer.run_on(&mut world)));
+    assert!(unwound.is_err());
+
+    drop(buffer);
+    drop(world);
+
+    assert_eq!(
+        DROPS.load(Ordering::SeqCst),
+        2,
+        "a component moved into the world must not be destroyed by the buffer"
+    );
+}
+
+#[test]
 fn remove_missing() {
     let mut world = World::new();
     let e = world.spawn(("abc", 123));


### PR DESCRIPTION
Found while researching panic-safety in Rust containers.

## Summary

Three places destroy or move components before committing the state that says
which slots are live. `Component` has no bound excluding a panicking `Drop`, so
a caller only needs to catch the unwind and touch the container again. All three
are double-drops (CWE-415) reachable from safe Rust.

| Location | Skipped commit | Second drop |
| --- | --- | --- |
| `Archetype::clear` | `self.len = 0` | `Drop for Archetype` calls `clear` again |
| `Archetype::remove` | `self.len = last` | the slot already dropped, and the duplicate left by `copy_nonoverlapping` |
| `CommandBuffer::run_on` | `self.components.clear()` | `CommandBuffer::clear` drops components already moved into the world |

`run_on` already carries a comment saying "Wipe out component references so
`clear` doesn't try to double-free". It just does not run when a command
unwinds.

## Fix

`clear` takes the length before running any destructor. Components not reached
are leaked, which is safe.

`remove` runs the loop under a guard. On unwind the guard finishes the backfill
for the remaining types without running further destructors, moves the entity
id, and commits the length. The dropped slot is overwritten by the moved entity
and the duplicate falls out of range, so the archetype is left consistent.
Components of the removed entity past the panic are leaked.

`run_on` tracks how many components the world has taken and splits the two
groups in a guard. Those already handed over are dropped from the list without
running destructors, the rest are destroyed normally. No leak on this path.

`World::despawn` is not covered. It updates its entity index from the value
`remove` returns, and that is skipped when the unwind passes through, so the
moved entity keeps a stale index entry. That is a logical inconsistency, not
memory unsafety. I left it alone since the right shape looks like your call.

## Verification

Three regression tests count destructor invocations. Against the unpatched
code `clear` runs 7 destructors where 4 components exist, `run_on` runs 3
where 2 exist, and `despawn` runs 8 where 6 exist. With the fix `clear`
destroys 3 of the 4 and `run_on` 2 of 2; the `despawn` test asserts only
that the count stays at or below 6, since how far the loop gets before the
unwind depends on the order the archetype stores its types in.

The double-frees were confirmed earlier with AddressSanitizer (`attempting
double-free`) on the unpatched code, through `World::clear`,
`World::despawn`, `World::spawn_at` and `World::spawn_column_batch_at`.
Existing tests pass and `cargo build --no-default-features` still builds.
Confirmed on 0.11.1.